### PR TITLE
fix: fix release tag workflow to fetch all tags first

### DIFF
--- a/.github/workflows/create_additional_release_tag.yaml
+++ b/.github/workflows/create_additional_release_tag.yaml
@@ -20,6 +20,9 @@ jobs:
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
 
+    - name: Fetch all tags
+      run: git fetch --tags
+
     - name: Create additional tags
       run: |
         ARTIFACT_IDS=('google-cloud-shared-dependencies' 'api-common' 'gax')


### PR DESCRIPTION
Hopefully final follow-up to: https://github.com/googleapis/sdk-platform-java/pull/1699 

Workflow currently fails if tag is already created. This is because the actions/checkout checks out the code in a fresh workspace that does not contain tags by default. This adds in the step of fetching tags.