### PR TITLE
chore: temporarily turning off Renovate Bot until August

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
+  "enabled": false,
   "extends": [
     "config:base"
   ],


### PR DESCRIPTION
Temporarily turning off RenovateBot https://docs.renovatebot.com/configuration-options/#enabled.

We examine dependency upgrades manually until August to avoid unexpected dependency upgrades sneaking into the shared dependencies.

