### PR TITLE
chore: add Cloud Java team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-*     @miraleung @googleapis/actools-java @googleapis/cloud-java-team-sync
+*     @miraleung @googleapis/actools-java @googleapis/cloud-java-team-teamsync


### PR DESCRIPTION
Adding @googleapis/cloud-java-team-teamsync.