### PR TITLE
fix: [api-common-java] reduce wildcards in PathTemplate string conversion

### DIFF
--- a/api-common-java/src/main/java/com/google/api/pathtemplate/PathTemplate.java
+++ b/api-common-java/src/main/java/com/google/api/pathtemplate/PathTemplate.java
@@ -1119,7 +1119,7 @@ public class PathTemplate {
   // the list iterator in its state.
   private static boolean peek(ListIterator<Segment> segments, SegmentKind... kinds) {
     int start = segments.nextIndex();
-    boolean success = false;
+    boolean success = true;
     for (SegmentKind kind : kinds) {
       if (!segments.hasNext() || segments.next().kind() != kind) {
         success = false;

--- a/api-common-java/src/test/java/com/google/api/pathtemplate/PathTemplateTest.java
+++ b/api-common-java/src/test/java/com/google/api/pathtemplate/PathTemplateTest.java
@@ -840,6 +840,27 @@ public class PathTemplateTest {
     Truth.assertThat(url).isEqualTo("v1/shelves/s1/books/b1");
   }
 
+  @Test
+  public void testTemplateStringConversionWithUnbound() {
+    PathTemplate template = PathTemplate.create("v1/shelves/*/books/**");
+    Truth.assertThat(template.toRawString()).isEqualTo("v1/shelves/{$0=*}/books/{$1=**}");
+    Truth.assertThat(template.toString()).isEqualTo("v1/shelves/*/books/**");
+  }
+
+  @Test
+  public void testTemplateStringConversionWithBinding() {
+    PathTemplate template = PathTemplate.create("v1/shelves/{shelf=*}/books/{book=**}");
+    Truth.assertThat(template.toRawString()).isEqualTo("v1/shelves/{shelf=*}/books/{book=**}");
+    Truth.assertThat(template.toString()).isEqualTo("v1/shelves/{shelf}/books/{book=**}");
+  }
+
+  @Test
+  public void testSubTemplate() {
+    PathTemplate template = PathTemplate.create("v1/shelves/{shelf}/books/{book=books/*/**}");
+    Truth.assertThat(template.subTemplate("shelf").toString()).isEqualTo("*");
+    Truth.assertThat(template.subTemplate("book").toString()).isEqualTo("books/*/**");
+  }
+
   private static void assertPositionalMatch(Map<String, String> match, String... expected) {
     Truth.assertThat(match).isNotNull();
     int i = 0;

--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/protoparser/HttpRuleParser.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/protoparser/HttpRuleParser.java
@@ -217,7 +217,7 @@ public class HttpRuleParser {
     if (pattern == null || pattern.isEmpty()) {
       return varPattern;
     }
-    Matcher m = TEMPLATE_VALS_PATTERN.matcher(PathTemplate.create(pattern).toString());
+    Matcher m = TEMPLATE_VALS_PATTERN.matcher(PathTemplate.create(pattern).toRawString());
 
     while (m.find()) {
       varPattern.put(m.group("var"), m.group("template"));


### PR DESCRIPTION
Fixes #1546 ☕️

- Fix for `PathTemplate` pretty printing to reduce `{name=*}` to `{name}` 
- Adds unit tests for public `PathTemplate` methods `toString()`, `toRawString()`, and `subTemplate()` upstream of the updated helper logic

**Todo:**
- [ ] Confirm compatibility with downstream usages in `HttpRuleParser`(see [comment](https://github.com/googleapis/gapic-generator-java/pull/1557#issuecomment-1487049076))