### PR TITLE
chore: increase AssertByPollingTest timeout

### DIFF
--- a/gax-java/gax/src/test/java/com/google/api/gax/batching/AssertByPollingTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/batching/AssertByPollingTest.java
@@ -79,7 +79,7 @@ public class AssertByPollingTest {
           }
         };
 
-    Duration timeout = Duration.ofMillis(100);
+    Duration timeout = Duration.ofMillis(300);
     assertByPolling(timeout, succeedsThirdTime);
     Truth.assertThat(numFailures.get()).isEqualTo(2);
   }


### PR DESCRIPTION
This test failed due to a timeout: https://github.com/googleapis/gapic-generator-java/actions/runs/4749547068/jobs/8436916413

This happens if the OS takes significantly longer to return to the thread than the requested sleep time.

This PR increases the timeout from 100ms to 300ms.