### PR TITLE
chore: add 2 minute timeout to GrpcDirectStreamControllerTest

### DIFF
--- a/gax-java/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcDirectStreamControllerTest.java
+++ b/gax-java/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcDirectStreamControllerTest.java
@@ -59,7 +59,7 @@ import org.threeten.bp.Duration;
 @RunWith(JUnit4.class)
 public class GrpcDirectStreamControllerTest {
 
-  @Test(timeout = 120_000) // ms
+  @Test(timeout = 180_000) // ms
   public void testRetryNoRaceCondition() throws Exception {
     Server server = ServerBuilder.forPort(1234).addService(new FakeService()).build();
     server.start();

--- a/gax-java/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcDirectStreamControllerTest.java
+++ b/gax-java/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcDirectStreamControllerTest.java
@@ -59,7 +59,7 @@ import org.threeten.bp.Duration;
 @RunWith(JUnit4.class)
 public class GrpcDirectStreamControllerTest {
 
-  @Test
+  @Test(timeout = 120_000) // ms
   public void testRetryNoRaceCondition() throws Exception {
     Server server = ServerBuilder.forPort(1234).addService(new FakeService()).build();
     server.start();


### PR DESCRIPTION
Recent builds was hanging for 6 hours on this test.

https://github.com/googleapis/sdk-platform-java/actions/runs/5017051494/jobs/8994676841?pr=1622
https://github.com/googleapis/sdk-platform-java/actions/runs/5017051494/jobs/8994676448?pr=1622