### PR TITLE
fix: update tag workflow

### DIFF
--- a/.github/workflows/create_additional_release_tag.yaml
+++ b/.github/workflows/create_additional_release_tag.yaml
@@ -23,15 +23,13 @@ jobs:
     - name: Create additional tags
       run: |
         ARTIFACT_IDS=('google-cloud-shared-dependencies' 'api-common' 'gax')
-        for ARTIFACT_ID in "${ARTIFACT_IDS[@]}"
-        do
+        for ARTIFACT_ID in "${ARTIFACT_IDS[@]}"; do
           VERSION=$(grep "^${ARTIFACT_ID}:" versions.txt | cut -d':' -f2 | tr -d '[:space:]')
           TAG_NAME="${ARTIFACT_ID}/v$VERSION"
-          if git show-ref --tags | grep -q "refs/tags/$TAG_NAME"
-            then
-              echo "Tag $TAG_NAME already exists. Skipping."
-              continue
-            fi
-          git tag $TAG_NAME ${{ github.event.inputs.releaseTag }}
+          if git show-ref --tags | grep -q "refs/tags/$TAG_NAME"; then
+            echo "Tag $TAG_NAME already exists. Skipping."
+            continue
+          fi
+          git tag $TAG_NAME
           git push origin $TAG_NAME
         done

--- a/.github/workflows/create_additional_release_tag.yaml
+++ b/.github/workflows/create_additional_release_tag.yaml
@@ -3,11 +3,7 @@ name: Create additional tags for each release
 on:
   release:
     types: [published]
-  workflow_dispatch: # If manually triggered, clarify which release to create the additional tags for
-    inputs:
-      releaseTag:
-        description: 'Release Tag'
-        required: true
+  workflow_dispatch:
 
 jobs:
   build:
@@ -17,7 +13,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
       with:
-        ref: ${{ github.event.inputs.releaseTag }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up Git
@@ -30,7 +25,13 @@ jobs:
         ARTIFACT_IDS=('google-cloud-shared-dependencies' 'api-common' 'gax')
         for ARTIFACT_ID in "${ARTIFACT_IDS[@]}"
         do
-          VERSION=$(grep "${ARTIFACT_ID}" versions.txt | cut -d':' -f2)
-          git tag ${ARTIFACT_ID}/$VERSION ${{ github.event.inputs.releaseTag }}
-          git push origin ${ARTIFACT_ID}/$VERSION
+          VERSION=$(grep "^${ARTIFACT_ID}:" versions.txt | cut -d':' -f2 | tr -d '[:space:]')
+          TAG_NAME="${ARTIFACT_ID}/v$VERSION"
+          if git show-ref --tags | grep -q "refs/tags/$TAG_NAME"
+            then
+              echo "Tag $TAG_NAME already exists. Skipping."
+              continue
+            fi
+          git tag $TAG_NAME ${{ github.event.inputs.releaseTag }}
+          git push origin $TAG_NAME
         done


### PR DESCRIPTION
Replacement for https://github.com/googleapis/sdk-platform-java/pull/1695

This fixes a couple issues with the original workflow:
1) Skips tags that are already created instead of failing
2) Uses exact matches for artifact IDs (multiple artifacts that begin with `gax` were causing issues)
3) Removes manual input for manual trigger; will automatically take the latest release which is what we want.