### PR TITLE
fix: update workflow for refs and multiple artifacts

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,3 +2,6 @@ startup --batch
 
 build --show_timestamps
 build --protocopt=--experimental_allow_proto3_optional
+
+build --cxxopt=-std=c++14
+build --host_cxxopt=-std=c++14

--- a/.github/workflows/create_additional_release_tags.yaml
+++ b/.github/workflows/create_additional_release_tags.yaml
@@ -3,11 +3,7 @@ name: Create additional tags for each release
 on:
   release:
     types: [published]
-  workflow_dispatch: # If manually triggered, clarify which release to create the additional tags for
-    inputs:
-      releaseTag:
-        description: 'Release Tag'
-        required: true
+  workflow_dispatch:
 
 jobs:
   build:
@@ -17,7 +13,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
       with:
-        ref: ${{ github.event.release.tag_name || github.event.inputs.releaseTag }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up Git
@@ -27,17 +22,16 @@ jobs:
 
     - name: Create additional tags
       run: |
-        REF=${{ github.event.release.tag_name || github.event.inputs.releaseTag }}
         ARTIFACT_IDS=('google-cloud-shared-dependencies' 'api-common' 'gax')
         for ARTIFACT_ID in "${ARTIFACT_IDS[@]}"
         do
           VERSION=$(grep "^${ARTIFACT_ID}:" versions.txt | cut -d':' -f2 | tr -d '[:space:]')
-          TEMP_BRANCH="temp_branch_${ARTIFACT_ID}_$VERSION"
-          git checkout -b $TEMP_BRANCH
-          git rm .github/workflows/create_additional_release_tag.yaml
-          git commit -m "Remove workflow file"
-          git tag "${ARTIFACT_ID}/$VERSION"
-          git push origin "${ARTIFACT_ID}/$VERSION"
-          git checkout "$REF"
-          git branch -D $TEMP_BRANCH
+          TAG_NAME="${ARTIFACT_ID}/v$VERSION"
+          if git show-ref --tags | grep -q "refs/tags/$TAG_NAME"
+            then
+              echo "Tag $TAG_NAME already exists. Skipping."
+              continue
+            fi
+          git tag $TAG_NAME ${{ github.event.inputs.releaseTag }}
+          git push origin $TAG_NAME
         done

--- a/.github/workflows/create_additional_release_tags.yaml
+++ b/.github/workflows/create_additional_release_tags.yaml
@@ -17,7 +17,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
       with:
-        ref: ${{ github.event.inputs.releaseTag }}
+        ref: ${{ github.event.release.tag_name || github.event.inputs.releaseTag }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up Git
@@ -27,10 +27,17 @@ jobs:
 
     - name: Create additional tags
       run: |
+        REF=${{ github.event.release.tag_name || github.event.inputs.releaseTag }}
         ARTIFACT_IDS=('google-cloud-shared-dependencies' 'api-common' 'gax')
         for ARTIFACT_ID in "${ARTIFACT_IDS[@]}"
         do
-          VERSION=$(grep "${ARTIFACT_ID}" versions.txt | cut -d':' -f2)
-          git tag ${ARTIFACT_ID}/$VERSION ${{ github.event.inputs.releaseTag }}
-          git push origin ${ARTIFACT_ID}/$VERSION
+          VERSION=$(grep "^${ARTIFACT_ID}:" versions.txt | cut -d':' -f2 | tr -d '[:space:]')
+          TEMP_BRANCH="temp_branch_${ARTIFACT_ID}_$VERSION"
+          git checkout -b $TEMP_BRANCH
+          git rm .github/workflows/create_additional_release_tag.yaml
+          git commit -m "Remove workflow file"
+          git tag "${ARTIFACT_ID}/$VERSION"
+          git push origin "${ARTIFACT_ID}/$VERSION"
+          git checkout "$REF"
+          git branch -D $TEMP_BRANCH
         done

--- a/.kokoro/requirements.txt
+++ b/.kokoro/requirements.txt
@@ -16,7 +16,7 @@ certifi==2022.12.7 \
     --hash=sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3 \
     --hash=sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18
     # via
-    #   -r .kokoro/requirements.in
+    #   -r requirements.in
     #   requests
 cffi==1.15.1 \
     --hash=sha256:00a9ed42e88df81ffae7a8ab6d9356b371399b91dbdf0c3cb1e84c03a13aceb5 \
@@ -92,7 +92,7 @@ click==8.0.4 \
     --hash=sha256:6a7a62563bbfabfda3a38f3023a1db4a35978c0abd76f6c9605ecd6554d6d9b1 \
     --hash=sha256:8458d7b1287c5fb128c90e23381cf99dcde74beaf6c7ff6384ce84d6fe090adb
     # via
-    #   -r .kokoro/requirements.in
+    #   -r requirements.in
     #   gcp-docuploader
     #   gcp-releasetool
 colorlog==6.7.0 \
@@ -124,17 +124,17 @@ cryptography==39.0.2 \
     --hash=sha256:fa507318e427169ade4e9eccef39e9011cdc19534f55ca2f36ec3f388c1f70f3 \
     --hash=sha256:ffd394c7896ed7821a6d13b24657c6a34b6e2650bd84ae063cf11ccffa4f1a97
     # via
-    #   -r .kokoro/requirements.in
+    #   -r requirements.in
     #   gcp-releasetool
     #   secretstorage
 gcp-docuploader==0.6.5 \
     --hash=sha256:30221d4ac3e5a2b9c69aa52fdbef68cc3f27d0e6d0d90e220fc024584b8d2318 \
     --hash=sha256:b7458ef93f605b9d46a4bf3a8dc1755dad1f31d030c8679edf304e343b347eea
-    # via -r .kokoro/requirements.in
+    # via -r requirements.in
 gcp-releasetool==1.10.5 \
     --hash=sha256:174b7b102d704b254f2a26a3eda2c684fd3543320ec239baf771542a2e58e109 \
     --hash=sha256:e29d29927fe2ca493105a82958c6873bb2b90d503acac56be2c229e74de0eec9
-    # via -r .kokoro/requirements.in
+    # via -r requirements.in
 google-api-core==2.8.2 \
     --hash=sha256:06f7244c640322b508b125903bb5701bebabce8832f85aba9335ec00b3d02edc \
     --hash=sha256:93c6a91ccac79079ac6bbf8b74ee75db970cc899278b97d53bc012f35908cf50
@@ -220,18 +220,20 @@ importlib-metadata==4.8.3 \
 jeepney==0.7.1 \
     --hash=sha256:1b5a0ea5c0e7b166b2f5895b91a08c14de8915afda4407fb5022a195224958ac \
     --hash=sha256:fa9e232dfa0c498bd0b8a3a73b8d8a31978304dcef0515adc859d4e096f96f4f
-    # via secretstorage
+    # via
+    #   keyring
+    #   secretstorage
 jinja2==3.0.3 \
     --hash=sha256:077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8 \
     --hash=sha256:611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7
     # via
-    #   -r .kokoro/requirements.in
+    #   -r requirements.in
     #   gcp-releasetool
 keyring==23.4.1 \
     --hash=sha256:17e49fb0d6883c2b4445359434dba95aad84aabb29bbff044ad0ed7100232eca \
     --hash=sha256:89cbd74d4683ed164c8082fb38619341097741323b3786905c6dac04d6915a55
     # via
-    #   -r .kokoro/requirements.in
+    #   -r requirements.in
     #   gcp-releasetool
 markupsafe==2.0.1 \
     --hash=sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298 \
@@ -368,9 +370,9 @@ python-dateutil==2.8.2 \
     --hash=sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86 \
     --hash=sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9
     # via gcp-releasetool
-requests==2.27.1 \
-    --hash=sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61 \
-    --hash=sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d
+requests==2.31.0 \
+    --hash=sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f \
+    --hash=sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1
     # via
     #   gcp-releasetool
     #   google-api-core
@@ -382,7 +384,9 @@ rsa==4.9 \
 secretstorage==3.3.3 \
     --hash=sha256:2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77 \
     --hash=sha256:f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99
-    # via -r .kokoro/requirements.in
+    # via
+    #   -r requirements.in
+    #   keyring
 six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
@@ -393,7 +397,7 @@ six==1.16.0 \
 typing-extensions==4.1.1 \
     --hash=sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42 \
     --hash=sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2
-    # via -r .kokoro/requirements.in
+    # via -r requirements.in
 urllib3==1.26.15 \
     --hash=sha256:8a388717b9476f934a21484e8c8e61875ab60644d29b9b39e11e4b9dc1c6b305 \
     --hash=sha256:aa751d169e23c7479ce47a0cb0da579e3ede798f994f5816a74e4f4500dcea42

--- a/gapic-generator-java-pom-parent/pom.xml
+++ b/gapic-generator-java-pom-parent/pom.xml
@@ -26,11 +26,11 @@
     <!-- External dependencies, especially gRPC and Protobuf version, should be
         consistent across modules in this repository -->
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
-    <grpc.version>1.54.0</grpc.version>
+    <grpc.version>1.55.1</grpc.version>
     <google.auth.version>1.16.0</google.auth.version>
     <gson.version>2.10.1</gson.version>
     <guava.version>31.1-jre</guava.version>
-    <protobuf.version>3.21.12</protobuf.version>
+    <protobuf.version>3.23.1</protobuf.version>
     <maven.compiler.release>8</maven.compiler.release>
   </properties>
 

--- a/gax-java/dependencies.properties
+++ b/gax-java/dependencies.properties
@@ -23,9 +23,9 @@ version.gax_httpjson=0.112.1-SNAPSHOT
 # Versions for dependencies which actual artifacts differ between Bazel and Gradle.
 # Gradle build depends on prebuilt maven artifacts, while Bazel build depends on Bazel workspaces
 # with the sources.
-version.com_google_protobuf=3.21.12
+version.com_google_protobuf=3.23.1
 version.google_java_format=1.15.0
-version.io_grpc=1.54.0
+version.io_grpc=1.55.1
 
 # Maven artifacts.
 # Note, the actual name of each property matters (bazel build scripts depend on it).

--- a/gax-java/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcDirectStreamControllerTest.java
+++ b/gax-java/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcDirectStreamControllerTest.java
@@ -59,7 +59,7 @@ import org.threeten.bp.Duration;
 @RunWith(JUnit4.class)
 public class GrpcDirectStreamControllerTest {
 
-  @Test
+  @Test(timeout = 180_000) // ms
   public void testRetryNoRaceCondition() throws Exception {
     Server server = ServerBuilder.forPort(1234).addService(new FakeService()).build();
     server.start();

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/AttemptSequenceRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/AttemptSequenceRequest.java
@@ -26,11 +26,6 @@ private static final long serialVersionUID = 0L;
     return new AttemptSequenceRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.SequenceOuterClass.internal_static_google_showcase_v1beta1_AttemptSequenceRequest_descriptor;
@@ -191,11 +186,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.AttemptSequenceRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.AttemptSequenceRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -310,38 +307,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.AttemptSequenceRequest) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/AttemptStreamingSequenceRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/AttemptStreamingSequenceRequest.java
@@ -26,11 +26,6 @@ private static final long serialVersionUID = 0L;
     return new AttemptStreamingSequenceRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.SequenceOuterClass.internal_static_google_showcase_v1beta1_AttemptStreamingSequenceRequest_descriptor;
@@ -191,11 +186,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.AttemptStreamingSequenceRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.AttemptStreamingSequenceRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -310,38 +307,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.AttemptStreamingSequenceRequest) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/AttemptStreamingSequenceResponse.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/AttemptStreamingSequenceResponse.java
@@ -30,11 +30,6 @@ private static final long serialVersionUID = 0L;
     return new AttemptStreamingSequenceResponse();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.SequenceOuterClass.internal_static_google_showcase_v1beta1_AttemptStreamingSequenceResponse_descriptor;
@@ -203,11 +198,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.AttemptStreamingSequenceResponse parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.AttemptStreamingSequenceResponse parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -326,38 +323,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.AttemptStreamingSequenceResponse) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/BlockRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/BlockRequest.java
@@ -29,11 +29,6 @@ private static final long serialVersionUID = 0L;
     return new BlockRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.EchoOuterClass.internal_static_google_showcase_v1beta1_BlockRequest_descriptor;
@@ -48,6 +43,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private int responseCase_ = 0;
+  @SuppressWarnings("serial")
   private java.lang.Object response_;
   public enum ResponseCase
       implements com.google.protobuf.Internal.EnumLite,
@@ -368,11 +364,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.BlockRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.BlockRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -519,38 +517,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.BlockRequest) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/BlockRequestOrBuilder.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/BlockRequestOrBuilder.java
@@ -91,5 +91,5 @@ public interface BlockRequestOrBuilder extends
    */
   com.google.showcase.v1beta1.BlockResponseOrBuilder getSuccessOrBuilder();
 
-  public com.google.showcase.v1beta1.BlockRequest.ResponseCase getResponseCase();
+  com.google.showcase.v1beta1.BlockRequest.ResponseCase getResponseCase();
 }

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/BlockResponse.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/BlockResponse.java
@@ -30,11 +30,6 @@ private static final long serialVersionUID = 0L;
     return new BlockResponse();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.EchoOuterClass.internal_static_google_showcase_v1beta1_BlockResponse_descriptor;
@@ -205,11 +200,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.BlockResponse parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.BlockResponse parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -328,38 +325,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.BlockResponse) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/Blurb.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/Blurb.java
@@ -32,11 +32,6 @@ private static final long serialVersionUID = 0L;
     return new Blurb();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.MessagingOuterClass.internal_static_google_showcase_v1beta1_Blurb_descriptor;
@@ -51,6 +46,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private int contentCase_ = 0;
+  @SuppressWarnings("serial")
   private java.lang.Object content_;
   public enum ContentCase
       implements com.google.protobuf.Internal.EnumLite,
@@ -92,6 +88,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private int legacyIdCase_ = 0;
+  @SuppressWarnings("serial")
   private java.lang.Object legacyId_;
   public enum LegacyIdCase
       implements com.google.protobuf.Internal.EnumLite,
@@ -762,11 +759,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.Blurb parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.Blurb parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -922,38 +921,6 @@ private static final long serialVersionUID = 0L;
       result.legacyId_ = this.legacyId_;
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.Blurb) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/BlurbOrBuilder.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/BlurbOrBuilder.java
@@ -219,7 +219,7 @@ public interface BlurbOrBuilder extends
   com.google.protobuf.ByteString
       getLegacyUserIdBytes();
 
-  public com.google.showcase.v1beta1.Blurb.ContentCase getContentCase();
+  com.google.showcase.v1beta1.Blurb.ContentCase getContentCase();
 
-  public com.google.showcase.v1beta1.Blurb.LegacyIdCase getLegacyIdCase();
+  com.google.showcase.v1beta1.Blurb.LegacyIdCase getLegacyIdCase();
 }

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ComplianceData.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ComplianceData.java
@@ -35,11 +35,6 @@ private static final long serialVersionUID = 0L;
     return new ComplianceData();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.ComplianceOuterClass.internal_static_google_showcase_v1beta1_ComplianceData_descriptor;
@@ -994,11 +989,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.ComplianceData parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.ComplianceData parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -1233,38 +1230,6 @@ private static final long serialVersionUID = 0L;
       result.bitField0_ |= to_bitField0_;
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.ComplianceData) {
@@ -1599,7 +1564,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setFInt32(int value) {
-      
+
       fInt32_ = value;
       bitField0_ |= 0x00000002;
       onChanged();
@@ -1631,7 +1596,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setFSint32(int value) {
-      
+
       fSint32_ = value;
       bitField0_ |= 0x00000004;
       onChanged();
@@ -1663,7 +1628,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setFSfixed32(int value) {
-      
+
       fSfixed32_ = value;
       bitField0_ |= 0x00000008;
       onChanged();
@@ -1695,7 +1660,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setFUint32(int value) {
-      
+
       fUint32_ = value;
       bitField0_ |= 0x00000010;
       onChanged();
@@ -1727,7 +1692,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setFFixed32(int value) {
-      
+
       fFixed32_ = value;
       bitField0_ |= 0x00000020;
       onChanged();
@@ -1759,7 +1724,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setFInt64(long value) {
-      
+
       fInt64_ = value;
       bitField0_ |= 0x00000040;
       onChanged();
@@ -1791,7 +1756,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setFSint64(long value) {
-      
+
       fSint64_ = value;
       bitField0_ |= 0x00000080;
       onChanged();
@@ -1823,7 +1788,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setFSfixed64(long value) {
-      
+
       fSfixed64_ = value;
       bitField0_ |= 0x00000100;
       onChanged();
@@ -1855,7 +1820,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setFUint64(long value) {
-      
+
       fUint64_ = value;
       bitField0_ |= 0x00000200;
       onChanged();
@@ -1887,7 +1852,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setFFixed64(long value) {
-      
+
       fFixed64_ = value;
       bitField0_ |= 0x00000400;
       onChanged();
@@ -1919,7 +1884,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setFDouble(double value) {
-      
+
       fDouble_ = value;
       bitField0_ |= 0x00000800;
       onChanged();
@@ -1951,7 +1916,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setFFloat(float value) {
-      
+
       fFloat_ = value;
       bitField0_ |= 0x00001000;
       onChanged();
@@ -1983,7 +1948,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setFBool(boolean value) {
-      
+
       fBool_ = value;
       bitField0_ |= 0x00002000;
       onChanged();
@@ -2306,7 +2271,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setPInt32(int value) {
-      
+
       pInt32_ = value;
       bitField0_ |= 0x00040000;
       onChanged();
@@ -2346,7 +2311,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setPDouble(double value) {
-      
+
       pDouble_ = value;
       bitField0_ |= 0x00080000;
       onChanged();
@@ -2386,7 +2351,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setPBool(boolean value) {
-      
+
       pBool_ = value;
       bitField0_ |= 0x00100000;
       onChanged();

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ComplianceDataChild.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ComplianceDataChild.java
@@ -29,11 +29,6 @@ private static final long serialVersionUID = 0L;
     return new ComplianceDataChild();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.ComplianceOuterClass.internal_static_google_showcase_v1beta1_ComplianceDataChild_descriptor;
@@ -578,11 +573,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.ComplianceDataChild parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.ComplianceDataChild parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -767,38 +764,6 @@ private static final long serialVersionUID = 0L;
       result.bitField0_ |= to_bitField0_;
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.ComplianceDataChild) {
@@ -1045,7 +1010,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setFFloat(float value) {
-      
+
       fFloat_ = value;
       bitField0_ |= 0x00000002;
       onChanged();
@@ -1077,7 +1042,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setFDouble(double value) {
-      
+
       fDouble_ = value;
       bitField0_ |= 0x00000004;
       onChanged();
@@ -1109,7 +1074,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setFBool(boolean value) {
-      
+
       fBool_ = value;
       bitField0_ |= 0x00000008;
       onChanged();
@@ -1400,7 +1365,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setPFloat(float value) {
-      
+
       pFloat_ = value;
       bitField0_ |= 0x00000080;
       onChanged();
@@ -1440,7 +1405,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setPDouble(double value) {
-      
+
       pDouble_ = value;
       bitField0_ |= 0x00000100;
       onChanged();
@@ -1480,7 +1445,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setPBool(boolean value) {
-      
+
       pBool_ = value;
       bitField0_ |= 0x00000200;
       onChanged();

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ComplianceDataGrandchild.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ComplianceDataGrandchild.java
@@ -26,11 +26,6 @@ private static final long serialVersionUID = 0L;
     return new ComplianceDataGrandchild();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.ComplianceOuterClass.internal_static_google_showcase_v1beta1_ComplianceDataGrandchild_descriptor;
@@ -238,11 +233,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.ComplianceDataGrandchild parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.ComplianceDataGrandchild parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -365,38 +362,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.ComplianceDataGrandchild) {
@@ -565,7 +530,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setFDouble(double value) {
-      
+
       fDouble_ = value;
       bitField0_ |= 0x00000002;
       onChanged();
@@ -597,7 +562,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setFBool(boolean value) {
-      
+
       fBool_ = value;
       bitField0_ |= 0x00000004;
       onChanged();

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ComplianceGroup.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ComplianceGroup.java
@@ -23,7 +23,8 @@ private static final long serialVersionUID = 0L;
   }
   private ComplianceGroup() {
     name_ = "";
-    rpcs_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+    rpcs_ =
+        com.google.protobuf.LazyStringArrayList.emptyList();
     requests_ = java.util.Collections.emptyList();
   }
 
@@ -34,11 +35,6 @@ private static final long serialVersionUID = 0L;
     return new ComplianceGroup();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.ComplianceOuterClass.internal_static_google_showcase_v1beta1_ComplianceGroup_descriptor;
@@ -93,7 +89,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int RPCS_FIELD_NUMBER = 2;
   @SuppressWarnings("serial")
-  private com.google.protobuf.LazyStringList rpcs_;
+  private com.google.protobuf.LazyStringArrayList rpcs_ =
+      com.google.protobuf.LazyStringArrayList.emptyList();
   /**
    * <code>repeated string rpcs = 2;</code>
    * @return A list containing the rpcs.
@@ -306,11 +303,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.ComplianceGroup parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.ComplianceGroup parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -393,8 +392,8 @@ private static final long serialVersionUID = 0L;
       super.clear();
       bitField0_ = 0;
       name_ = "";
-      rpcs_ = com.google.protobuf.LazyStringArrayList.EMPTY;
-      bitField0_ = (bitField0_ & ~0x00000002);
+      rpcs_ =
+          com.google.protobuf.LazyStringArrayList.emptyList();
       if (requestsBuilder_ == null) {
         requests_ = java.util.Collections.emptyList();
       } else {
@@ -435,11 +434,6 @@ private static final long serialVersionUID = 0L;
     }
 
     private void buildPartialRepeatedFields(com.google.showcase.v1beta1.ComplianceGroup result) {
-      if (((bitField0_ & 0x00000002) != 0)) {
-        rpcs_ = rpcs_.getUnmodifiableView();
-        bitField0_ = (bitField0_ & ~0x00000002);
-      }
-      result.rpcs_ = rpcs_;
       if (requestsBuilder_ == null) {
         if (((bitField0_ & 0x00000004) != 0)) {
           requests_ = java.util.Collections.unmodifiableList(requests_);
@@ -456,40 +450,12 @@ private static final long serialVersionUID = 0L;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.name_ = name_;
       }
+      if (((from_bitField0_ & 0x00000002) != 0)) {
+        rpcs_.makeImmutable();
+        result.rpcs_ = rpcs_;
+      }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.ComplianceGroup) {
@@ -510,7 +476,7 @@ private static final long serialVersionUID = 0L;
       if (!other.rpcs_.isEmpty()) {
         if (rpcs_.isEmpty()) {
           rpcs_ = other.rpcs_;
-          bitField0_ = (bitField0_ & ~0x00000002);
+          bitField0_ |= 0x00000002;
         } else {
           ensureRpcsIsMutable();
           rpcs_.addAll(other.rpcs_);
@@ -682,12 +648,13 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
-    private com.google.protobuf.LazyStringList rpcs_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+    private com.google.protobuf.LazyStringArrayList rpcs_ =
+        com.google.protobuf.LazyStringArrayList.emptyList();
     private void ensureRpcsIsMutable() {
-      if (!((bitField0_ & 0x00000002) != 0)) {
+      if (!rpcs_.isModifiable()) {
         rpcs_ = new com.google.protobuf.LazyStringArrayList(rpcs_);
-        bitField0_ |= 0x00000002;
-       }
+      }
+      bitField0_ |= 0x00000002;
     }
     /**
      * <code>repeated string rpcs = 2;</code>
@@ -695,7 +662,8 @@ private static final long serialVersionUID = 0L;
      */
     public com.google.protobuf.ProtocolStringList
         getRpcsList() {
-      return rpcs_.getUnmodifiableView();
+      rpcs_.makeImmutable();
+      return rpcs_;
     }
     /**
      * <code>repeated string rpcs = 2;</code>
@@ -732,6 +700,7 @@ private static final long serialVersionUID = 0L;
       if (value == null) { throw new NullPointerException(); }
       ensureRpcsIsMutable();
       rpcs_.set(index, value);
+      bitField0_ |= 0x00000002;
       onChanged();
       return this;
     }
@@ -745,6 +714,7 @@ private static final long serialVersionUID = 0L;
       if (value == null) { throw new NullPointerException(); }
       ensureRpcsIsMutable();
       rpcs_.add(value);
+      bitField0_ |= 0x00000002;
       onChanged();
       return this;
     }
@@ -758,6 +728,7 @@ private static final long serialVersionUID = 0L;
       ensureRpcsIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, rpcs_);
+      bitField0_ |= 0x00000002;
       onChanged();
       return this;
     }
@@ -766,8 +737,9 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearRpcs() {
-      rpcs_ = com.google.protobuf.LazyStringArrayList.EMPTY;
-      bitField0_ = (bitField0_ & ~0x00000002);
+      rpcs_ =
+        com.google.protobuf.LazyStringArrayList.emptyList();
+      bitField0_ = (bitField0_ & ~0x00000002);;
       onChanged();
       return this;
     }
@@ -782,6 +754,7 @@ private static final long serialVersionUID = 0L;
       checkByteStringIsUtf8(value);
       ensureRpcsIsMutable();
       rpcs_.add(value);
+      bitField0_ |= 0x00000002;
       onChanged();
       return this;
     }

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ComplianceSuite.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ComplianceSuite.java
@@ -32,11 +32,6 @@ private static final long serialVersionUID = 0L;
     return new ComplianceSuite();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.ComplianceOuterClass.internal_static_google_showcase_v1beta1_ComplianceSuite_descriptor;
@@ -202,11 +197,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.ComplianceSuite parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.ComplianceSuite parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -343,38 +340,6 @@ private static final long serialVersionUID = 0L;
       int from_bitField0_ = bitField0_;
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.ComplianceSuite) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ConnectRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ConnectRequest.java
@@ -30,11 +30,6 @@ private static final long serialVersionUID = 0L;
     return new ConnectRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.MessagingOuterClass.internal_static_google_showcase_v1beta1_ConnectRequest_descriptor;
@@ -95,11 +90,6 @@ private static final long serialVersionUID = 0L;
       return new ConnectConfig();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return com.google.showcase.v1beta1.MessagingOuterClass.internal_static_google_showcase_v1beta1_ConnectRequest_ConnectConfig_descriptor;
@@ -268,11 +258,13 @@ private static final long serialVersionUID = 0L;
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static com.google.showcase.v1beta1.ConnectRequest.ConnectConfig parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static com.google.showcase.v1beta1.ConnectRequest.ConnectConfig parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -387,38 +379,6 @@ private static final long serialVersionUID = 0L;
         }
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
-      }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.showcase.v1beta1.ConnectRequest.ConnectConfig) {
@@ -640,6 +600,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private int requestCase_ = 0;
+  @SuppressWarnings("serial")
   private java.lang.Object request_;
   public enum RequestCase
       implements com.google.protobuf.Internal.EnumLite,
@@ -906,11 +867,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.ConnectRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.ConnectRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -1048,38 +1011,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.ConnectRequest) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ConnectRequestOrBuilder.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ConnectRequestOrBuilder.java
@@ -64,5 +64,5 @@ public interface ConnectRequestOrBuilder extends
    */
   com.google.showcase.v1beta1.BlurbOrBuilder getBlurbOrBuilder();
 
-  public com.google.showcase.v1beta1.ConnectRequest.RequestCase getRequestCase();
+  com.google.showcase.v1beta1.ConnectRequest.RequestCase getRequestCase();
 }

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/CreateBlurbRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/CreateBlurbRequest.java
@@ -31,11 +31,6 @@ private static final long serialVersionUID = 0L;
     return new CreateBlurbRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.MessagingOuterClass.internal_static_google_showcase_v1beta1_CreateBlurbRequest_descriptor;
@@ -260,11 +255,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.CreateBlurbRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.CreateBlurbRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -394,38 +391,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.CreateBlurbRequest) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/CreateRoomRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/CreateRoomRequest.java
@@ -30,11 +30,6 @@ private static final long serialVersionUID = 0L;
     return new CreateRoomRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.MessagingOuterClass.internal_static_google_showcase_v1beta1_CreateRoomRequest_descriptor;
@@ -200,11 +195,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.CreateRoomRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.CreateRoomRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -330,38 +327,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.CreateRoomRequest) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/CreateSequenceRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/CreateSequenceRequest.java
@@ -25,11 +25,6 @@ private static final long serialVersionUID = 0L;
     return new CreateSequenceRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.SequenceOuterClass.internal_static_google_showcase_v1beta1_CreateSequenceRequest_descriptor;
@@ -183,11 +178,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.CreateSequenceRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.CreateSequenceRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -308,38 +305,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.CreateSequenceRequest) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/CreateSessionRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/CreateSessionRequest.java
@@ -29,11 +29,6 @@ private static final long serialVersionUID = 0L;
     return new CreateSessionRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.TestingOuterClass.internal_static_google_showcase_v1beta1_CreateSessionRequest_descriptor;
@@ -205,11 +200,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.CreateSessionRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.CreateSessionRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -334,38 +331,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.CreateSessionRequest) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/CreateStreamingSequenceRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/CreateStreamingSequenceRequest.java
@@ -25,11 +25,6 @@ private static final long serialVersionUID = 0L;
     return new CreateStreamingSequenceRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.SequenceOuterClass.internal_static_google_showcase_v1beta1_CreateStreamingSequenceRequest_descriptor;
@@ -183,11 +178,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.CreateStreamingSequenceRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.CreateStreamingSequenceRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -308,38 +305,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.CreateStreamingSequenceRequest) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/CreateUserRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/CreateUserRequest.java
@@ -30,11 +30,6 @@ private static final long serialVersionUID = 0L;
     return new CreateUserRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.IdentityOuterClass.internal_static_google_showcase_v1beta1_CreateUserRequest_descriptor;
@@ -200,11 +195,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.CreateUserRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.CreateUserRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -330,38 +327,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.CreateUserRequest) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/DeleteBlurbRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/DeleteBlurbRequest.java
@@ -31,11 +31,6 @@ private static final long serialVersionUID = 0L;
     return new DeleteBlurbRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.MessagingOuterClass.internal_static_google_showcase_v1beta1_DeleteBlurbRequest_descriptor;
@@ -204,11 +199,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.DeleteBlurbRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.DeleteBlurbRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -328,38 +325,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.DeleteBlurbRequest) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/DeleteRoomRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/DeleteRoomRequest.java
@@ -31,11 +31,6 @@ private static final long serialVersionUID = 0L;
     return new DeleteRoomRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.MessagingOuterClass.internal_static_google_showcase_v1beta1_DeleteRoomRequest_descriptor;
@@ -204,11 +199,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.DeleteRoomRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.DeleteRoomRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -328,38 +325,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.DeleteRoomRequest) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/DeleteSessionRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/DeleteSessionRequest.java
@@ -30,11 +30,6 @@ private static final long serialVersionUID = 0L;
     return new DeleteSessionRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.TestingOuterClass.internal_static_google_showcase_v1beta1_DeleteSessionRequest_descriptor;
@@ -203,11 +198,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.DeleteSessionRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.DeleteSessionRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -326,38 +323,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.DeleteSessionRequest) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/DeleteTestRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/DeleteTestRequest.java
@@ -30,11 +30,6 @@ private static final long serialVersionUID = 0L;
     return new DeleteTestRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.TestingOuterClass.internal_static_google_showcase_v1beta1_DeleteTestRequest_descriptor;
@@ -203,11 +198,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.DeleteTestRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.DeleteTestRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -326,38 +323,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.DeleteTestRequest) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/DeleteUserRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/DeleteUserRequest.java
@@ -31,11 +31,6 @@ private static final long serialVersionUID = 0L;
     return new DeleteUserRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.IdentityOuterClass.internal_static_google_showcase_v1beta1_DeleteUserRequest_descriptor;
@@ -204,11 +199,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.DeleteUserRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.DeleteUserRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -328,38 +325,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.DeleteUserRequest) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/EchoOuterClass.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/EchoOuterClass.java
@@ -110,78 +110,78 @@ public final class EchoOuterClass {
       "1.Severity\"x\n\rExpandRequest\022\017\n\007content\030\001" +
       " \001(\t\022!\n\005error\030\002 \001(\0132\022.google.rpc.Status\022" +
       "3\n\020stream_wait_time\030\003 \001(\0132\031.google.proto" +
-      "buf.Duration\"Q\n\022PagedExpandRequest\022\024\n\007co" +
-      "ntent\030\001 \001(\tB\003\340A\002\022\021\n\tpage_size\030\002 \001(\005\022\022\n\np" +
-      "age_token\030\003 \001(\t\"Y\n\030PagedExpandLegacyRequ" +
-      "est\022\024\n\007content\030\001 \001(\tB\003\340A\002\022\023\n\013max_results" +
-      "\030\002 \001(\005\022\022\n\npage_token\030\003 \001(\t\"h\n\023PagedExpan" +
-      "dResponse\0228\n\tresponses\030\001 \003(\0132%.google.sh" +
-      "owcase.v1beta1.EchoResponse\022\027\n\017next_page" +
-      "_token\030\002 \001(\t\"(\n\027PagedExpandResponseList\022" +
-      "\r\n\005words\030\001 \003(\t\"\203\002\n\037PagedExpandLegacyMapp" +
-      "edResponse\022`\n\014alphabetized\030\001 \003(\0132J.googl" +
-      "e.showcase.v1beta1.PagedExpandLegacyMapp" +
-      "edResponse.AlphabetizedEntry\022\027\n\017next_pag" +
-      "e_token\030\002 \001(\t\032e\n\021AlphabetizedEntry\022\013\n\003ke" +
-      "y\030\001 \001(\t\022?\n\005value\030\002 \001(\01320.google.showcase" +
-      ".v1beta1.PagedExpandResponseList:\0028\001\"\331\001\n" +
-      "\013WaitRequest\022.\n\010end_time\030\001 \001(\0132\032.google." +
-      "protobuf.TimestampH\000\022(\n\003ttl\030\004 \001(\0132\031.goog" +
-      "le.protobuf.DurationH\000\022#\n\005error\030\002 \001(\0132\022." +
-      "google.rpc.StatusH\001\0228\n\007success\030\003 \001(\0132%.g" +
-      "oogle.showcase.v1beta1.WaitResponseH\001B\005\n" +
-      "\003endB\n\n\010response\"\037\n\014WaitResponse\022\017\n\007cont" +
-      "ent\030\001 \001(\t\"<\n\014WaitMetadata\022,\n\010end_time\030\001 " +
-      "\001(\0132\032.google.protobuf.Timestamp\"\255\001\n\014Bloc" +
-      "kRequest\0221\n\016response_delay\030\001 \001(\0132\031.googl" +
-      "e.protobuf.Duration\022#\n\005error\030\002 \001(\0132\022.goo" +
-      "gle.rpc.StatusH\000\0229\n\007success\030\003 \001(\0132&.goog" +
-      "le.showcase.v1beta1.BlockResponseH\000B\n\n\010r" +
-      "esponse\" \n\rBlockResponse\022\017\n\007content\030\001 \001(" +
-      "\t*D\n\010Severity\022\017\n\013UNNECESSARY\020\000\022\r\n\tNECESS" +
-      "ARY\020\001\022\n\n\006URGENT\020\002\022\014\n\010CRITICAL\020\0032\377\013\n\004Echo" +
-      "\022\224\003\n\004Echo\022$.google.showcase.v1beta1.Echo" +
-      "Request\032%.google.showcase.v1beta1.EchoRe" +
-      "sponse\"\276\002\202\323\344\223\002\027\"\022/v1beta1/echo:echo:\001*\212\323" +
-      "\344\223\002\232\002\022\010\n\006header\022\031\n\006header\022\017{routing_id=*" +
-      "*}\022+\n\006header\022!{table_name=regions/*/zone" +
-      "s/*/**}\022\"\n\006header\022\030{super_id=projects/*}" +
-      "/**\0220\n\006header\022&{table_name=projects/*/in" +
-      "stances/*/**}\0221\n\006header\022\'projects/*/{ins" +
-      "tance_id=instances/*}/**\022\030\n\014other_header" +
-      "\022\010{baz=**}\022#\n\014other_header\022\023{qux=project" +
-      "s/*}/**\022\212\001\n\006Expand\022&.google.showcase.v1b" +
-      "eta1.ExpandRequest\032%.google.showcase.v1b" +
-      "eta1.EchoResponse\"/\202\323\344\223\002\031\"\024/v1beta1/echo" +
-      ":expand:\001*\332A\rcontent,error0\001\022z\n\007Collect\022" +
-      "$.google.showcase.v1beta1.EchoRequest\032%." +
-      "google.showcase.v1beta1.EchoResponse\" \202\323" +
-      "\344\223\002\032\"\025/v1beta1/echo:collect:\001*(\001\022W\n\004Chat" +
-      "\022$.google.showcase.v1beta1.EchoRequest\032%" +
-      ".google.showcase.v1beta1.EchoResponse(\0010" +
-      "\001\022\216\001\n\013PagedExpand\022+.google.showcase.v1be" +
-      "ta1.PagedExpandRequest\032,.google.showcase" +
-      ".v1beta1.PagedExpandResponse\"$\202\323\344\223\002\036\"\031/v" +
-      "1beta1/echo:pagedExpand:\001*\022\240\001\n\021PagedExpa" +
-      "ndLegacy\0221.google.showcase.v1beta1.Paged" +
-      "ExpandLegacyRequest\032,.google.showcase.v1" +
-      "beta1.PagedExpandResponse\"*\202\323\344\223\002$\"\037/v1be" +
-      "ta1/echo:pagedExpandLegacy:\001*\022\262\001\n\027PagedE" +
-      "xpandLegacyMapped\022+.google.showcase.v1be" +
-      "ta1.PagedExpandRequest\0328.google.showcase" +
-      ".v1beta1.PagedExpandLegacyMappedResponse" +
-      "\"0\202\323\344\223\002*\"%/v1beta1/echo:pagedExpandLegac" +
-      "yMapped:\001*\022\211\001\n\004Wait\022$.google.showcase.v1" +
-      "beta1.WaitRequest\032\035.google.longrunning.O" +
-      "peration\"<\202\323\344\223\002\027\"\022/v1beta1/echo:wait:\001*\312" +
-      "A\034\n\014WaitResponse\022\014WaitMetadata\022v\n\005Block\022" +
-      "%.google.showcase.v1beta1.BlockRequest\032&" +
-      ".google.showcase.v1beta1.BlockResponse\"\036" +
-      "\202\323\344\223\002\030\"\023/v1beta1/echo:block:\001*\032\021\312A\016local" +
-      "host:7469Bq\n\033com.google.showcase.v1beta1" +
-      "P\001Z4github.com/googleapis/gapic-showcase" +
-      "/server/genproto\352\002\031Google::Showcase::V1b" +
-      "eta1b\006proto3"
+      "buf.Duration\"R\n\022PagedExpandRequest\022\025\n\007co" +
+      "ntent\030\001 \001(\tB\004\342A\001\002\022\021\n\tpage_size\030\002 \001(\005\022\022\n\n" +
+      "page_token\030\003 \001(\t\"Z\n\030PagedExpandLegacyReq" +
+      "uest\022\025\n\007content\030\001 \001(\tB\004\342A\001\002\022\023\n\013max_resul" +
+      "ts\030\002 \001(\005\022\022\n\npage_token\030\003 \001(\t\"h\n\023PagedExp" +
+      "andResponse\0228\n\tresponses\030\001 \003(\0132%.google." +
+      "showcase.v1beta1.EchoResponse\022\027\n\017next_pa" +
+      "ge_token\030\002 \001(\t\"(\n\027PagedExpandResponseLis" +
+      "t\022\r\n\005words\030\001 \003(\t\"\203\002\n\037PagedExpandLegacyMa" +
+      "ppedResponse\022`\n\014alphabetized\030\001 \003(\0132J.goo" +
+      "gle.showcase.v1beta1.PagedExpandLegacyMa" +
+      "ppedResponse.AlphabetizedEntry\022\027\n\017next_p" +
+      "age_token\030\002 \001(\t\032e\n\021AlphabetizedEntry\022\013\n\003" +
+      "key\030\001 \001(\t\022?\n\005value\030\002 \001(\01320.google.showca" +
+      "se.v1beta1.PagedExpandResponseList:\0028\001\"\331" +
+      "\001\n\013WaitRequest\022.\n\010end_time\030\001 \001(\0132\032.googl" +
+      "e.protobuf.TimestampH\000\022(\n\003ttl\030\004 \001(\0132\031.go" +
+      "ogle.protobuf.DurationH\000\022#\n\005error\030\002 \001(\0132" +
+      "\022.google.rpc.StatusH\001\0228\n\007success\030\003 \001(\0132%" +
+      ".google.showcase.v1beta1.WaitResponseH\001B" +
+      "\005\n\003endB\n\n\010response\"\037\n\014WaitResponse\022\017\n\007co" +
+      "ntent\030\001 \001(\t\"<\n\014WaitMetadata\022,\n\010end_time\030" +
+      "\001 \001(\0132\032.google.protobuf.Timestamp\"\255\001\n\014Bl" +
+      "ockRequest\0221\n\016response_delay\030\001 \001(\0132\031.goo" +
+      "gle.protobuf.Duration\022#\n\005error\030\002 \001(\0132\022.g" +
+      "oogle.rpc.StatusH\000\0229\n\007success\030\003 \001(\0132&.go" +
+      "ogle.showcase.v1beta1.BlockResponseH\000B\n\n" +
+      "\010response\" \n\rBlockResponse\022\017\n\007content\030\001 " +
+      "\001(\t*D\n\010Severity\022\017\n\013UNNECESSARY\020\000\022\r\n\tNECE" +
+      "SSARY\020\001\022\n\n\006URGENT\020\002\022\014\n\010CRITICAL\020\0032\377\013\n\004Ec" +
+      "ho\022\224\003\n\004Echo\022$.google.showcase.v1beta1.Ec" +
+      "hoRequest\032%.google.showcase.v1beta1.Echo" +
+      "Response\"\276\002\202\323\344\223\002\027\"\022/v1beta1/echo:echo:\001*" +
+      "\212\323\344\223\002\232\002\022\010\n\006header\022\031\n\006header\022\017{routing_id" +
+      "=**}\022+\n\006header\022!{table_name=regions/*/zo" +
+      "nes/*/**}\022\"\n\006header\022\030{super_id=projects/" +
+      "*}/**\0220\n\006header\022&{table_name=projects/*/" +
+      "instances/*/**}\0221\n\006header\022\'projects/*/{i" +
+      "nstance_id=instances/*}/**\022\030\n\014other_head" +
+      "er\022\010{baz=**}\022#\n\014other_header\022\023{qux=proje" +
+      "cts/*}/**\022\212\001\n\006Expand\022&.google.showcase.v" +
+      "1beta1.ExpandRequest\032%.google.showcase.v" +
+      "1beta1.EchoResponse\"/\332A\rcontent,error\202\323\344" +
+      "\223\002\031\"\024/v1beta1/echo:expand:\001*0\001\022z\n\007Collec" +
+      "t\022$.google.showcase.v1beta1.EchoRequest\032" +
+      "%.google.showcase.v1beta1.EchoResponse\" " +
+      "\202\323\344\223\002\032\"\025/v1beta1/echo:collect:\001*(\001\022W\n\004Ch" +
+      "at\022$.google.showcase.v1beta1.EchoRequest" +
+      "\032%.google.showcase.v1beta1.EchoResponse(" +
+      "\0010\001\022\216\001\n\013PagedExpand\022+.google.showcase.v1" +
+      "beta1.PagedExpandRequest\032,.google.showca" +
+      "se.v1beta1.PagedExpandResponse\"$\202\323\344\223\002\036\"\031" +
+      "/v1beta1/echo:pagedExpand:\001*\022\240\001\n\021PagedEx" +
+      "pandLegacy\0221.google.showcase.v1beta1.Pag" +
+      "edExpandLegacyRequest\032,.google.showcase." +
+      "v1beta1.PagedExpandResponse\"*\202\323\344\223\002$\"\037/v1" +
+      "beta1/echo:pagedExpandLegacy:\001*\022\262\001\n\027Page" +
+      "dExpandLegacyMapped\022+.google.showcase.v1" +
+      "beta1.PagedExpandRequest\0328.google.showca" +
+      "se.v1beta1.PagedExpandLegacyMappedRespon" +
+      "se\"0\202\323\344\223\002*\"%/v1beta1/echo:pagedExpandLeg" +
+      "acyMapped:\001*\022\211\001\n\004Wait\022$.google.showcase." +
+      "v1beta1.WaitRequest\032\035.google.longrunning" +
+      ".Operation\"<\312A\034\n\014WaitResponse\022\014WaitMetad" +
+      "ata\202\323\344\223\002\027\"\022/v1beta1/echo:wait:\001*\022v\n\005Bloc" +
+      "k\022%.google.showcase.v1beta1.BlockRequest" +
+      "\032&.google.showcase.v1beta1.BlockResponse" +
+      "\"\036\202\323\344\223\002\030\"\023/v1beta1/echo:block:\001*\032\021\312A\016loc" +
+      "alhost:7469Bq\n\033com.google.showcase.v1bet" +
+      "a1P\001Z4github.com/googleapis/gapic-showca" +
+      "se/server/genproto\352\002\031Google::Showcase::V" +
+      "1beta1b\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/EchoRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/EchoRequest.java
@@ -35,11 +35,6 @@ private static final long serialVersionUID = 0L;
     return new EchoRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.EchoOuterClass.internal_static_google_showcase_v1beta1_EchoRequest_descriptor;
@@ -54,6 +49,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private int responseCase_ = 0;
+  @SuppressWarnings("serial")
   private java.lang.Object response_;
   public enum ResponseCase
       implements com.google.protobuf.Internal.EnumLite,
@@ -487,11 +483,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.EchoRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.EchoRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -636,38 +634,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.EchoRequest) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/EchoRequestOrBuilder.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/EchoRequestOrBuilder.java
@@ -122,5 +122,5 @@ public interface EchoRequestOrBuilder extends
   com.google.protobuf.ByteString
       getOtherHeaderBytes();
 
-  public com.google.showcase.v1beta1.EchoRequest.ResponseCase getResponseCase();
+  com.google.showcase.v1beta1.EchoRequest.ResponseCase getResponseCase();
 }

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/EchoResponse.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/EchoResponse.java
@@ -31,11 +31,6 @@ private static final long serialVersionUID = 0L;
     return new EchoResponse();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.EchoOuterClass.internal_static_google_showcase_v1beta1_EchoResponse_descriptor;
@@ -240,11 +235,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.EchoResponse parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.EchoResponse parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -367,38 +364,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.EchoResponse) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/EnumRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/EnumRequest.java
@@ -25,11 +25,6 @@ private static final long serialVersionUID = 0L;
     return new EnumRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.ComplianceOuterClass.internal_static_google_showcase_v1beta1_EnumRequest_descriptor;
@@ -168,11 +163,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.EnumRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.EnumRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -288,38 +285,6 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
-    @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.EnumRequest) {
         return mergeFrom((com.google.showcase.v1beta1.EnumRequest)other);
@@ -405,7 +370,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setUnknownEnum(boolean value) {
-      
+
       unknownEnum_ = value;
       bitField0_ |= 0x00000001;
       onChanged();

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/EnumResponse.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/EnumResponse.java
@@ -26,11 +26,6 @@ private static final long serialVersionUID = 0L;
     return new EnumResponse();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.ComplianceOuterClass.internal_static_google_showcase_v1beta1_EnumResponse_descriptor;
@@ -232,11 +227,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.EnumResponse parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.EnumResponse parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -361,38 +358,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.EnumResponse) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ExpandRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ExpandRequest.java
@@ -30,11 +30,6 @@ private static final long serialVersionUID = 0L;
     return new ExpandRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.EchoOuterClass.internal_static_google_showcase_v1beta1_ExpandRequest_descriptor;
@@ -311,11 +306,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.ExpandRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.ExpandRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -454,38 +451,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.ExpandRequest) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/GetBlurbRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/GetBlurbRequest.java
@@ -31,11 +31,6 @@ private static final long serialVersionUID = 0L;
     return new GetBlurbRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.MessagingOuterClass.internal_static_google_showcase_v1beta1_GetBlurbRequest_descriptor;
@@ -204,11 +199,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.GetBlurbRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.GetBlurbRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -328,38 +325,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.GetBlurbRequest) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/GetRoomRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/GetRoomRequest.java
@@ -31,11 +31,6 @@ private static final long serialVersionUID = 0L;
     return new GetRoomRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.MessagingOuterClass.internal_static_google_showcase_v1beta1_GetRoomRequest_descriptor;
@@ -204,11 +199,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.GetRoomRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.GetRoomRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -328,38 +325,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.GetRoomRequest) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/GetSequenceReportRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/GetSequenceReportRequest.java
@@ -26,11 +26,6 @@ private static final long serialVersionUID = 0L;
     return new GetSequenceReportRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.SequenceOuterClass.internal_static_google_showcase_v1beta1_GetSequenceReportRequest_descriptor;
@@ -191,11 +186,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.GetSequenceReportRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.GetSequenceReportRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -310,38 +307,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.GetSequenceReportRequest) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/GetSessionRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/GetSessionRequest.java
@@ -30,11 +30,6 @@ private static final long serialVersionUID = 0L;
     return new GetSessionRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.TestingOuterClass.internal_static_google_showcase_v1beta1_GetSessionRequest_descriptor;
@@ -203,11 +198,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.GetSessionRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.GetSessionRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -326,38 +323,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.GetSessionRequest) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/GetStreamingSequenceReportRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/GetStreamingSequenceReportRequest.java
@@ -26,11 +26,6 @@ private static final long serialVersionUID = 0L;
     return new GetStreamingSequenceReportRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.SequenceOuterClass.internal_static_google_showcase_v1beta1_GetStreamingSequenceReportRequest_descriptor;
@@ -191,11 +186,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.GetStreamingSequenceReportRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.GetStreamingSequenceReportRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -310,38 +307,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.GetStreamingSequenceReportRequest) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/GetUserRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/GetUserRequest.java
@@ -31,11 +31,6 @@ private static final long serialVersionUID = 0L;
     return new GetUserRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.IdentityOuterClass.internal_static_google_showcase_v1beta1_GetUserRequest_descriptor;
@@ -204,11 +199,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.GetUserRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.GetUserRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -328,38 +325,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.GetUserRequest) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/IdentityOuterClass.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/IdentityOuterClass.java
@@ -65,51 +65,51 @@ public final class IdentityOuterClass {
       "\032\031google/api/resource.proto\032\033google/prot" +
       "obuf/empty.proto\032 google/protobuf/field_" +
       "mask.proto\032\037google/protobuf/timestamp.pr" +
-      "oto\"\204\003\n\004User\022\014\n\004name\030\001 \001(\t\022\031\n\014display_na" +
-      "me\030\002 \001(\tB\003\340A\002\022\022\n\005email\030\003 \001(\tB\003\340A\002\0224\n\013cre" +
-      "ate_time\030\004 \001(\0132\032.google.protobuf.Timesta" +
-      "mpB\003\340A\003\0224\n\013update_time\030\005 \001(\0132\032.google.pr" +
-      "otobuf.TimestampB\003\340A\003\022\020\n\003age\030\006 \001(\005H\000\210\001\001\022" +
-      "\030\n\013height_feet\030\007 \001(\001H\001\210\001\001\022\025\n\010nickname\030\010 " +
-      "\001(\tH\002\210\001\001\022!\n\024enable_notifications\030\t \001(\010H\003" +
-      "\210\001\001:/\352A,\n\034showcase.googleapis.com/User\022\014" +
-      "users/{user}B\006\n\004_ageB\016\n\014_height_feetB\013\n\t" +
-      "_nicknameB\027\n\025_enable_notifications\"@\n\021Cr" +
-      "eateUserRequest\022+\n\004user\030\001 \001(\0132\035.google.s" +
-      "howcase.v1beta1.User\"D\n\016GetUserRequest\0222" +
-      "\n\004name\030\001 \001(\tB$\372A\036\n\034showcase.googleapis.c" +
-      "om/User\340A\002\"q\n\021UpdateUserRequest\022+\n\004user\030" +
-      "\001 \001(\0132\035.google.showcase.v1beta1.User\022/\n\013" +
-      "update_mask\030\002 \001(\0132\032.google.protobuf.Fiel" +
-      "dMask\"G\n\021DeleteUserRequest\0222\n\004name\030\001 \001(\t" +
-      "B$\372A\036\n\034showcase.googleapis.com/User\340A\002\"9" +
-      "\n\020ListUsersRequest\022\021\n\tpage_size\030\001 \001(\005\022\022\n" +
-      "\npage_token\030\002 \001(\t\"Z\n\021ListUsersResponse\022," +
-      "\n\005users\030\001 \003(\0132\035.google.showcase.v1beta1." +
-      "User\022\027\n\017next_page_token\030\002 \001(\t2\212\006\n\010Identi" +
-      "ty\022\363\001\n\nCreateUser\022*.google.showcase.v1be" +
-      "ta1.CreateUserRequest\032\035.google.showcase." +
-      "v1beta1.User\"\231\001\202\323\344\223\002\023\"\016/v1beta1/users:\001*" +
-      "\332A\034user.display_name,user.email\332A^user.d" +
-      "isplay_name,user.email,user.age,user.nic" +
-      "kname,user.enable_notifications,user.hei" +
-      "ght_feet\022y\n\007GetUser\022\'.google.showcase.v1" +
-      "beta1.GetUserRequest\032\035.google.showcase.v" +
-      "1beta1.User\"&\202\323\344\223\002\031\022\027/v1beta1/{name=user" +
-      "s/*}\332A\004name\022\203\001\n\nUpdateUser\022*.google.show" +
-      "case.v1beta1.UpdateUserRequest\032\035.google." +
-      "showcase.v1beta1.User\"*\202\323\344\223\002$2\034/v1beta1/" +
-      "{user.name=users/*}:\004user\022x\n\nDeleteUser\022" +
-      "*.google.showcase.v1beta1.DeleteUserRequ" +
-      "est\032\026.google.protobuf.Empty\"&\202\323\344\223\002\031*\027/v1" +
-      "beta1/{name=users/*}\332A\004name\022z\n\tListUsers" +
-      "\022).google.showcase.v1beta1.ListUsersRequ" +
-      "est\032*.google.showcase.v1beta1.ListUsersR" +
-      "esponse\"\026\202\323\344\223\002\020\022\016/v1beta1/users\032\021\312A\016loca" +
-      "lhost:7469Bq\n\033com.google.showcase.v1beta" +
-      "1P\001Z4github.com/googleapis/gapic-showcas" +
-      "e/server/genproto\352\002\031Google::Showcase::V1" +
-      "beta1b\006proto3"
+      "oto\"\210\003\n\004User\022\014\n\004name\030\001 \001(\t\022\032\n\014display_na" +
+      "me\030\002 \001(\tB\004\342A\001\002\022\023\n\005email\030\003 \001(\tB\004\342A\001\002\0225\n\013c" +
+      "reate_time\030\004 \001(\0132\032.google.protobuf.Times" +
+      "tampB\004\342A\001\003\0225\n\013update_time\030\005 \001(\0132\032.google" +
+      ".protobuf.TimestampB\004\342A\001\003\022\020\n\003age\030\006 \001(\005H\000" +
+      "\210\001\001\022\030\n\013height_feet\030\007 \001(\001H\001\210\001\001\022\025\n\010nicknam" +
+      "e\030\010 \001(\tH\002\210\001\001\022!\n\024enable_notifications\030\t \001" +
+      "(\010H\003\210\001\001:/\352A,\n\034showcase.googleapis.com/Us" +
+      "er\022\014users/{user}B\006\n\004_ageB\016\n\014_height_feet" +
+      "B\013\n\t_nicknameB\027\n\025_enable_notifications\"@" +
+      "\n\021CreateUserRequest\022+\n\004user\030\001 \001(\0132\035.goog" +
+      "le.showcase.v1beta1.User\"E\n\016GetUserReque" +
+      "st\0223\n\004name\030\001 \001(\tB%\342A\001\002\372A\036\n\034showcase.goog" +
+      "leapis.com/User\"q\n\021UpdateUserRequest\022+\n\004" +
+      "user\030\001 \001(\0132\035.google.showcase.v1beta1.Use" +
+      "r\022/\n\013update_mask\030\002 \001(\0132\032.google.protobuf" +
+      ".FieldMask\"H\n\021DeleteUserRequest\0223\n\004name\030" +
+      "\001 \001(\tB%\342A\001\002\372A\036\n\034showcase.googleapis.com/" +
+      "User\"9\n\020ListUsersRequest\022\021\n\tpage_size\030\001 " +
+      "\001(\005\022\022\n\npage_token\030\002 \001(\t\"Z\n\021ListUsersResp" +
+      "onse\022,\n\005users\030\001 \003(\0132\035.google.showcase.v1" +
+      "beta1.User\022\027\n\017next_page_token\030\002 \001(\t2\212\006\n\010" +
+      "Identity\022\363\001\n\nCreateUser\022*.google.showcas" +
+      "e.v1beta1.CreateUserRequest\032\035.google.sho" +
+      "wcase.v1beta1.User\"\231\001\332A\034user.display_nam" +
+      "e,user.email\332A^user.display_name,user.em" +
+      "ail,user.age,user.nickname,user.enable_n" +
+      "otifications,user.height_feet\202\323\344\223\002\023\"\016/v1" +
+      "beta1/users:\001*\022y\n\007GetUser\022\'.google.showc" +
+      "ase.v1beta1.GetUserRequest\032\035.google.show" +
+      "case.v1beta1.User\"&\332A\004name\202\323\344\223\002\031\022\027/v1bet" +
+      "a1/{name=users/*}\022\203\001\n\nUpdateUser\022*.googl" +
+      "e.showcase.v1beta1.UpdateUserRequest\032\035.g" +
+      "oogle.showcase.v1beta1.User\"*\202\323\344\223\002$2\034/v1" +
+      "beta1/{user.name=users/*}:\004user\022x\n\nDelet" +
+      "eUser\022*.google.showcase.v1beta1.DeleteUs" +
+      "erRequest\032\026.google.protobuf.Empty\"&\332A\004na" +
+      "me\202\323\344\223\002\031*\027/v1beta1/{name=users/*}\022z\n\tLis" +
+      "tUsers\022).google.showcase.v1beta1.ListUse" +
+      "rsRequest\032*.google.showcase.v1beta1.List" +
+      "UsersResponse\"\026\202\323\344\223\002\020\022\016/v1beta1/users\032\021\312" +
+      "A\016localhost:7469Bq\n\033com.google.showcase." +
+      "v1beta1P\001Z4github.com/googleapis/gapic-s" +
+      "howcase/server/genproto\352\002\031Google::Showca" +
+      "se::V1beta1b\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/Issue.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/Issue.java
@@ -32,11 +32,6 @@ private static final long serialVersionUID = 0L;
     return new Issue();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.TestingOuterClass.internal_static_google_showcase_v1beta1_Issue_descriptor;
@@ -570,11 +565,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.Issue parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.Issue parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -701,38 +698,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.Issue) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ListBlurbsRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ListBlurbsRequest.java
@@ -32,11 +32,6 @@ private static final long serialVersionUID = 0L;
     return new ListBlurbsRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.MessagingOuterClass.internal_static_google_showcase_v1beta1_ListBlurbsRequest_descriptor;
@@ -294,11 +289,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.ListBlurbsRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.ListBlurbsRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -426,38 +423,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.ListBlurbsRequest) {
@@ -660,7 +625,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setPageSize(int value) {
-      
+
       pageSize_ = value;
       bitField0_ |= 0x00000002;
       onChanged();

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ListBlurbsResponse.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ListBlurbsResponse.java
@@ -32,11 +32,6 @@ private static final long serialVersionUID = 0L;
     return new ListBlurbsResponse();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.MessagingOuterClass.internal_static_google_showcase_v1beta1_ListBlurbsResponse_descriptor;
@@ -285,11 +280,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.ListBlurbsResponse parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.ListBlurbsResponse parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -429,38 +426,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.ListBlurbsResponse) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ListRoomsRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ListRoomsRequest.java
@@ -31,11 +31,6 @@ private static final long serialVersionUID = 0L;
     return new ListRoomsRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.MessagingOuterClass.internal_static_google_showcase_v1beta1_ListRoomsRequest_descriptor;
@@ -235,11 +230,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.ListRoomsRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.ListRoomsRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -364,38 +361,6 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
-    @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.ListRoomsRequest) {
         return mergeFrom((com.google.showcase.v1beta1.ListRoomsRequest)other);
@@ -493,7 +458,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setPageSize(int value) {
-      
+
       pageSize_ = value;
       bitField0_ |= 0x00000001;
       onChanged();

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ListRoomsResponse.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ListRoomsResponse.java
@@ -32,11 +32,6 @@ private static final long serialVersionUID = 0L;
     return new ListRoomsResponse();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.MessagingOuterClass.internal_static_google_showcase_v1beta1_ListRoomsResponse_descriptor;
@@ -285,11 +280,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.ListRoomsResponse parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.ListRoomsResponse parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -429,38 +426,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.ListRoomsResponse) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ListSessionsRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ListSessionsRequest.java
@@ -30,11 +30,6 @@ private static final long serialVersionUID = 0L;
     return new ListSessionsRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.TestingOuterClass.internal_static_google_showcase_v1beta1_ListSessionsRequest_descriptor;
@@ -229,11 +224,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.ListSessionsRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.ListSessionsRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -357,38 +354,6 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
-    @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.ListSessionsRequest) {
         return mergeFrom((com.google.showcase.v1beta1.ListSessionsRequest)other);
@@ -484,7 +449,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setPageSize(int value) {
-      
+
       pageSize_ = value;
       bitField0_ |= 0x00000001;
       onChanged();

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ListSessionsResponse.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ListSessionsResponse.java
@@ -31,11 +31,6 @@ private static final long serialVersionUID = 0L;
     return new ListSessionsResponse();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.TestingOuterClass.internal_static_google_showcase_v1beta1_ListSessionsResponse_descriptor;
@@ -280,11 +275,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.ListSessionsResponse parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.ListSessionsResponse parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -423,38 +420,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.ListSessionsResponse) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ListTestsRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ListTestsRequest.java
@@ -31,11 +31,6 @@ private static final long serialVersionUID = 0L;
     return new ListTestsRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.TestingOuterClass.internal_static_google_showcase_v1beta1_ListTestsRequest_descriptor;
@@ -287,11 +282,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.ListTestsRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.ListTestsRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -418,38 +415,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.ListTestsRequest) {
@@ -648,7 +613,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setPageSize(int value) {
-      
+
       pageSize_ = value;
       bitField0_ |= 0x00000002;
       onChanged();

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ListTestsResponse.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ListTestsResponse.java
@@ -31,11 +31,6 @@ private static final long serialVersionUID = 0L;
     return new ListTestsResponse();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.TestingOuterClass.internal_static_google_showcase_v1beta1_ListTestsResponse_descriptor;
@@ -280,11 +275,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.ListTestsResponse parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.ListTestsResponse parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -423,38 +420,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.ListTestsResponse) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ListUsersRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ListUsersRequest.java
@@ -31,11 +31,6 @@ private static final long serialVersionUID = 0L;
     return new ListUsersRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.IdentityOuterClass.internal_static_google_showcase_v1beta1_ListUsersRequest_descriptor;
@@ -235,11 +230,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.ListUsersRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.ListUsersRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -364,38 +361,6 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
-    @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.ListUsersRequest) {
         return mergeFrom((com.google.showcase.v1beta1.ListUsersRequest)other);
@@ -493,7 +458,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setPageSize(int value) {
-      
+
       pageSize_ = value;
       bitField0_ |= 0x00000001;
       onChanged();

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ListUsersResponse.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ListUsersResponse.java
@@ -32,11 +32,6 @@ private static final long serialVersionUID = 0L;
     return new ListUsersResponse();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.IdentityOuterClass.internal_static_google_showcase_v1beta1_ListUsersResponse_descriptor;
@@ -285,11 +280,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.ListUsersResponse parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.ListUsersResponse parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -429,38 +426,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.ListUsersResponse) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/MessagingOuterClass.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/MessagingOuterClass.java
@@ -141,140 +141,141 @@ public final class MessagingOuterClass {
       "grunning/operations.proto\032\033google/protob" +
       "uf/empty.proto\032 google/protobuf/field_ma" +
       "sk.proto\032\037google/protobuf/timestamp.prot" +
-      "o\032\036google/rpc/error_details.proto\"\341\001\n\004Ro" +
-      "om\022\014\n\004name\030\001 \001(\t\022\031\n\014display_name\030\002 \001(\tB\003" +
-      "\340A\002\022\023\n\013description\030\003 \001(\t\0224\n\013create_time\030" +
-      "\004 \001(\0132\032.google.protobuf.TimestampB\003\340A\003\0224" +
-      "\n\013update_time\030\005 \001(\0132\032.google.protobuf.Ti" +
-      "mestampB\003\340A\003:/\352A,\n\034showcase.googleapis.c" +
-      "om/Room\022\014rooms/{room}\"@\n\021CreateRoomReque" +
-      "st\022+\n\004room\030\001 \001(\0132\035.google.showcase.v1bet" +
-      "a1.Room\"D\n\016GetRoomRequest\0222\n\004name\030\001 \001(\tB" +
-      "$\372A\036\n\034showcase.googleapis.com/Room\340A\002\"q\n" +
-      "\021UpdateRoomRequest\022+\n\004room\030\001 \001(\0132\035.googl" +
-      "e.showcase.v1beta1.Room\022/\n\013update_mask\030\002" +
-      " \001(\0132\032.google.protobuf.FieldMask\"G\n\021Dele" +
-      "teRoomRequest\0222\n\004name\030\001 \001(\tB$\372A\036\n\034showca" +
-      "se.googleapis.com/Room\340A\002\"9\n\020ListRoomsRe" +
-      "quest\022\021\n\tpage_size\030\001 \001(\005\022\022\n\npage_token\030\002" +
-      " \001(\t\"Z\n\021ListRoomsResponse\022,\n\005rooms\030\001 \003(\013" +
-      "2\035.google.showcase.v1beta1.Room\022\027\n\017next_" +
-      "page_token\030\002 \001(\t\"\366\003\n\005Blurb\022\014\n\004name\030\001 \001(\t" +
-      "\0222\n\004user\030\002 \001(\tB$\372A\036\n\034showcase.googleapis" +
-      ".com/User\340A\002\022\016\n\004text\030\003 \001(\tH\000\022\017\n\005image\030\004 " +
-      "\001(\014H\000\0224\n\013create_time\030\005 \001(\0132\032.google.prot" +
-      "obuf.TimestampB\003\340A\003\0224\n\013update_time\030\006 \001(\013" +
-      "2\032.google.protobuf.TimestampB\003\340A\003\022\030\n\016leg" +
-      "acy_room_id\030\007 \001(\tH\001\022\030\n\016legacy_user_id\030\010 " +
-      "\001(\tH\001:\321\001\352A\315\001\n\035showcase.googleapis.com/Bl" +
-      "urb\0228users/{user}/profile/blurbs/legacy/" +
-      "{legacy_user}~{blurb}\022#users/{user}/prof" +
-      "ile/blurbs/{blurb}\022\033rooms/{room}/blurbs/" +
-      "{blurb}\0220rooms/{room}/blurbs/legacy/{leg" +
-      "acy_room}.{blurb}B\t\n\007contentB\013\n\tlegacy_i" +
-      "d\"z\n\022CreateBlurbRequest\0225\n\006parent\030\001 \001(\tB" +
-      "%\372A\037\022\035showcase.googleapis.com/Blurb\340A\002\022-" +
-      "\n\005blurb\030\002 \001(\0132\036.google.showcase.v1beta1." +
-      "Blurb\"F\n\017GetBlurbRequest\0223\n\004name\030\001 \001(\tB%" +
-      "\372A\037\n\035showcase.googleapis.com/Blurb\340A\002\"t\n" +
-      "\022UpdateBlurbRequest\022-\n\005blurb\030\001 \001(\0132\036.goo" +
-      "gle.showcase.v1beta1.Blurb\022/\n\013update_mas" +
-      "k\030\002 \001(\0132\032.google.protobuf.FieldMask\"I\n\022D" +
-      "eleteBlurbRequest\0223\n\004name\030\001 \001(\tB%\372A\037\n\035sh" +
-      "owcase.googleapis.com/Blurb\340A\002\"q\n\021ListBl" +
-      "urbsRequest\0225\n\006parent\030\001 \001(\tB%\372A\037\022\035showca" +
-      "se.googleapis.com/Blurb\340A\002\022\021\n\tpage_size\030" +
-      "\002 \001(\005\022\022\n\npage_token\030\003 \001(\t\"]\n\022ListBlurbsR" +
-      "esponse\022.\n\006blurbs\030\001 \003(\0132\036.google.showcas" +
-      "e.v1beta1.Blurb\022\027\n\017next_page_token\030\002 \001(\t" +
-      "\"\204\001\n\023SearchBlurbsRequest\022\022\n\005query\030\001 \001(\tB" +
-      "\003\340A\002\0222\n\006parent\030\002 \001(\tB\"\372A\037\022\035showcase.goog" +
-      "leapis.com/Blurb\022\021\n\tpage_size\030\003 \001(\005\022\022\n\np" +
-      "age_token\030\004 \001(\t\"A\n\024SearchBlurbsMetadata\022" +
-      ")\n\nretry_info\030\001 \001(\0132\025.google.rpc.RetryIn" +
-      "fo\"_\n\024SearchBlurbsResponse\022.\n\006blurbs\030\001 \003" +
-      "(\0132\036.google.showcase.v1beta1.Blurb\022\027\n\017ne" +
-      "xt_page_token\030\002 \001(\t\"\200\001\n\023StreamBlurbsRequ" +
-      "est\0223\n\004name\030\001 \001(\tB%\372A\037\022\035showcase.googlea" +
-      "pis.com/Blurb\340A\002\0224\n\013expire_time\030\002 \001(\0132\032." +
-      "google.protobuf.TimestampB\003\340A\002\"\321\001\n\024Strea" +
-      "mBlurbsResponse\022-\n\005blurb\030\001 \001(\0132\036.google." +
-      "showcase.v1beta1.Blurb\022D\n\006action\030\002 \001(\01624" +
-      ".google.showcase.v1beta1.StreamBlurbsRes" +
-      "ponse.Action\"D\n\006Action\022\026\n\022ACTION_UNSPECI" +
-      "FIED\020\000\022\n\n\006CREATE\020\001\022\n\n\006UPDATE\020\002\022\n\n\006DELETE" +
-      "\020\003\"#\n\022SendBlurbsResponse\022\r\n\005names\030\001 \003(\t\"" +
-      "\332\001\n\016ConnectRequest\022G\n\006config\030\001 \001(\01325.goo" +
-      "gle.showcase.v1beta1.ConnectRequest.Conn" +
-      "ectConfigH\000\022/\n\005blurb\030\002 \001(\0132\036.google.show" +
-      "case.v1beta1.BlurbH\000\032C\n\rConnectConfig\0222\n" +
-      "\006parent\030\001 \001(\tB\"\372A\037\022\035showcase.googleapis." +
-      "com/BlurbB\t\n\007request2\264\023\n\tMessaging\022\227\001\n\nC" +
-      "reateRoom\022*.google.showcase.v1beta1.Crea" +
-      "teRoomRequest\032\035.google.showcase.v1beta1." +
-      "Room\">\202\323\344\223\002\023\"\016/v1beta1/rooms:\001*\332A\"room.d" +
-      "isplay_name,room.description\022y\n\007GetRoom\022" +
-      "\'.google.showcase.v1beta1.GetRoomRequest" +
-      "\032\035.google.showcase.v1beta1.Room\"&\202\323\344\223\002\031\022" +
-      "\027/v1beta1/{name=rooms/*}\332A\004name\022\203\001\n\nUpda" +
-      "teRoom\022*.google.showcase.v1beta1.UpdateR" +
-      "oomRequest\032\035.google.showcase.v1beta1.Roo" +
-      "m\"*\202\323\344\223\002$2\034/v1beta1/{room.name=rooms/*}:" +
-      "\004room\022x\n\nDeleteRoom\022*.google.showcase.v1" +
-      "beta1.DeleteRoomRequest\032\026.google.protobu" +
-      "f.Empty\"&\202\323\344\223\002\031*\027/v1beta1/{name=rooms/*}" +
-      "\332A\004name\022z\n\tListRooms\022).google.showcase.v" +
-      "1beta1.ListRoomsRequest\032*.google.showcas" +
-      "e.v1beta1.ListRoomsResponse\"\026\202\323\344\223\002\020\022\016/v1" +
-      "beta1/rooms\022\366\001\n\013CreateBlurb\022+.google.sho" +
-      "wcase.v1beta1.CreateBlurbRequest\032\036.googl" +
-      "e.showcase.v1beta1.Blurb\"\231\001\202\323\344\223\002T\" /v1be" +
-      "ta1/{parent=rooms/*}/blurbs:\001*Z-\"(/v1bet" +
-      "a1/{parent=users/*/profile}/blurbs:\001*\332A\034" +
-      "parent,blurb.user,blurb.text\332A\035parent,bl" +
-      "urb.user,blurb.image\022\261\001\n\010GetBlurb\022(.goog" +
-      "le.showcase.v1beta1.GetBlurbRequest\032\036.go" +
-      "ogle.showcase.v1beta1.Blurb\"[\202\323\344\223\002N\022 /v1" +
-      "beta1/{name=rooms/*/blurbs/*}Z*\022(/v1beta" +
-      "1/{name=users/*/profile/blurbs/*}\332A\004name" +
-      "\022\312\001\n\013UpdateBlurb\022+.google.showcase.v1bet" +
-      "a1.UpdateBlurbRequest\032\036.google.showcase." +
-      "v1beta1.Blurb\"n\202\323\344\223\002h2&/v1beta1/{blurb.n" +
-      "ame=rooms/*/blurbs/*}:\005blurbZ72./v1beta1" +
-      "/{blurb.name=users/*/profile/blurbs/*}:\005" +
-      "blurb\022\257\001\n\013DeleteBlurb\022+.google.showcase." +
-      "v1beta1.DeleteBlurbRequest\032\026.google.prot" +
-      "obuf.Empty\"[\202\323\344\223\002N* /v1beta1/{name=rooms" +
-      "/*/blurbs/*}Z**(/v1beta1/{name=users/*/p" +
-      "rofile/blurbs/*}\332A\004name\022\304\001\n\nListBlurbs\022*" +
-      ".google.showcase.v1beta1.ListBlurbsReque" +
-      "st\032+.google.showcase.v1beta1.ListBlurbsR" +
-      "esponse\"]\202\323\344\223\002N\022 /v1beta1/{parent=rooms/" +
-      "*}/blurbsZ*\022(/v1beta1/{parent=users/*/pr" +
-      "ofile}/blurbs\332A\006parent\022\201\002\n\014SearchBlurbs\022" +
-      ",.google.showcase.v1beta1.SearchBlurbsRe" +
-      "quest\032\035.google.longrunning.Operation\"\243\001\202" +
-      "\323\344\223\002_\"\'/v1beta1/{parent=rooms/*}/blurbs:" +
-      "search:\001*Z1\"//v1beta1/{parent=users/*/pr" +
-      "ofile}/blurbs:search\312A,\n\024SearchBlurbsRes" +
-      "ponse\022\024SearchBlurbsMetadata\332A\014parent,que" +
-      "ry\022\323\001\n\014StreamBlurbs\022,.google.showcase.v1" +
-      "beta1.StreamBlurbsRequest\032-.google.showc" +
-      "ase.v1beta1.StreamBlurbsResponse\"d\202\323\344\223\002^" +
-      "\"%/v1beta1/{name=rooms/*}/blurbs:stream:" +
-      "\001*Z2\"-/v1beta1/{name=users/*/profile}/bl" +
-      "urbs:stream:\001*0\001\022\316\001\n\nSendBlurbs\022+.google" +
-      ".showcase.v1beta1.CreateBlurbRequest\032+.g" +
-      "oogle.showcase.v1beta1.SendBlurbsRespons" +
-      "e\"d\202\323\344\223\002^\"%/v1beta1/{parent=rooms/*}/blu" +
-      "rbs:send:\001*Z2\"-/v1beta1/{parent=users/*/" +
-      "profile}/blurbs:send:\001*(\001\022e\n\007Connect\022\'.g" +
-      "oogle.showcase.v1beta1.ConnectRequest\032-." +
-      "google.showcase.v1beta1.StreamBlurbsResp" +
-      "onse(\0010\001\032\021\312A\016localhost:7469Bq\n\033com.googl" +
-      "e.showcase.v1beta1P\001Z4github.com/googlea" +
-      "pis/gapic-showcase/server/genproto\352\002\031Goo" +
-      "gle::Showcase::V1beta1b\006proto3"
+      "o\032\036google/rpc/error_details.proto\"\344\001\n\004Ro" +
+      "om\022\014\n\004name\030\001 \001(\t\022\032\n\014display_name\030\002 \001(\tB\004" +
+      "\342A\001\002\022\023\n\013description\030\003 \001(\t\0225\n\013create_time" +
+      "\030\004 \001(\0132\032.google.protobuf.TimestampB\004\342A\001\003" +
+      "\0225\n\013update_time\030\005 \001(\0132\032.google.protobuf." +
+      "TimestampB\004\342A\001\003:/\352A,\n\034showcase.googleapi" +
+      "s.com/Room\022\014rooms/{room}\"@\n\021CreateRoomRe" +
+      "quest\022+\n\004room\030\001 \001(\0132\035.google.showcase.v1" +
+      "beta1.Room\"E\n\016GetRoomRequest\0223\n\004name\030\001 \001" +
+      "(\tB%\342A\001\002\372A\036\n\034showcase.googleapis.com/Roo" +
+      "m\"q\n\021UpdateRoomRequest\022+\n\004room\030\001 \001(\0132\035.g" +
+      "oogle.showcase.v1beta1.Room\022/\n\013update_ma" +
+      "sk\030\002 \001(\0132\032.google.protobuf.FieldMask\"H\n\021" +
+      "DeleteRoomRequest\0223\n\004name\030\001 \001(\tB%\342A\001\002\372A\036" +
+      "\n\034showcase.googleapis.com/Room\"9\n\020ListRo" +
+      "omsRequest\022\021\n\tpage_size\030\001 \001(\005\022\022\n\npage_to" +
+      "ken\030\002 \001(\t\"Z\n\021ListRoomsResponse\022,\n\005rooms\030" +
+      "\001 \003(\0132\035.google.showcase.v1beta1.Room\022\027\n\017" +
+      "next_page_token\030\002 \001(\t\"\371\003\n\005Blurb\022\014\n\004name\030" +
+      "\001 \001(\t\0223\n\004user\030\002 \001(\tB%\342A\001\002\372A\036\n\034showcase.g" +
+      "oogleapis.com/User\022\016\n\004text\030\003 \001(\tH\000\022\017\n\005im" +
+      "age\030\004 \001(\014H\000\0225\n\013create_time\030\005 \001(\0132\032.googl" +
+      "e.protobuf.TimestampB\004\342A\001\003\0225\n\013update_tim" +
+      "e\030\006 \001(\0132\032.google.protobuf.TimestampB\004\342A\001" +
+      "\003\022\030\n\016legacy_room_id\030\007 \001(\tH\001\022\030\n\016legacy_us" +
+      "er_id\030\010 \001(\tH\001:\321\001\352A\315\001\n\035showcase.googleapi" +
+      "s.com/Blurb\0228users/{user}/profile/blurbs" +
+      "/legacy/{legacy_user}~{blurb}\022#users/{us" +
+      "er}/profile/blurbs/{blurb}\022\033rooms/{room}" +
+      "/blurbs/{blurb}\0220rooms/{room}/blurbs/leg" +
+      "acy/{legacy_room}.{blurb}B\t\n\007contentB\013\n\t" +
+      "legacy_id\"{\n\022CreateBlurbRequest\0226\n\006paren" +
+      "t\030\001 \001(\tB&\342A\001\002\372A\037\022\035showcase.googleapis.co" +
+      "m/Blurb\022-\n\005blurb\030\002 \001(\0132\036.google.showcase" +
+      ".v1beta1.Blurb\"G\n\017GetBlurbRequest\0224\n\004nam" +
+      "e\030\001 \001(\tB&\342A\001\002\372A\037\n\035showcase.googleapis.co" +
+      "m/Blurb\"t\n\022UpdateBlurbRequest\022-\n\005blurb\030\001" +
+      " \001(\0132\036.google.showcase.v1beta1.Blurb\022/\n\013" +
+      "update_mask\030\002 \001(\0132\032.google.protobuf.Fiel" +
+      "dMask\"J\n\022DeleteBlurbRequest\0224\n\004name\030\001 \001(" +
+      "\tB&\342A\001\002\372A\037\n\035showcase.googleapis.com/Blur" +
+      "b\"r\n\021ListBlurbsRequest\0226\n\006parent\030\001 \001(\tB&" +
+      "\342A\001\002\372A\037\022\035showcase.googleapis.com/Blurb\022\021" +
+      "\n\tpage_size\030\002 \001(\005\022\022\n\npage_token\030\003 \001(\t\"]\n" +
+      "\022ListBlurbsResponse\022.\n\006blurbs\030\001 \003(\0132\036.go" +
+      "ogle.showcase.v1beta1.Blurb\022\027\n\017next_page" +
+      "_token\030\002 \001(\t\"\205\001\n\023SearchBlurbsRequest\022\023\n\005" +
+      "query\030\001 \001(\tB\004\342A\001\002\0222\n\006parent\030\002 \001(\tB\"\372A\037\022\035" +
+      "showcase.googleapis.com/Blurb\022\021\n\tpage_si" +
+      "ze\030\003 \001(\005\022\022\n\npage_token\030\004 \001(\t\"A\n\024SearchBl" +
+      "urbsMetadata\022)\n\nretry_info\030\001 \001(\0132\025.googl" +
+      "e.rpc.RetryInfo\"_\n\024SearchBlurbsResponse\022" +
+      ".\n\006blurbs\030\001 \003(\0132\036.google.showcase.v1beta" +
+      "1.Blurb\022\027\n\017next_page_token\030\002 \001(\t\"\202\001\n\023Str" +
+      "eamBlurbsRequest\0224\n\004name\030\001 \001(\tB&\342A\001\002\372A\037\022" +
+      "\035showcase.googleapis.com/Blurb\0225\n\013expire" +
+      "_time\030\002 \001(\0132\032.google.protobuf.TimestampB" +
+      "\004\342A\001\002\"\321\001\n\024StreamBlurbsResponse\022-\n\005blurb\030" +
+      "\001 \001(\0132\036.google.showcase.v1beta1.Blurb\022D\n" +
+      "\006action\030\002 \001(\01624.google.showcase.v1beta1." +
+      "StreamBlurbsResponse.Action\"D\n\006Action\022\026\n" +
+      "\022ACTION_UNSPECIFIED\020\000\022\n\n\006CREATE\020\001\022\n\n\006UPD" +
+      "ATE\020\002\022\n\n\006DELETE\020\003\"#\n\022SendBlurbsResponse\022" +
+      "\r\n\005names\030\001 \003(\t\"\332\001\n\016ConnectRequest\022G\n\006con" +
+      "fig\030\001 \001(\01325.google.showcase.v1beta1.Conn" +
+      "ectRequest.ConnectConfigH\000\022/\n\005blurb\030\002 \001(" +
+      "\0132\036.google.showcase.v1beta1.BlurbH\000\032C\n\rC" +
+      "onnectConfig\0222\n\006parent\030\001 \001(\tB\"\372A\037\022\035showc" +
+      "ase.googleapis.com/BlurbB\t\n\007request2\264\023\n\t" +
+      "Messaging\022\227\001\n\nCreateRoom\022*.google.showca" +
+      "se.v1beta1.CreateRoomRequest\032\035.google.sh" +
+      "owcase.v1beta1.Room\">\332A\"room.display_nam" +
+      "e,room.description\202\323\344\223\002\023\"\016/v1beta1/rooms" +
+      ":\001*\022y\n\007GetRoom\022\'.google.showcase.v1beta1" +
+      ".GetRoomRequest\032\035.google.showcase.v1beta" +
+      "1.Room\"&\332A\004name\202\323\344\223\002\031\022\027/v1beta1/{name=ro" +
+      "oms/*}\022\203\001\n\nUpdateRoom\022*.google.showcase." +
+      "v1beta1.UpdateRoomRequest\032\035.google.showc" +
+      "ase.v1beta1.Room\"*\202\323\344\223\002$2\034/v1beta1/{room" +
+      ".name=rooms/*}:\004room\022x\n\nDeleteRoom\022*.goo" +
+      "gle.showcase.v1beta1.DeleteRoomRequest\032\026" +
+      ".google.protobuf.Empty\"&\332A\004name\202\323\344\223\002\031*\027/" +
+      "v1beta1/{name=rooms/*}\022z\n\tListRooms\022).go" +
+      "ogle.showcase.v1beta1.ListRoomsRequest\032*" +
+      ".google.showcase.v1beta1.ListRoomsRespon" +
+      "se\"\026\202\323\344\223\002\020\022\016/v1beta1/rooms\022\366\001\n\013CreateBlu" +
+      "rb\022+.google.showcase.v1beta1.CreateBlurb" +
+      "Request\032\036.google.showcase.v1beta1.Blurb\"" +
+      "\231\001\332A\034parent,blurb.user,blurb.text\332A\035pare" +
+      "nt,blurb.user,blurb.image\202\323\344\223\002T\" /v1beta" +
+      "1/{parent=rooms/*}/blurbs:\001*Z-\"(/v1beta1" +
+      "/{parent=users/*/profile}/blurbs:\001*\022\261\001\n\010" +
+      "GetBlurb\022(.google.showcase.v1beta1.GetBl" +
+      "urbRequest\032\036.google.showcase.v1beta1.Blu" +
+      "rb\"[\332A\004name\202\323\344\223\002N\022 /v1beta1/{name=rooms/" +
+      "*/blurbs/*}Z*\022(/v1beta1/{name=users/*/pr" +
+      "ofile/blurbs/*}\022\312\001\n\013UpdateBlurb\022+.google" +
+      ".showcase.v1beta1.UpdateBlurbRequest\032\036.g" +
+      "oogle.showcase.v1beta1.Blurb\"n\202\323\344\223\002h2&/v" +
+      "1beta1/{blurb.name=rooms/*/blurbs/*}:\005bl" +
+      "urbZ72./v1beta1/{blurb.name=users/*/prof" +
+      "ile/blurbs/*}:\005blurb\022\257\001\n\013DeleteBlurb\022+.g" +
+      "oogle.showcase.v1beta1.DeleteBlurbReques" +
+      "t\032\026.google.protobuf.Empty\"[\332A\004name\202\323\344\223\002N" +
+      "* /v1beta1/{name=rooms/*/blurbs/*}Z**(/v" +
+      "1beta1/{name=users/*/profile/blurbs/*}\022\304" +
+      "\001\n\nListBlurbs\022*.google.showcase.v1beta1." +
+      "ListBlurbsRequest\032+.google.showcase.v1be" +
+      "ta1.ListBlurbsResponse\"]\332A\006parent\202\323\344\223\002N\022" +
+      " /v1beta1/{parent=rooms/*}/blurbsZ*\022(/v1" +
+      "beta1/{parent=users/*/profile}/blurbs\022\201\002" +
+      "\n\014SearchBlurbs\022,.google.showcase.v1beta1" +
+      ".SearchBlurbsRequest\032\035.google.longrunnin" +
+      "g.Operation\"\243\001\312A,\n\024SearchBlurbsResponse\022" +
+      "\024SearchBlurbsMetadata\332A\014parent,query\202\323\344\223" +
+      "\002_\"\'/v1beta1/{parent=rooms/*}/blurbs:sea" +
+      "rch:\001*Z1\"//v1beta1/{parent=users/*/profi" +
+      "le}/blurbs:search\022\323\001\n\014StreamBlurbs\022,.goo" +
+      "gle.showcase.v1beta1.StreamBlurbsRequest" +
+      "\032-.google.showcase.v1beta1.StreamBlurbsR" +
+      "esponse\"d\202\323\344\223\002^\"%/v1beta1/{name=rooms/*}" +
+      "/blurbs:stream:\001*Z2\"-/v1beta1/{name=user" +
+      "s/*/profile}/blurbs:stream:\001*0\001\022\316\001\n\nSend" +
+      "Blurbs\022+.google.showcase.v1beta1.CreateB" +
+      "lurbRequest\032+.google.showcase.v1beta1.Se" +
+      "ndBlurbsResponse\"d\202\323\344\223\002^\"%/v1beta1/{pare" +
+      "nt=rooms/*}/blurbs:send:\001*Z2\"-/v1beta1/{" +
+      "parent=users/*/profile}/blurbs:send:\001*(\001" +
+      "\022e\n\007Connect\022\'.google.showcase.v1beta1.Co" +
+      "nnectRequest\032-.google.showcase.v1beta1.S" +
+      "treamBlurbsResponse(\0010\001\032\021\312A\016localhost:74" +
+      "69Bq\n\033com.google.showcase.v1beta1P\001Z4git" +
+      "hub.com/googleapis/gapic-showcase/server" +
+      "/genproto\352\002\031Google::Showcase::V1beta1b\006p" +
+      "roto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/PagedExpandLegacyMappedResponse.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/PagedExpandLegacyMappedResponse.java
@@ -26,11 +26,6 @@ private static final long serialVersionUID = 0L;
     return new PagedExpandLegacyMappedResponse();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.EchoOuterClass.internal_static_google_showcase_v1beta1_PagedExpandLegacyMappedResponse_descriptor;
@@ -336,11 +331,13 @@ com.google.showcase.v1beta1.PagedExpandResponseList defaultValue) {
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.PagedExpandLegacyMappedResponse parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.PagedExpandLegacyMappedResponse parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -482,38 +479,6 @@ com.google.showcase.v1beta1.PagedExpandResponseList defaultValue) {
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.PagedExpandLegacyMappedResponse) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/PagedExpandLegacyRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/PagedExpandLegacyRequest.java
@@ -33,11 +33,6 @@ private static final long serialVersionUID = 0L;
     return new PagedExpandLegacyRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.EchoOuterClass.internal_static_google_showcase_v1beta1_PagedExpandLegacyRequest_descriptor;
@@ -291,11 +286,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.PagedExpandLegacyRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.PagedExpandLegacyRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -424,38 +421,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.PagedExpandLegacyRequest) {
@@ -658,7 +623,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setMaxResults(int value) {
-      
+
       maxResults_ = value;
       bitField0_ |= 0x00000002;
       onChanged();

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/PagedExpandRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/PagedExpandRequest.java
@@ -31,11 +31,6 @@ private static final long serialVersionUID = 0L;
     return new PagedExpandRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.EchoOuterClass.internal_static_google_showcase_v1beta1_PagedExpandRequest_descriptor;
@@ -287,11 +282,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.PagedExpandRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.PagedExpandRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -418,38 +415,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.PagedExpandRequest) {
@@ -648,7 +613,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setPageSize(int value) {
-      
+
       pageSize_ = value;
       bitField0_ |= 0x00000002;
       onChanged();

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/PagedExpandResponse.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/PagedExpandResponse.java
@@ -31,11 +31,6 @@ private static final long serialVersionUID = 0L;
     return new PagedExpandResponse();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.EchoOuterClass.internal_static_google_showcase_v1beta1_PagedExpandResponse_descriptor;
@@ -278,11 +273,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.PagedExpandResponse parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.PagedExpandResponse parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -421,38 +418,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.PagedExpandResponse) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/PagedExpandResponseList.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/PagedExpandResponseList.java
@@ -20,7 +20,8 @@ private static final long serialVersionUID = 0L;
     super(builder);
   }
   private PagedExpandResponseList() {
-    words_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+    words_ =
+        com.google.protobuf.LazyStringArrayList.emptyList();
   }
 
   @java.lang.Override
@@ -30,11 +31,6 @@ private static final long serialVersionUID = 0L;
     return new PagedExpandResponseList();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.EchoOuterClass.internal_static_google_showcase_v1beta1_PagedExpandResponseList_descriptor;
@@ -50,7 +46,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int WORDS_FIELD_NUMBER = 1;
   @SuppressWarnings("serial")
-  private com.google.protobuf.LazyStringList words_;
+  private com.google.protobuf.LazyStringArrayList words_ =
+      com.google.protobuf.LazyStringArrayList.emptyList();
   /**
    * <code>repeated string words = 1;</code>
    * @return A list containing the words.
@@ -199,11 +196,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.PagedExpandResponseList parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.PagedExpandResponseList parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -283,8 +282,8 @@ private static final long serialVersionUID = 0L;
     public Builder clear() {
       super.clear();
       bitField0_ = 0;
-      words_ = com.google.protobuf.LazyStringArrayList.EMPTY;
-      bitField0_ = (bitField0_ & ~0x00000001);
+      words_ =
+          com.google.protobuf.LazyStringArrayList.emptyList();
       return this;
     }
 
@@ -311,56 +310,19 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.showcase.v1beta1.PagedExpandResponseList buildPartial() {
       com.google.showcase.v1beta1.PagedExpandResponseList result = new com.google.showcase.v1beta1.PagedExpandResponseList(this);
-      buildPartialRepeatedFields(result);
       if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
     }
 
-    private void buildPartialRepeatedFields(com.google.showcase.v1beta1.PagedExpandResponseList result) {
-      if (((bitField0_ & 0x00000001) != 0)) {
-        words_ = words_.getUnmodifiableView();
-        bitField0_ = (bitField0_ & ~0x00000001);
-      }
-      result.words_ = words_;
-    }
-
     private void buildPartial0(com.google.showcase.v1beta1.PagedExpandResponseList result) {
       int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        words_.makeImmutable();
+        result.words_ = words_;
+      }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.PagedExpandResponseList) {
@@ -376,7 +338,7 @@ private static final long serialVersionUID = 0L;
       if (!other.words_.isEmpty()) {
         if (words_.isEmpty()) {
           words_ = other.words_;
-          bitField0_ = (bitField0_ & ~0x00000001);
+          bitField0_ |= 0x00000001;
         } else {
           ensureWordsIsMutable();
           words_.addAll(other.words_);
@@ -432,12 +394,13 @@ private static final long serialVersionUID = 0L;
     }
     private int bitField0_;
 
-    private com.google.protobuf.LazyStringList words_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+    private com.google.protobuf.LazyStringArrayList words_ =
+        com.google.protobuf.LazyStringArrayList.emptyList();
     private void ensureWordsIsMutable() {
-      if (!((bitField0_ & 0x00000001) != 0)) {
+      if (!words_.isModifiable()) {
         words_ = new com.google.protobuf.LazyStringArrayList(words_);
-        bitField0_ |= 0x00000001;
-       }
+      }
+      bitField0_ |= 0x00000001;
     }
     /**
      * <code>repeated string words = 1;</code>
@@ -445,7 +408,8 @@ private static final long serialVersionUID = 0L;
      */
     public com.google.protobuf.ProtocolStringList
         getWordsList() {
-      return words_.getUnmodifiableView();
+      words_.makeImmutable();
+      return words_;
     }
     /**
      * <code>repeated string words = 1;</code>
@@ -482,6 +446,7 @@ private static final long serialVersionUID = 0L;
       if (value == null) { throw new NullPointerException(); }
       ensureWordsIsMutable();
       words_.set(index, value);
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -495,6 +460,7 @@ private static final long serialVersionUID = 0L;
       if (value == null) { throw new NullPointerException(); }
       ensureWordsIsMutable();
       words_.add(value);
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -508,6 +474,7 @@ private static final long serialVersionUID = 0L;
       ensureWordsIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, words_);
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -516,8 +483,9 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearWords() {
-      words_ = com.google.protobuf.LazyStringArrayList.EMPTY;
-      bitField0_ = (bitField0_ & ~0x00000001);
+      words_ =
+        com.google.protobuf.LazyStringArrayList.emptyList();
+      bitField0_ = (bitField0_ & ~0x00000001);;
       onChanged();
       return this;
     }
@@ -532,6 +500,7 @@ private static final long serialVersionUID = 0L;
       checkByteStringIsUtf8(value);
       ensureWordsIsMutable();
       words_.add(value);
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/RepeatRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/RepeatRequest.java
@@ -27,11 +27,6 @@ private static final long serialVersionUID = 0L;
     return new RepeatRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.ComplianceOuterClass.internal_static_google_showcase_v1beta1_RepeatRequest_descriptor;
@@ -519,11 +514,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.RepeatRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.RepeatRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -686,38 +683,6 @@ private static final long serialVersionUID = 0L;
       result.bitField0_ |= to_bitField0_;
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.RepeatRequest) {
@@ -1075,7 +1040,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setServerVerify(boolean value) {
-      
+
       serverVerify_ = value;
       bitField0_ |= 0x00000004;
       onChanged();
@@ -1225,7 +1190,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setFInt32(int value) {
-      
+
       fInt32_ = value;
       bitField0_ |= 0x00000010;
       onChanged();
@@ -1262,7 +1227,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setFInt64(long value) {
-      
+
       fInt64_ = value;
       bitField0_ |= 0x00000020;
       onChanged();
@@ -1294,7 +1259,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setFDouble(double value) {
-      
+
       fDouble_ = value;
       bitField0_ |= 0x00000040;
       onChanged();
@@ -1334,7 +1299,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setPInt32(int value) {
-      
+
       pInt32_ = value;
       bitField0_ |= 0x00000080;
       onChanged();
@@ -1374,7 +1339,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setPInt64(long value) {
-      
+
       pInt64_ = value;
       bitField0_ |= 0x00000100;
       onChanged();
@@ -1414,7 +1379,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setPDouble(double value) {
-      
+
       pDouble_ = value;
       bitField0_ |= 0x00000200;
       onChanged();

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/RepeatResponse.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/RepeatResponse.java
@@ -26,11 +26,6 @@ private static final long serialVersionUID = 0L;
     return new RepeatResponse();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.ComplianceOuterClass.internal_static_google_showcase_v1beta1_RepeatResponse_descriptor;
@@ -241,11 +236,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.RepeatResponse parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.RepeatResponse parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -370,38 +367,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.RepeatResponse) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ReportSessionRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ReportSessionRequest.java
@@ -30,11 +30,6 @@ private static final long serialVersionUID = 0L;
     return new ReportSessionRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.TestingOuterClass.internal_static_google_showcase_v1beta1_ReportSessionRequest_descriptor;
@@ -203,11 +198,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.ReportSessionRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.ReportSessionRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -326,38 +323,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.ReportSessionRequest) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ReportSessionResponse.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ReportSessionResponse.java
@@ -31,11 +31,6 @@ private static final long serialVersionUID = 0L;
     return new ReportSessionResponse();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.TestingOuterClass.internal_static_google_showcase_v1beta1_ReportSessionResponse_descriptor;
@@ -411,11 +406,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.ReportSessionResponse parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.ReportSessionResponse parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -554,38 +551,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.ReportSessionResponse) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/Room.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/Room.java
@@ -32,11 +32,6 @@ private static final long serialVersionUID = 0L;
     return new Room();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.MessagingOuterClass.internal_static_google_showcase_v1beta1_Room_descriptor;
@@ -427,11 +422,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.Room parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.Room parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -578,38 +575,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.Room) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/SearchBlurbsMetadata.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/SearchBlurbsMetadata.java
@@ -30,11 +30,6 @@ private static final long serialVersionUID = 0L;
     return new SearchBlurbsMetadata();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.MessagingOuterClass.internal_static_google_showcase_v1beta1_SearchBlurbsMetadata_descriptor;
@@ -200,11 +195,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.SearchBlurbsMetadata parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.SearchBlurbsMetadata parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -330,38 +327,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.SearchBlurbsMetadata) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/SearchBlurbsRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/SearchBlurbsRequest.java
@@ -33,11 +33,6 @@ private static final long serialVersionUID = 0L;
     return new SearchBlurbsRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.MessagingOuterClass.internal_static_google_showcase_v1beta1_SearchBlurbsRequest_descriptor;
@@ -358,11 +353,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.SearchBlurbsRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.SearchBlurbsRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -494,38 +491,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.SearchBlurbsRequest) {
@@ -840,7 +805,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setPageSize(int value) {
-      
+
       pageSize_ = value;
       bitField0_ |= 0x00000004;
       onChanged();

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/SearchBlurbsResponse.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/SearchBlurbsResponse.java
@@ -32,11 +32,6 @@ private static final long serialVersionUID = 0L;
     return new SearchBlurbsResponse();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.MessagingOuterClass.internal_static_google_showcase_v1beta1_SearchBlurbsResponse_descriptor;
@@ -285,11 +280,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.SearchBlurbsResponse parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.SearchBlurbsResponse parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -429,38 +426,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.SearchBlurbsResponse) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/SendBlurbsResponse.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/SendBlurbsResponse.java
@@ -21,7 +21,8 @@ private static final long serialVersionUID = 0L;
     super(builder);
   }
   private SendBlurbsResponse() {
-    names_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+    names_ =
+        com.google.protobuf.LazyStringArrayList.emptyList();
   }
 
   @java.lang.Override
@@ -31,11 +32,6 @@ private static final long serialVersionUID = 0L;
     return new SendBlurbsResponse();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.MessagingOuterClass.internal_static_google_showcase_v1beta1_SendBlurbsResponse_descriptor;
@@ -51,7 +47,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int NAMES_FIELD_NUMBER = 1;
   @SuppressWarnings("serial")
-  private com.google.protobuf.LazyStringList names_;
+  private com.google.protobuf.LazyStringArrayList names_ =
+      com.google.protobuf.LazyStringArrayList.emptyList();
   /**
    * <pre>
    * The names of successful blurb creations.
@@ -216,11 +213,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.SendBlurbsResponse parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.SendBlurbsResponse parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -301,8 +300,8 @@ private static final long serialVersionUID = 0L;
     public Builder clear() {
       super.clear();
       bitField0_ = 0;
-      names_ = com.google.protobuf.LazyStringArrayList.EMPTY;
-      bitField0_ = (bitField0_ & ~0x00000001);
+      names_ =
+          com.google.protobuf.LazyStringArrayList.emptyList();
       return this;
     }
 
@@ -329,56 +328,19 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.showcase.v1beta1.SendBlurbsResponse buildPartial() {
       com.google.showcase.v1beta1.SendBlurbsResponse result = new com.google.showcase.v1beta1.SendBlurbsResponse(this);
-      buildPartialRepeatedFields(result);
       if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
     }
 
-    private void buildPartialRepeatedFields(com.google.showcase.v1beta1.SendBlurbsResponse result) {
-      if (((bitField0_ & 0x00000001) != 0)) {
-        names_ = names_.getUnmodifiableView();
-        bitField0_ = (bitField0_ & ~0x00000001);
-      }
-      result.names_ = names_;
-    }
-
     private void buildPartial0(com.google.showcase.v1beta1.SendBlurbsResponse result) {
       int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        names_.makeImmutable();
+        result.names_ = names_;
+      }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.SendBlurbsResponse) {
@@ -394,7 +356,7 @@ private static final long serialVersionUID = 0L;
       if (!other.names_.isEmpty()) {
         if (names_.isEmpty()) {
           names_ = other.names_;
-          bitField0_ = (bitField0_ & ~0x00000001);
+          bitField0_ |= 0x00000001;
         } else {
           ensureNamesIsMutable();
           names_.addAll(other.names_);
@@ -450,12 +412,13 @@ private static final long serialVersionUID = 0L;
     }
     private int bitField0_;
 
-    private com.google.protobuf.LazyStringList names_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+    private com.google.protobuf.LazyStringArrayList names_ =
+        com.google.protobuf.LazyStringArrayList.emptyList();
     private void ensureNamesIsMutable() {
-      if (!((bitField0_ & 0x00000001) != 0)) {
+      if (!names_.isModifiable()) {
         names_ = new com.google.protobuf.LazyStringArrayList(names_);
-        bitField0_ |= 0x00000001;
-       }
+      }
+      bitField0_ |= 0x00000001;
     }
     /**
      * <pre>
@@ -467,7 +430,8 @@ private static final long serialVersionUID = 0L;
      */
     public com.google.protobuf.ProtocolStringList
         getNamesList() {
-      return names_.getUnmodifiableView();
+      names_.makeImmutable();
+      return names_;
     }
     /**
      * <pre>
@@ -520,6 +484,7 @@ private static final long serialVersionUID = 0L;
       if (value == null) { throw new NullPointerException(); }
       ensureNamesIsMutable();
       names_.set(index, value);
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -537,6 +502,7 @@ private static final long serialVersionUID = 0L;
       if (value == null) { throw new NullPointerException(); }
       ensureNamesIsMutable();
       names_.add(value);
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -554,6 +520,7 @@ private static final long serialVersionUID = 0L;
       ensureNamesIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, names_);
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -566,8 +533,9 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearNames() {
-      names_ = com.google.protobuf.LazyStringArrayList.EMPTY;
-      bitField0_ = (bitField0_ & ~0x00000001);
+      names_ =
+        com.google.protobuf.LazyStringArrayList.emptyList();
+      bitField0_ = (bitField0_ & ~0x00000001);;
       onChanged();
       return this;
     }
@@ -586,6 +554,7 @@ private static final long serialVersionUID = 0L;
       checkByteStringIsUtf8(value);
       ensureNamesIsMutable();
       names_.add(value);
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/Sequence.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/Sequence.java
@@ -27,11 +27,6 @@ private static final long serialVersionUID = 0L;
     return new Sequence();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.SequenceOuterClass.internal_static_google_showcase_v1beta1_Sequence_descriptor;
@@ -129,11 +124,6 @@ private static final long serialVersionUID = 0L;
       return new Response();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return com.google.showcase.v1beta1.SequenceOuterClass.internal_static_google_showcase_v1beta1_Sequence_Response_descriptor;
@@ -353,11 +343,13 @@ private static final long serialVersionUID = 0L;
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static com.google.showcase.v1beta1.Sequence.Response parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static com.google.showcase.v1beta1.Sequence.Response parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -492,38 +484,6 @@ private static final long serialVersionUID = 0L;
         }
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
-      }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.showcase.v1beta1.Sequence.Response) {
@@ -1198,11 +1158,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.Sequence parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.Sequence parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -1337,38 +1299,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.Sequence) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/SequenceOuterClass.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/SequenceOuterClass.java
@@ -105,91 +105,91 @@ public final class SequenceOuterClass {
       "\032\031google/api/resource.proto\032\036google/prot" +
       "obuf/duration.proto\032\033google/protobuf/emp" +
       "ty.proto\032\037google/protobuf/timestamp.prot" +
-      "o\032\027google/rpc/status.proto\"\363\001\n\010Sequence\022" +
-      "\021\n\004name\030\001 \001(\tB\003\340A\003\022=\n\tresponses\030\002 \003(\0132*." +
-      "google.showcase.v1beta1.Sequence.Respons" +
-      "e\032X\n\010Response\022\"\n\006status\030\001 \001(\0132\022.google.r" +
-      "pc.Status\022(\n\005delay\030\002 \001(\0132\031.google.protob" +
-      "uf.Duration:;\352A8\n showcase.googleapis.co" +
-      "m/Sequence\022\024sequences/{sequence}\"\312\002\n\021Str" +
-      "eamingSequence\022\021\n\004name\030\001 \001(\tB\003\340A\003\022\017\n\007con" +
-      "tent\030\002 \001(\t\022F\n\tresponses\030\003 \003(\01323.google.s" +
-      "howcase.v1beta1.StreamingSequence.Respon" +
-      "se\032p\n\010Response\022\"\n\006status\030\001 \001(\0132\022.google." +
+      "o\032\027google/rpc/status.proto\"\364\001\n\010Sequence\022" +
+      "\022\n\004name\030\001 \001(\tB\004\342A\001\003\022=\n\tresponses\030\002 \003(\0132*" +
+      ".google.showcase.v1beta1.Sequence.Respon" +
+      "se\032X\n\010Response\022\"\n\006status\030\001 \001(\0132\022.google." +
       "rpc.Status\022(\n\005delay\030\002 \001(\0132\031.google.proto" +
-      "buf.Duration\022\026\n\016response_index\030\003 \001(\005:W\352A" +
-      "T\n)showcase.googleapis.com/StreamingSequ" +
-      "ence\022\'streamingSequences/{streaming_sequ" +
-      "ence}\"\350\003\n\027StreamingSequenceReport\022\021\n\004nam" +
-      "e\030\001 \001(\tB\003\340A\003\022J\n\010attempts\030\002 \003(\01328.google." +
-      "showcase.v1beta1.StreamingSequenceReport" +
-      ".Attempt\032\366\001\n\007Attempt\022\026\n\016attempt_number\030\001" +
-      " \001(\005\0224\n\020attempt_deadline\030\002 \001(\0132\032.google." +
-      "protobuf.Timestamp\0221\n\rresponse_time\030\003 \001(" +
-      "\0132\032.google.protobuf.Timestamp\0220\n\rattempt" +
-      "_delay\030\004 \001(\0132\031.google.protobuf.Duration\022" +
-      "\"\n\006status\030\005 \001(\0132\022.google.rpc.Status\022\024\n\014c" +
-      "ontent_sent\030\006 \001(\t:u\352Ar\n/showcase.googlea" +
-      "pis.com/StreamingSequenceReport\022?streami" +
-      "ngSequences/{streaming_sequence}/streami" +
-      "ngSequenceReport\"\233\003\n\016SequenceReport\022\021\n\004n" +
-      "ame\030\001 \001(\tB\003\340A\003\022A\n\010attempts\030\002 \003(\0132/.googl" +
-      "e.showcase.v1beta1.SequenceReport.Attemp" +
-      "t\032\340\001\n\007Attempt\022\026\n\016attempt_number\030\001 \001(\005\0224\n" +
-      "\020attempt_deadline\030\002 \001(\0132\032.google.protobu" +
-      "f.Timestamp\0221\n\rresponse_time\030\003 \001(\0132\032.goo" +
-      "gle.protobuf.Timestamp\0220\n\rattempt_delay\030" +
-      "\004 \001(\0132\031.google.protobuf.Duration\022\"\n\006stat" +
-      "us\030\005 \001(\0132\022.google.rpc.Status:P\352AM\n&showc" +
-      "ase.googleapis.com/SequenceReport\022#seque" +
-      "nces/{sequence}/sequenceReport\"L\n\025Create" +
-      "SequenceRequest\0223\n\010sequence\030\001 \001(\0132!.goog" +
-      "le.showcase.v1beta1.Sequence\"h\n\036CreateSt" +
-      "reamingSequenceRequest\022F\n\022streaming_sequ" +
-      "ence\030\001 \001(\0132*.google.showcase.v1beta1.Str" +
-      "eamingSequence\"P\n\026AttemptSequenceRequest" +
-      "\0226\n\004name\030\001 \001(\tB(\372A\"\n showcase.googleapis" +
-      ".com/Sequence\340A\002\"b\n\037AttemptStreamingSequ" +
-      "enceRequest\022?\n\004name\030\001 \001(\tB1\372A+\n)showcase" +
-      ".googleapis.com/StreamingSequence\340A\002\"3\n " +
-      "AttemptStreamingSequenceResponse\022\017\n\007cont" +
-      "ent\030\001 \001(\t\"X\n\030GetSequenceReportRequest\022<\n" +
-      "\004name\030\001 \001(\tB.\372A(\n&showcase.googleapis.co" +
-      "m/SequenceReport\340A\002\"j\n!GetStreamingSeque" +
-      "nceReportRequest\022E\n\004name\030\001 \001(\tB7\372A1\n/sho" +
-      "wcase.googleapis.com/StreamingSequenceRe" +
-      "port\340A\0022\360\010\n\017SequenceService\022\224\001\n\016CreateSe" +
-      "quence\022..google.showcase.v1beta1.CreateS" +
-      "equenceRequest\032!.google.showcase.v1beta1" +
-      ".Sequence\"/\202\323\344\223\002\036\"\022/v1beta1/sequences:\010s" +
-      "equence\332A\010sequence\022\314\001\n\027CreateStreamingSe" +
-      "quence\0227.google.showcase.v1beta1.CreateS" +
-      "treamingSequenceRequest\032*.google.showcas" +
-      "e.v1beta1.StreamingSequence\"L\202\323\344\223\0021\"\033/v1" +
-      "beta1/streamingSequences:\022streaming_sequ" +
-      "ence\332A\022streaming_sequence\022\252\001\n\021GetSequenc" +
-      "eReport\0221.google.showcase.v1beta1.GetSeq" +
-      "uenceReportRequest\032\'.google.showcase.v1b" +
-      "eta1.SequenceReport\"9\202\323\344\223\002,\022*/v1beta1/{n" +
-      "ame=sequences/*/sequenceReport}\332A\004name\022\327" +
-      "\001\n\032GetStreamingSequenceReport\022:.google.s" +
-      "howcase.v1beta1.GetStreamingSequenceRepo" +
-      "rtRequest\0320.google.showcase.v1beta1.Stre" +
-      "amingSequenceReport\"K\202\323\344\223\002>\022</v1beta1/{n" +
-      "ame=streamingSequences/*/streamingSequen" +
-      "ceReport}\332A\004name\022\211\001\n\017AttemptSequence\022/.g" +
-      "oogle.showcase.v1beta1.AttemptSequenceRe" +
-      "quest\032\026.google.protobuf.Empty\"-\202\323\344\223\002 \"\033/" +
-      "v1beta1/{name=sequences/*}:\001*\332A\004name\022\320\001\n" +
-      "\030AttemptStreamingSequence\0228.google.showc" +
-      "ase.v1beta1.AttemptStreamingSequenceRequ" +
-      "est\0329.google.showcase.v1beta1.AttemptStr" +
-      "eamingSequenceResponse\"=\202\323\344\223\0020\"+/v1beta1" +
-      "/{name=streamingSequences/*}:stream:\001*\332A" +
-      "\004name0\001\032\021\312A\016localhost:7469Bq\n\033com.google" +
-      ".showcase.v1beta1P\001Z4github.com/googleap" +
-      "is/gapic-showcase/server/genproto\352\002\031Goog" +
-      "le::Showcase::V1beta1b\006proto3"
+      "buf.Duration:;\352A8\n showcase.googleapis.c" +
+      "om/Sequence\022\024sequences/{sequence}\"\313\002\n\021St" +
+      "reamingSequence\022\022\n\004name\030\001 \001(\tB\004\342A\001\003\022\017\n\007c" +
+      "ontent\030\002 \001(\t\022F\n\tresponses\030\003 \003(\01323.google" +
+      ".showcase.v1beta1.StreamingSequence.Resp" +
+      "onse\032p\n\010Response\022\"\n\006status\030\001 \001(\0132\022.googl" +
+      "e.rpc.Status\022(\n\005delay\030\002 \001(\0132\031.google.pro" +
+      "tobuf.Duration\022\026\n\016response_index\030\003 \001(\005:W" +
+      "\352AT\n)showcase.googleapis.com/StreamingSe" +
+      "quence\022\'streamingSequences/{streaming_se" +
+      "quence}\"\351\003\n\027StreamingSequenceReport\022\022\n\004n" +
+      "ame\030\001 \001(\tB\004\342A\001\003\022J\n\010attempts\030\002 \003(\01328.goog" +
+      "le.showcase.v1beta1.StreamingSequenceRep" +
+      "ort.Attempt\032\366\001\n\007Attempt\022\026\n\016attempt_numbe" +
+      "r\030\001 \001(\005\0224\n\020attempt_deadline\030\002 \001(\0132\032.goog" +
+      "le.protobuf.Timestamp\0221\n\rresponse_time\030\003" +
+      " \001(\0132\032.google.protobuf.Timestamp\0220\n\ratte" +
+      "mpt_delay\030\004 \001(\0132\031.google.protobuf.Durati" +
+      "on\022\"\n\006status\030\005 \001(\0132\022.google.rpc.Status\022\024" +
+      "\n\014content_sent\030\006 \001(\t:u\352Ar\n/showcase.goog" +
+      "leapis.com/StreamingSequenceReport\022?stre" +
+      "amingSequences/{streaming_sequence}/stre" +
+      "amingSequenceReport\"\234\003\n\016SequenceReport\022\022" +
+      "\n\004name\030\001 \001(\tB\004\342A\001\003\022A\n\010attempts\030\002 \003(\0132/.g" +
+      "oogle.showcase.v1beta1.SequenceReport.At" +
+      "tempt\032\340\001\n\007Attempt\022\026\n\016attempt_number\030\001 \001(" +
+      "\005\0224\n\020attempt_deadline\030\002 \001(\0132\032.google.pro" +
+      "tobuf.Timestamp\0221\n\rresponse_time\030\003 \001(\0132\032" +
+      ".google.protobuf.Timestamp\0220\n\rattempt_de" +
+      "lay\030\004 \001(\0132\031.google.protobuf.Duration\022\"\n\006" +
+      "status\030\005 \001(\0132\022.google.rpc.Status:P\352AM\n&s" +
+      "howcase.googleapis.com/SequenceReport\022#s" +
+      "equences/{sequence}/sequenceReport\"L\n\025Cr" +
+      "eateSequenceRequest\0223\n\010sequence\030\001 \001(\0132!." +
+      "google.showcase.v1beta1.Sequence\"h\n\036Crea" +
+      "teStreamingSequenceRequest\022F\n\022streaming_" +
+      "sequence\030\001 \001(\0132*.google.showcase.v1beta1" +
+      ".StreamingSequence\"Q\n\026AttemptSequenceReq" +
+      "uest\0227\n\004name\030\001 \001(\tB)\342A\001\002\372A\"\n showcase.go" +
+      "ogleapis.com/Sequence\"c\n\037AttemptStreamin" +
+      "gSequenceRequest\022@\n\004name\030\001 \001(\tB2\342A\001\002\372A+\n" +
+      ")showcase.googleapis.com/StreamingSequen" +
+      "ce\"3\n AttemptStreamingSequenceResponse\022\017" +
+      "\n\007content\030\001 \001(\t\"Y\n\030GetSequenceReportRequ" +
+      "est\022=\n\004name\030\001 \001(\tB/\342A\001\002\372A(\n&showcase.goo" +
+      "gleapis.com/SequenceReport\"k\n!GetStreami" +
+      "ngSequenceReportRequest\022F\n\004name\030\001 \001(\tB8\342" +
+      "A\001\002\372A1\n/showcase.googleapis.com/Streamin" +
+      "gSequenceReport2\360\010\n\017SequenceService\022\224\001\n\016" +
+      "CreateSequence\022..google.showcase.v1beta1" +
+      ".CreateSequenceRequest\032!.google.showcase" +
+      ".v1beta1.Sequence\"/\332A\010sequence\202\323\344\223\002\036\"\022/v" +
+      "1beta1/sequences:\010sequence\022\314\001\n\027CreateStr" +
+      "eamingSequence\0227.google.showcase.v1beta1" +
+      ".CreateStreamingSequenceRequest\032*.google" +
+      ".showcase.v1beta1.StreamingSequence\"L\332A\022" +
+      "streaming_sequence\202\323\344\223\0021\"\033/v1beta1/strea" +
+      "mingSequences:\022streaming_sequence\022\252\001\n\021Ge" +
+      "tSequenceReport\0221.google.showcase.v1beta" +
+      "1.GetSequenceReportRequest\032\'.google.show" +
+      "case.v1beta1.SequenceReport\"9\332A\004name\202\323\344\223" +
+      "\002,\022*/v1beta1/{name=sequences/*/sequenceR" +
+      "eport}\022\327\001\n\032GetStreamingSequenceReport\022:." +
+      "google.showcase.v1beta1.GetStreamingSequ" +
+      "enceReportRequest\0320.google.showcase.v1be" +
+      "ta1.StreamingSequenceReport\"K\332A\004name\202\323\344\223" +
+      "\002>\022</v1beta1/{name=streamingSequences/*/" +
+      "streamingSequenceReport}\022\211\001\n\017AttemptSequ" +
+      "ence\022/.google.showcase.v1beta1.AttemptSe" +
+      "quenceRequest\032\026.google.protobuf.Empty\"-\332" +
+      "A\004name\202\323\344\223\002 \"\033/v1beta1/{name=sequences/*" +
+      "}:\001*\022\320\001\n\030AttemptStreamingSequence\0228.goog" +
+      "le.showcase.v1beta1.AttemptStreamingSequ" +
+      "enceRequest\0329.google.showcase.v1beta1.At" +
+      "temptStreamingSequenceResponse\"=\332A\004name\202" +
+      "\323\344\223\0020\"+/v1beta1/{name=streamingSequences" +
+      "/*}:stream:\001*0\001\032\021\312A\016localhost:7469Bq\n\033co" +
+      "m.google.showcase.v1beta1P\001Z4github.com/" +
+      "googleapis/gapic-showcase/server/genprot" +
+      "o\352\002\031Google::Showcase::V1beta1b\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/SequenceReport.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/SequenceReport.java
@@ -27,11 +27,6 @@ private static final long serialVersionUID = 0L;
     return new SequenceReport();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.SequenceOuterClass.internal_static_google_showcase_v1beta1_SequenceReport_descriptor;
@@ -199,11 +194,6 @@ private static final long serialVersionUID = 0L;
       return new Attempt();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return com.google.showcase.v1beta1.SequenceOuterClass.internal_static_google_showcase_v1beta1_SequenceReport_Attempt_descriptor;
@@ -563,11 +553,13 @@ private static final long serialVersionUID = 0L;
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static com.google.showcase.v1beta1.SequenceReport.Attempt parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static com.google.showcase.v1beta1.SequenceReport.Attempt parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -727,38 +719,6 @@ private static final long serialVersionUID = 0L;
       }
 
       @java.lang.Override
-      public Builder clone() {
-        return super.clone();
-      }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.showcase.v1beta1.SequenceReport.Attempt) {
           return mergeFrom((com.google.showcase.v1beta1.SequenceReport.Attempt)other);
@@ -884,7 +844,7 @@ private static final long serialVersionUID = 0L;
        * @return This builder for chaining.
        */
       public Builder setAttemptNumber(int value) {
-        
+
         attemptNumber_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -1827,11 +1787,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.SequenceReport parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.SequenceReport parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -1966,38 +1928,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.SequenceReport) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/Session.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/Session.java
@@ -7,6 +7,7 @@ package com.google.showcase.v1beta1;
  * <pre>
  * A session is a suite of tests, generally being made in the context
  * of testing code generation.
+ *
  * A session defines tests it may expect, based on which version of the
  * code generation spec is in use.
  * </pre>
@@ -34,11 +35,6 @@ private static final long serialVersionUID = 0L;
     return new Session();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.TestingOuterClass.internal_static_google_showcase_v1beta1_Session_descriptor;
@@ -392,11 +388,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.Session parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.Session parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -442,6 +440,7 @@ private static final long serialVersionUID = 0L;
    * <pre>
    * A session is a suite of tests, generally being made in the context
    * of testing code generation.
+   *
    * A session defines tests it may expect, based on which version of the
    * code generation spec is in use.
    * </pre>
@@ -522,38 +521,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.Session) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/StreamBlurbsRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/StreamBlurbsRequest.java
@@ -31,11 +31,6 @@ private static final long serialVersionUID = 0L;
     return new StreamBlurbsRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.MessagingOuterClass.internal_static_google_showcase_v1beta1_StreamBlurbsRequest_descriptor;
@@ -258,11 +253,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.StreamBlurbsRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.StreamBlurbsRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -392,38 +389,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.StreamBlurbsRequest) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/StreamBlurbsResponse.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/StreamBlurbsResponse.java
@@ -31,11 +31,6 @@ private static final long serialVersionUID = 0L;
     return new StreamBlurbsResponse();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.MessagingOuterClass.internal_static_google_showcase_v1beta1_StreamBlurbsResponse_descriptor;
@@ -391,11 +386,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.StreamBlurbsResponse parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.StreamBlurbsResponse parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -525,38 +522,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.StreamBlurbsResponse) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/StreamingSequence.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/StreamingSequence.java
@@ -28,11 +28,6 @@ private static final long serialVersionUID = 0L;
     return new StreamingSequence();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.SequenceOuterClass.internal_static_google_showcase_v1beta1_StreamingSequence_descriptor;
@@ -140,11 +135,6 @@ private static final long serialVersionUID = 0L;
       return new Response();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return com.google.showcase.v1beta1.SequenceOuterClass.internal_static_google_showcase_v1beta1_StreamingSequence_Response_descriptor;
@@ -390,11 +380,13 @@ private static final long serialVersionUID = 0L;
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static com.google.showcase.v1beta1.StreamingSequence.Response parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static com.google.showcase.v1beta1.StreamingSequence.Response parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -533,38 +525,6 @@ private static final long serialVersionUID = 0L;
         }
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
-      }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.showcase.v1beta1.StreamingSequence.Response) {
@@ -981,7 +941,7 @@ private static final long serialVersionUID = 0L;
        * @return This builder for chaining.
        */
       public Builder setResponseIndex(int value) {
-        
+
         responseIndex_ = value;
         bitField0_ |= 0x00000004;
         onChanged();
@@ -1348,11 +1308,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.StreamingSequence parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.StreamingSequence parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -1491,38 +1453,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.StreamingSequence) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/StreamingSequenceReport.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/StreamingSequenceReport.java
@@ -27,11 +27,6 @@ private static final long serialVersionUID = 0L;
     return new StreamingSequenceReport();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.SequenceOuterClass.internal_static_google_showcase_v1beta1_StreamingSequenceReport_descriptor;
@@ -212,11 +207,6 @@ private static final long serialVersionUID = 0L;
       return new Attempt();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return com.google.showcase.v1beta1.SequenceOuterClass.internal_static_google_showcase_v1beta1_StreamingSequenceReport_Attempt_descriptor;
@@ -625,11 +615,13 @@ private static final long serialVersionUID = 0L;
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static com.google.showcase.v1beta1.StreamingSequenceReport.Attempt parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static com.google.showcase.v1beta1.StreamingSequenceReport.Attempt parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -793,38 +785,6 @@ private static final long serialVersionUID = 0L;
       }
 
       @java.lang.Override
-      public Builder clone() {
-        return super.clone();
-      }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.showcase.v1beta1.StreamingSequenceReport.Attempt) {
           return mergeFrom((com.google.showcase.v1beta1.StreamingSequenceReport.Attempt)other);
@@ -960,7 +920,7 @@ private static final long serialVersionUID = 0L;
        * @return This builder for chaining.
        */
       public Builder setAttemptNumber(int value) {
-        
+
         attemptNumber_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -1975,11 +1935,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.StreamingSequenceReport parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.StreamingSequenceReport parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -2114,38 +2076,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.StreamingSequenceReport) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/Test.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/Test.java
@@ -29,11 +29,6 @@ private static final long serialVersionUID = 0L;
     return new Test();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.TestingOuterClass.internal_static_google_showcase_v1beta1_Test_descriptor;
@@ -71,8 +66,10 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * This test is recommended.
+     *
      * If a generator explicitly ignores a recommended test (see `DeleteTest`),
      * then the report may still pass, but with a warning.
+     *
      * If a generator skips a recommended test and does not explicitly
      * express that intention, the report will fail.
      * </pre>
@@ -83,8 +80,10 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * This test is optional.
+     *
      * If a generator explicitly ignores an optional test (see `DeleteTest`),
      * then the report may still pass, and no warning will be issued.
+     *
      * If a generator skips an optional test and does not explicitly
      * express that intention, the report may still pass, but with a
      * warning.
@@ -111,8 +110,10 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * This test is recommended.
+     *
      * If a generator explicitly ignores a recommended test (see `DeleteTest`),
      * then the report may still pass, but with a warning.
+     *
      * If a generator skips a recommended test and does not explicitly
      * express that intention, the report will fail.
      * </pre>
@@ -123,8 +124,10 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * This test is optional.
+     *
      * If a generator explicitly ignores an optional test (see `DeleteTest`),
      * then the report may still pass, and no warning will be issued.
+     *
      * If a generator skips an optional test and does not explicitly
      * express that intention, the report may still pass, but with a
      * warning.
@@ -366,11 +369,6 @@ private static final long serialVersionUID = 0L;
       return new Blueprint();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return com.google.showcase.v1beta1.TestingOuterClass.internal_static_google_showcase_v1beta1_Test_Blueprint_descriptor;
@@ -446,11 +444,6 @@ private static final long serialVersionUID = 0L;
         return new Invocation();
       }
 
-      @java.lang.Override
-      public final com.google.protobuf.UnknownFieldSet
-      getUnknownFields() {
-        return this.unknownFields;
-      }
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return com.google.showcase.v1beta1.TestingOuterClass.internal_static_google_showcase_v1beta1_Test_Blueprint_Invocation_descriptor;
@@ -645,11 +638,13 @@ private static final long serialVersionUID = 0L;
         return com.google.protobuf.GeneratedMessageV3
             .parseWithIOException(PARSER, input, extensionRegistry);
       }
+
       public static com.google.showcase.v1beta1.Test.Blueprint.Invocation parseDelimitedFrom(java.io.InputStream input)
           throws java.io.IOException {
         return com.google.protobuf.GeneratedMessageV3
             .parseDelimitedWithIOException(PARSER, input);
       }
+
       public static com.google.showcase.v1beta1.Test.Blueprint.Invocation parseDelimitedFrom(
           java.io.InputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -772,38 +767,6 @@ private static final long serialVersionUID = 0L;
           }
         }
 
-        @java.lang.Override
-        public Builder clone() {
-          return super.clone();
-        }
-        @java.lang.Override
-        public Builder setField(
-            com.google.protobuf.Descriptors.FieldDescriptor field,
-            java.lang.Object value) {
-          return super.setField(field, value);
-        }
-        @java.lang.Override
-        public Builder clearField(
-            com.google.protobuf.Descriptors.FieldDescriptor field) {
-          return super.clearField(field);
-        }
-        @java.lang.Override
-        public Builder clearOneof(
-            com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-          return super.clearOneof(oneof);
-        }
-        @java.lang.Override
-        public Builder setRepeatedField(
-            com.google.protobuf.Descriptors.FieldDescriptor field,
-            int index, java.lang.Object value) {
-          return super.setRepeatedField(field, index, value);
-        }
-        @java.lang.Override
-        public Builder addRepeatedField(
-            com.google.protobuf.Descriptors.FieldDescriptor field,
-            java.lang.Object value) {
-          return super.addRepeatedField(field, value);
-        }
         @java.lang.Override
         public Builder mergeFrom(com.google.protobuf.Message other) {
           if (other instanceof com.google.showcase.v1beta1.Test.Blueprint.Invocation) {
@@ -1416,11 +1379,13 @@ private static final long serialVersionUID = 0L;
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static com.google.showcase.v1beta1.Test.Blueprint parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static com.google.showcase.v1beta1.Test.Blueprint parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -1576,38 +1541,6 @@ private static final long serialVersionUID = 0L;
         }
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
-      }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.showcase.v1beta1.Test.Blueprint) {
@@ -2787,11 +2720,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.Test parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.Test parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -2934,38 +2869,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.Test) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/TestRun.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/TestRun.java
@@ -30,11 +30,6 @@ private static final long serialVersionUID = 0L;
     return new TestRun();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.TestingOuterClass.internal_static_google_showcase_v1beta1_TestRun_descriptor;
@@ -261,11 +256,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.TestRun parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.TestRun parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -394,38 +391,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.TestRun) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/UpdateBlurbRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/UpdateBlurbRequest.java
@@ -30,11 +30,6 @@ private static final long serialVersionUID = 0L;
     return new UpdateBlurbRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.MessagingOuterClass.internal_static_google_showcase_v1beta1_UpdateBlurbRequest_descriptor;
@@ -257,11 +252,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.UpdateBlurbRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.UpdateBlurbRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -397,38 +394,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.UpdateBlurbRequest) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/UpdateRoomRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/UpdateRoomRequest.java
@@ -30,11 +30,6 @@ private static final long serialVersionUID = 0L;
     return new UpdateRoomRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.MessagingOuterClass.internal_static_google_showcase_v1beta1_UpdateRoomRequest_descriptor;
@@ -257,11 +252,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.UpdateRoomRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.UpdateRoomRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -397,38 +394,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.UpdateRoomRequest) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/UpdateUserRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/UpdateUserRequest.java
@@ -30,11 +30,6 @@ private static final long serialVersionUID = 0L;
     return new UpdateUserRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.IdentityOuterClass.internal_static_google_showcase_v1beta1_UpdateUserRequest_descriptor;
@@ -257,11 +252,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.UpdateUserRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.UpdateUserRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -397,38 +394,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.UpdateUserRequest) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/User.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/User.java
@@ -33,11 +33,6 @@ private static final long serialVersionUID = 0L;
     return new User();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.IdentityOuterClass.internal_static_google_showcase_v1beta1_User_descriptor;
@@ -329,6 +324,7 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * The nickname of the user.
+   *
    * (-- aip.dev/not-precedent: An empty string is a valid nickname.
    *     Ordinarily, proto3_optional should not be used on a `string` field. --)
    * </pre>
@@ -343,6 +339,7 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * The nickname of the user.
+   *
    * (-- aip.dev/not-precedent: An empty string is a valid nickname.
    *     Ordinarily, proto3_optional should not be used on a `string` field. --)
    * </pre>
@@ -366,6 +363,7 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * The nickname of the user.
+   *
    * (-- aip.dev/not-precedent: An empty string is a valid nickname.
    *     Ordinarily, proto3_optional should not be used on a `string` field. --)
    * </pre>
@@ -393,6 +391,7 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * Enables the receiving of notifications. The default is true if unset.
+   *
    * (-- aip.dev/not-precedent: The default for the feature is true.
    *     Ordinarily, the default for a `bool` field should be false. --)
    * </pre>
@@ -407,6 +406,7 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * Enables the receiving of notifications. The default is true if unset.
+   *
    * (-- aip.dev/not-precedent: The default for the feature is true.
    *     Ordinarily, the default for a `bool` field should be false. --)
    * </pre>
@@ -645,11 +645,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.User parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.User parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -818,38 +820,6 @@ private static final long serialVersionUID = 0L;
       result.bitField0_ |= to_bitField0_;
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.User) {
@@ -1610,7 +1580,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setAge(int value) {
-      
+
       age_ = value;
       bitField0_ |= 0x00000020;
       onChanged();
@@ -1666,7 +1636,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setHeightFeet(double value) {
-      
+
       heightFeet_ = value;
       bitField0_ |= 0x00000040;
       onChanged();
@@ -1691,6 +1661,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * The nickname of the user.
+     *
      * (-- aip.dev/not-precedent: An empty string is a valid nickname.
      *     Ordinarily, proto3_optional should not be used on a `string` field. --)
      * </pre>
@@ -1704,6 +1675,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * The nickname of the user.
+     *
      * (-- aip.dev/not-precedent: An empty string is a valid nickname.
      *     Ordinarily, proto3_optional should not be used on a `string` field. --)
      * </pre>
@@ -1726,6 +1698,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * The nickname of the user.
+     *
      * (-- aip.dev/not-precedent: An empty string is a valid nickname.
      *     Ordinarily, proto3_optional should not be used on a `string` field. --)
      * </pre>
@@ -1749,6 +1722,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * The nickname of the user.
+     *
      * (-- aip.dev/not-precedent: An empty string is a valid nickname.
      *     Ordinarily, proto3_optional should not be used on a `string` field. --)
      * </pre>
@@ -1768,6 +1742,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * The nickname of the user.
+     *
      * (-- aip.dev/not-precedent: An empty string is a valid nickname.
      *     Ordinarily, proto3_optional should not be used on a `string` field. --)
      * </pre>
@@ -1784,6 +1759,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * The nickname of the user.
+     *
      * (-- aip.dev/not-precedent: An empty string is a valid nickname.
      *     Ordinarily, proto3_optional should not be used on a `string` field. --)
      * </pre>
@@ -1806,6 +1782,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * Enables the receiving of notifications. The default is true if unset.
+     *
      * (-- aip.dev/not-precedent: The default for the feature is true.
      *     Ordinarily, the default for a `bool` field should be false. --)
      * </pre>
@@ -1820,6 +1797,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * Enables the receiving of notifications. The default is true if unset.
+     *
      * (-- aip.dev/not-precedent: The default for the feature is true.
      *     Ordinarily, the default for a `bool` field should be false. --)
      * </pre>
@@ -1834,6 +1812,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * Enables the receiving of notifications. The default is true if unset.
+     *
      * (-- aip.dev/not-precedent: The default for the feature is true.
      *     Ordinarily, the default for a `bool` field should be false. --)
      * </pre>
@@ -1843,7 +1822,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setEnableNotifications(boolean value) {
-      
+
       enableNotifications_ = value;
       bitField0_ |= 0x00000100;
       onChanged();
@@ -1852,6 +1831,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * Enables the receiving of notifications. The default is true if unset.
+     *
      * (-- aip.dev/not-precedent: The default for the feature is true.
      *     Ordinarily, the default for a `bool` field should be false. --)
      * </pre>

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/UserOrBuilder.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/UserOrBuilder.java
@@ -162,6 +162,7 @@ public interface UserOrBuilder extends
   /**
    * <pre>
    * The nickname of the user.
+   *
    * (-- aip.dev/not-precedent: An empty string is a valid nickname.
    *     Ordinarily, proto3_optional should not be used on a `string` field. --)
    * </pre>
@@ -173,6 +174,7 @@ public interface UserOrBuilder extends
   /**
    * <pre>
    * The nickname of the user.
+   *
    * (-- aip.dev/not-precedent: An empty string is a valid nickname.
    *     Ordinarily, proto3_optional should not be used on a `string` field. --)
    * </pre>
@@ -184,6 +186,7 @@ public interface UserOrBuilder extends
   /**
    * <pre>
    * The nickname of the user.
+   *
    * (-- aip.dev/not-precedent: An empty string is a valid nickname.
    *     Ordinarily, proto3_optional should not be used on a `string` field. --)
    * </pre>
@@ -197,6 +200,7 @@ public interface UserOrBuilder extends
   /**
    * <pre>
    * Enables the receiving of notifications. The default is true if unset.
+   *
    * (-- aip.dev/not-precedent: The default for the feature is true.
    *     Ordinarily, the default for a `bool` field should be false. --)
    * </pre>
@@ -208,6 +212,7 @@ public interface UserOrBuilder extends
   /**
    * <pre>
    * Enables the receiving of notifications. The default is true if unset.
+   *
    * (-- aip.dev/not-precedent: The default for the feature is true.
    *     Ordinarily, the default for a `bool` field should be false. --)
    * </pre>

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/VerifyTestRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/VerifyTestRequest.java
@@ -28,11 +28,6 @@ private static final long serialVersionUID = 0L;
     return new VerifyTestRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.TestingOuterClass.internal_static_google_showcase_v1beta1_VerifyTestRequest_descriptor;
@@ -285,11 +280,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.VerifyTestRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.VerifyTestRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -418,38 +415,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.VerifyTestRequest) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/VerifyTestResponse.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/VerifyTestResponse.java
@@ -25,11 +25,6 @@ private static final long serialVersionUID = 0L;
     return new VerifyTestResponse();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.TestingOuterClass.internal_static_google_showcase_v1beta1_VerifyTestResponse_descriptor;
@@ -195,11 +190,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.VerifyTestResponse parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.VerifyTestResponse parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -320,38 +317,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.VerifyTestResponse) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/WaitMetadata.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/WaitMetadata.java
@@ -29,11 +29,6 @@ private static final long serialVersionUID = 0L;
     return new WaitMetadata();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.EchoOuterClass.internal_static_google_showcase_v1beta1_WaitMetadata_descriptor;
@@ -199,11 +194,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.WaitMetadata parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.WaitMetadata parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -328,38 +325,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.WaitMetadata) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/WaitRequest.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/WaitRequest.java
@@ -29,11 +29,6 @@ private static final long serialVersionUID = 0L;
     return new WaitRequest();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.EchoOuterClass.internal_static_google_showcase_v1beta1_WaitRequest_descriptor;
@@ -48,6 +43,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private int endCase_ = 0;
+  @SuppressWarnings("serial")
   private java.lang.Object end_;
   public enum EndCase
       implements com.google.protobuf.Internal.EnumLite,
@@ -89,6 +85,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private int responseCase_ = 0;
+  @SuppressWarnings("serial")
   private java.lang.Object response_;
   public enum ResponseCase
       implements com.google.protobuf.Internal.EnumLite,
@@ -480,11 +477,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.WaitRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.WaitRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -639,38 +638,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.WaitRequest) {

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/WaitRequestOrBuilder.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/WaitRequestOrBuilder.java
@@ -118,7 +118,7 @@ public interface WaitRequestOrBuilder extends
    */
   com.google.showcase.v1beta1.WaitResponseOrBuilder getSuccessOrBuilder();
 
-  public com.google.showcase.v1beta1.WaitRequest.EndCase getEndCase();
+  com.google.showcase.v1beta1.WaitRequest.EndCase getEndCase();
 
-  public com.google.showcase.v1beta1.WaitRequest.ResponseCase getResponseCase();
+  com.google.showcase.v1beta1.WaitRequest.ResponseCase getResponseCase();
 }

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/WaitResponse.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/WaitResponse.java
@@ -30,11 +30,6 @@ private static final long serialVersionUID = 0L;
     return new WaitResponse();
   }
 
-  @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
-    return this.unknownFields;
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return com.google.showcase.v1beta1.EchoOuterClass.internal_static_google_showcase_v1beta1_WaitResponse_descriptor;
@@ -203,11 +198,13 @@ private static final long serialVersionUID = 0L;
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
+
   public static com.google.showcase.v1beta1.WaitResponse parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
+
   public static com.google.showcase.v1beta1.WaitResponse parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -326,38 +323,6 @@ private static final long serialVersionUID = 0L;
       }
     }
 
-    @java.lang.Override
-    public Builder clone() {
-      return super.clone();
-    }
-    @java.lang.Override
-    public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.setField(field, value);
-    }
-    @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
-      return super.clearField(field);
-    }
-    @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-      return super.clearOneof(oneof);
-    }
-    @java.lang.Override
-    public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
-      return super.setRepeatedField(field, index, value);
-    }
-    @java.lang.Override
-    public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
-      return super.addRepeatedField(field, value);
-    }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.showcase.v1beta1.WaitResponse) {


### PR DESCRIPTION
Follow up to https://github.com/googleapis/sdk-platform-java/pull/1692
This fixes an error in the workflow if it is triggered via release, and also corrects for multiple artifacts that begin with `gax`.