### PR TITLE
chore: restore thrown exception in showcase test method

### DIFF
--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITServerSideStreaming.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITServerSideStreaming.java
@@ -32,6 +32,7 @@ import com.google.showcase.v1beta1.EchoSettings;
 import com.google.showcase.v1beta1.ExpandRequest;
 import io.grpc.ManagedChannelBuilder;
 import java.io.IOException;
+import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import org.junit.After;
@@ -45,7 +46,7 @@ public class ITServerSideStreaming {
   private EchoClient httpjsonClient;
 
   @Before
-  public void createClients() throws IOException {
+  public void createClients() throws IOException, GeneralSecurityException {
     // Create gRPC Echo Client
     EchoSettings grpcEchoSettings =
         EchoSettings.newBuilder()


### PR DESCRIPTION
Fixes the following error:
```
 Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.10.1:testCompile (default-testCompile) on project gapic-showcase: Compilation failure
Error:  /home/runner/work/gapic-generator-java/gapic-generator-java/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITServerSideStreaming.java:[66,80] unreported exception 
```
Likely to have been caused by a race condition from two git merges (https://github.com/googleapis/gapic-generator-java/pull/1502 and https://github.com/googleapis/gapic-generator-java/pull/1588) 
