### PR TITLE
chore: add workaround for sonatype issue with Java 17

### DIFF
--- a/.kokoro/release/stage.sh
+++ b/.kokoro/release/stage.sh
@@ -30,6 +30,9 @@ pushd $(dirname "$0")/../../
 setup_environment_secrets
 create_settings_xml_file "settings.xml"
 
+# workaround for nexus maven plugin issue with Java 16+: https://issues.sonatype.org/browse/OSSRH-66257
+export MAVEN_OPTS="--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED"
+
 mvn clean deploy -B \
   -DskipTests=true \
   -Dclirr.skip=true \


### PR DESCRIPTION
The release in https://github.com/googleapis/sdk-platform-java/pull/1674 failed with the following error:
```
[ERROR] Failed to execute goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.13:release (default-cli) on project gapic-generator-java-root: Execution default-cli of goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.13:release failed: No converter available
[ERROR] ---- Debugging information ----
[ERROR] message             : No converter available
[ERROR] type                : java.util.Arrays$ArrayList
[ERROR] converter           : com.thoughtworks.xstream.converters.reflection.ReflectionConverter
[ERROR] message[1]          : Unable to make field protected transient int java.util.AbstractList.modCount accessible: module java.base does not "opens java.util" to unnamed module @6a1d526c
[ERROR] -------------------------------
```
Using the workaround created in https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1576 to resolve this issue.