### PR TITLE
deps: Update dependency com.google.auth:google-auth-library-credentials and google-auth-library-oauth2-http to v1.16.1

### DIFF
--- a/gapic-generator-java-pom-parent/pom.xml
+++ b/gapic-generator-java-pom-parent/pom.xml
@@ -27,7 +27,7 @@
         consistent across modules in this repository -->
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
     <grpc.version>1.55.1</grpc.version>
-    <google.auth.version>1.16.0</google.auth.version>
+    <google.auth.version>1.16.1</google.auth.version>
     <gson.version>2.10.1</gson.version>
     <guava.version>31.1-jre</guava.version>
     <protobuf.version>3.23.1</protobuf.version>

--- a/gapic-generator-java/src/main/java/com/google/api/generator/engine/ast/ConcreteReference.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/engine/ast/ConcreteReference.java
@@ -103,14 +103,15 @@ public abstract class ConcreteReference implements Reference {
     if (!hasEnclosingClass()) {
       return ImmutableList.of();
     }
-    // The innermost type will be the last element in the list.
+    // Builds list in order of inner to outer.
+    // Return the reversed list, since the outermost type is expected to lie at index 0.
     ImmutableList.Builder<String> listBuilder = new ImmutableList.Builder<>();
     Class<?> currentClz = clazz();
     while (currentClz.getEnclosingClass() != null) {
       listBuilder.add(currentClz.getEnclosingClass().getSimpleName());
       currentClz = currentClz.getEnclosingClass();
     }
-    return listBuilder.build();
+    return listBuilder.build().reverse();
   }
 
   @Override

--- a/gapic-generator-java/src/main/java/com/google/api/generator/engine/writer/ImportWriterVisitor.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/engine/writer/ImportWriterVisitor.java
@@ -508,9 +508,11 @@ public class ImportWriterVisitor implements AstNodeVisitor {
       staticImports.add(reference.fullName());
     } else {
       if (reference.hasEnclosingClass()) {
+        // Only import outermost enclosing class, e.g. import com.foo.bar.Outer
         addImport(
             String.format(
-                "%s.%s", reference.pakkage(), String.join(DOT, reference.enclosingClassNames())));
+                "%s.%s",
+                reference.pakkage(), String.join(DOT, reference.enclosingClassNames().get(0))));
       } else {
         addImport(reference.fullName());
       }

--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/comment/CommentComposer.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/comment/CommentComposer.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 public class CommentComposer {
   private static final String APACHE_LICENSE_STRING =
-      "Copyright 2022 Google LLC\n\n"
+      "Copyright 2023 Google LLC\n\n"
           + "Licensed under the Apache License, Version 2.0 (the \"License\");\n"
           + "you may not use this file except in compliance with the License.\n"
           + "You may obtain a copy of the License at\n\n"

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/writer/ImportWriterVisitorTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/writer/ImportWriterVisitorTest.java
@@ -58,6 +58,7 @@ import com.google.api.generator.engine.ast.VariableExpr;
 import com.google.api.generator.test.utils.LineFormatter;
 import com.google.common.base.Function;
 import com.google.common.base.Strings;
+import com.google.testgapic.v1beta1.Outer;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -426,6 +427,27 @@ public class ImportWriterVisitorTest {
             "import java.lang.annotation.Repeatable;\n",
             "import java.util.List;\n\n"),
         writerVisitor.write());
+  }
+
+  @Test
+  public void writeVaporReferenceImport_outermostForNestedClass() {
+    VaporReference nestedVaporReference =
+        VaporReference.builder()
+            .setName("Inner")
+            .setEnclosingClassNames(Arrays.asList("Outer", "Middle"))
+            .setPakkage("com.google.testgapic.v1beta1")
+            .build();
+
+    TypeNode.withReference(nestedVaporReference).accept(writerVisitor);
+    assertEquals("import com.google.testgapic.v1beta1.Outer;\n\n", writerVisitor.write());
+  }
+
+  @Test
+  public void writeConcreteReferenceImport_outermostForNestedClass() {
+    ConcreteReference nestedConcreteReference =
+        ConcreteReference.withClazz(Outer.Middle.Inner.class);
+    TypeNode.withReference(nestedConcreteReference).accept(writerVisitor);
+    assertEquals("import com.google.testgapic.v1beta1.Outer;\n\n", writerVisitor.write());
   }
 
   @Test

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/writer/JavaWriterVisitorTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/writer/JavaWriterVisitorTest.java
@@ -71,9 +71,16 @@ import com.google.api.generator.engine.ast.VaporReference;
 import com.google.api.generator.engine.ast.Variable;
 import com.google.api.generator.engine.ast.VariableExpr;
 import com.google.api.generator.engine.ast.WhileStatement;
+import com.google.api.generator.gapic.composer.grpc.ServiceClientClassComposer;
+import com.google.api.generator.gapic.model.GapicClass;
+import com.google.api.generator.gapic.model.GapicContext;
+import com.google.api.generator.gapic.model.Service;
+import com.google.api.generator.test.framework.Assert;
+import com.google.api.generator.test.protoloader.TestProtoLoader;
 import com.google.api.generator.test.utils.LineFormatter;
 import com.google.api.generator.test.utils.TestExprBuilder;
 import com.google.common.base.Function;
+import com.google.testgapic.v1beta1.Outer;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -127,6 +134,26 @@ public class JavaWriterVisitorTest {
             VaporReference.builder().setName("FooBar").setPakkage("com.foo.bar").build())
         .accept(writerVisitor);
     assertEquals("FooBar", writerVisitor.write());
+  }
+
+  @Test
+  public void writeVaporReferenceType_nestedClasses() {
+    VaporReference nestedVaporReference =
+        VaporReference.builder()
+            .setName("Inner")
+            .setEnclosingClassNames(Arrays.asList("Outer", "Middle"))
+            .setPakkage("com.google.testgapic.v1beta1")
+            .build();
+    TypeNode.withReference(nestedVaporReference).accept(writerVisitor);
+    assertEquals("Outer.Middle.Inner", writerVisitor.write());
+  }
+
+  @Test
+  public void writeConcreteReferenceType_nestedClasses() {
+    ConcreteReference nestedConcreteReference =
+        ConcreteReference.withClazz(Outer.Middle.Inner.class);
+    TypeNode.withReference(nestedConcreteReference).accept(writerVisitor);
+    assertEquals("Outer.Middle.Inner", writerVisitor.write());
   }
 
   @Test
@@ -2794,6 +2821,17 @@ public class JavaWriterVisitorTest {
             "\n",
             "import javax.annotation.Generated;\n"),
         writerVisitor.write());
+  }
+
+  /** =============================== GOLDEN TESTS =============================== */
+  @Test
+  public void writeSGrpcServiceClientWithNestedClassImport() {
+    GapicContext context = TestProtoLoader.instance().parseNestedMessage();
+    Service nestedService = context.services().get(0);
+    GapicClass clazz = ServiceClientClassComposer.instance().generate(context, nestedService);
+
+    Assert.assertGoldenClass(
+        this.getClass(), clazz, "GrpcServiceClientWithNestedClassImport.golden");
   }
 
   /** =============================== HELPERS =============================== */

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/writer/goldens/GrpcServiceClientWithNestedClassImport.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/writer/goldens/GrpcServiceClientWithNestedClassImport.golden
@@ -1,0 +1,216 @@
+package com.google.types.testing;
+
+import com.google.api.gax.core.BackgroundResource;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.testgapic.v1beta1.Outer;
+import com.google.types.testing.stub.NestedMessageServiceStub;
+import com.google.types.testing.stub.NestedMessageServiceStubSettings;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS.
+/**
+ * This class provides the ability to make remote calls to the backing service through method calls
+ * that map to API methods. Sample code to get started:
+ *
+ * <pre>{@code
+ * // This snippet has been automatically generated and should be regarded as a code template only.
+ * // It will require modifications to work:
+ * // - It may require correct/in-range values for request initialization.
+ * // - It may require specifying regional endpoints when creating the service client as shown in
+ * // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+ * try (NestedMessageServiceClient nestedMessageServiceClient =
+ *     NestedMessageServiceClient.create()) {
+ *   Outer.Middle request = Outer.Middle.newBuilder().setX(120).build();
+ *   Outer.Middle.Inner response = nestedMessageServiceClient.nestedMessageMethod(request);
+ * }
+ * }</pre>
+ *
+ * <p>Note: close() needs to be called on the NestedMessageServiceClient object to clean up
+ * resources such as threads. In the example above, try-with-resources is used, which automatically
+ * calls close().
+ *
+ * <p>The surface of this class includes several types of Java methods for each of the API's
+ * methods:
+ *
+ * <ol>
+ *   <li>A "flattened" method. With this type of method, the fields of the request type have been
+ *       converted into function parameters. It may be the case that not all fields are available as
+ *       parameters, and not every API method will have a flattened method entry point.
+ *   <li>A "request object" method. This type of method only takes one parameter, a request object,
+ *       which must be constructed before the call. Not every API method will have a request object
+ *       method.
+ *   <li>A "callable" method. This type of method takes no parameters and returns an immutable API
+ *       callable object, which can be used to initiate calls to the service.
+ * </ol>
+ *
+ * <p>See the individual methods for example code.
+ *
+ * <p>Many parameters require resource names to be formatted in a particular way. To assist with
+ * these names, this class includes a format method for each type of name, and additionally a parse
+ * method to extract the individual identifiers contained within names that are returned.
+ *
+ * <p>This class can be customized by passing in a custom instance of NestedMessageServiceSettings
+ * to create(). For example:
+ *
+ * <p>To customize credentials:
+ *
+ * <pre>{@code
+ * // This snippet has been automatically generated and should be regarded as a code template only.
+ * // It will require modifications to work:
+ * // - It may require correct/in-range values for request initialization.
+ * // - It may require specifying regional endpoints when creating the service client as shown in
+ * // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+ * NestedMessageServiceSettings nestedMessageServiceSettings =
+ *     NestedMessageServiceSettings.newBuilder()
+ *         .setCredentialsProvider(FixedCredentialsProvider.create(myCredentials))
+ *         .build();
+ * NestedMessageServiceClient nestedMessageServiceClient =
+ *     NestedMessageServiceClient.create(nestedMessageServiceSettings);
+ * }</pre>
+ *
+ * <p>To customize the endpoint:
+ *
+ * <pre>{@code
+ * // This snippet has been automatically generated and should be regarded as a code template only.
+ * // It will require modifications to work:
+ * // - It may require correct/in-range values for request initialization.
+ * // - It may require specifying regional endpoints when creating the service client as shown in
+ * // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+ * NestedMessageServiceSettings nestedMessageServiceSettings =
+ *     NestedMessageServiceSettings.newBuilder().setEndpoint(myEndpoint).build();
+ * NestedMessageServiceClient nestedMessageServiceClient =
+ *     NestedMessageServiceClient.create(nestedMessageServiceSettings);
+ * }</pre>
+ *
+ * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
+ */
+@Generated("by gapic-generator-java")
+public class NestedMessageServiceClient implements BackgroundResource {
+  private final NestedMessageServiceSettings settings;
+  private final NestedMessageServiceStub stub;
+
+  /** Constructs an instance of NestedMessageServiceClient with default settings. */
+  public static final NestedMessageServiceClient create() throws IOException {
+    return create(NestedMessageServiceSettings.newBuilder().build());
+  }
+
+  /**
+   * Constructs an instance of NestedMessageServiceClient, using the given settings. The channels
+   * are created based on the settings passed in, or defaults for any settings that are not set.
+   */
+  public static final NestedMessageServiceClient create(NestedMessageServiceSettings settings)
+      throws IOException {
+    return new NestedMessageServiceClient(settings);
+  }
+
+  /**
+   * Constructs an instance of NestedMessageServiceClient, using the given stub for making calls.
+   * This is for advanced usage - prefer using create(NestedMessageServiceSettings).
+   */
+  public static final NestedMessageServiceClient create(NestedMessageServiceStub stub) {
+    return new NestedMessageServiceClient(stub);
+  }
+
+  /**
+   * Constructs an instance of NestedMessageServiceClient, using the given settings. This is
+   * protected so that it is easy to make a subclass, but otherwise, the static factory methods
+   * should be preferred.
+   */
+  protected NestedMessageServiceClient(NestedMessageServiceSettings settings) throws IOException {
+    this.settings = settings;
+    this.stub = ((NestedMessageServiceStubSettings) settings.getStubSettings()).createStub();
+  }
+
+  protected NestedMessageServiceClient(NestedMessageServiceStub stub) {
+    this.settings = null;
+    this.stub = stub;
+  }
+
+  public final NestedMessageServiceSettings getSettings() {
+    return settings;
+  }
+
+  public NestedMessageServiceStub getStub() {
+    return stub;
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated and should be regarded as a code template only.
+   * // It will require modifications to work:
+   * // - It may require correct/in-range values for request initialization.
+   * // - It may require specifying regional endpoints when creating the service client as shown in
+   * // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+   * try (NestedMessageServiceClient nestedMessageServiceClient =
+   *     NestedMessageServiceClient.create()) {
+   *   Outer.Middle request = Outer.Middle.newBuilder().setX(120).build();
+   *   Outer.Middle.Inner response = nestedMessageServiceClient.nestedMessageMethod(request);
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Outer.Middle.Inner nestedMessageMethod(Outer.Middle request) {
+    return nestedMessageMethodCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated and should be regarded as a code template only.
+   * // It will require modifications to work:
+   * // - It may require correct/in-range values for request initialization.
+   * // - It may require specifying regional endpoints when creating the service client as shown in
+   * // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+   * try (NestedMessageServiceClient nestedMessageServiceClient =
+   *     NestedMessageServiceClient.create()) {
+   *   Outer.Middle request = Outer.Middle.newBuilder().setX(120).build();
+   *   ApiFuture<Outer.Middle.Inner> future =
+   *       nestedMessageServiceClient.nestedMessageMethodCallable().futureCall(request);
+   *   // Do something.
+   *   Outer.Middle.Inner response = future.get();
+   * }
+   * }</pre>
+   */
+  public final UnaryCallable<Outer.Middle, Outer.Middle.Inner> nestedMessageMethodCallable() {
+    return stub.nestedMessageMethodCallable();
+  }
+
+  @Override
+  public final void close() {
+    stub.close();
+  }
+
+  @Override
+  public void shutdown() {
+    stub.shutdown();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return stub.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return stub.isTerminated();
+  }
+
+  @Override
+  public void shutdownNow() {
+    stub.shutdownNow();
+  }
+
+  @Override
+  public boolean awaitTermination(long duration, TimeUnit unit) throws InterruptedException {
+    return stub.awaitTermination(duration, unit);
+  }
+}

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/goldens/ComposerPostProcOnFooBar.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/goldens/ComposerPostProcOnFooBar.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/bookshopclient/AsyncGetBook.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/bookshopclient/AsyncGetBook.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/bookshopclient/SyncCreateSetCredentialsProvider.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/bookshopclient/SyncCreateSetCredentialsProvider.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/bookshopclient/SyncCreateSetEndpoint.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/bookshopclient/SyncCreateSetEndpoint.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/bookshopclient/SyncGetBook.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/bookshopclient/SyncGetBook.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/bookshopclient/SyncGetBookIntListbook.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/bookshopclient/SyncGetBookIntListbook.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/bookshopclient/SyncGetBookStringListbook.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/bookshopclient/SyncGetBookStringListbook.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/deprecatedserviceclient/AsyncFastFibonacci.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/deprecatedserviceclient/AsyncFastFibonacci.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/deprecatedserviceclient/AsyncSlowFibonacci.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/deprecatedserviceclient/AsyncSlowFibonacci.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/deprecatedserviceclient/SyncCreateSetCredentialsProvider.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/deprecatedserviceclient/SyncCreateSetCredentialsProvider.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/deprecatedserviceclient/SyncCreateSetEndpoint.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/deprecatedserviceclient/SyncCreateSetEndpoint.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/deprecatedserviceclient/SyncFastFibonacci.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/deprecatedserviceclient/SyncFastFibonacci.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/deprecatedserviceclient/SyncSlowFibonacci.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/deprecatedserviceclient/SyncSlowFibonacci.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/AsyncBlock.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/AsyncBlock.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/AsyncChat.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/AsyncChat.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/AsyncChatAgain.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/AsyncChatAgain.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/AsyncCollect.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/AsyncCollect.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/AsyncCollideName.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/AsyncCollideName.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/AsyncEcho.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/AsyncEcho.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/AsyncExpand.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/AsyncExpand.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/AsyncPagedExpand.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/AsyncPagedExpand.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/AsyncPagedExpandPaged.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/AsyncPagedExpandPaged.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/AsyncSimplePagedExpand.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/AsyncSimplePagedExpand.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/AsyncSimplePagedExpandPaged.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/AsyncSimplePagedExpandPaged.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/AsyncWait.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/AsyncWait.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/AsyncWaitLRO.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/AsyncWaitLRO.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncBlock.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncBlock.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncCollideName.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncCollideName.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncCreateSetCredentialsProvider.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncCreateSetCredentialsProvider.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncCreateSetEndpoint.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncCreateSetEndpoint.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncEcho.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncEcho.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncEchoFoobarname.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncEchoFoobarname.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncEchoNoargs.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncEchoNoargs.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncEchoResourcename.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncEchoResourcename.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncEchoStatus.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncEchoStatus.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncEchoString.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncEchoString.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncEchoString1.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncEchoString1.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncEchoString2.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncEchoString2.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncEchoStringSeverity.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncEchoStringSeverity.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncPagedExpand.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncPagedExpand.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncSimplePagedExpand.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncSimplePagedExpand.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncSimplePagedExpandNoargs.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncSimplePagedExpandNoargs.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncWait.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncWait.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncWaitDuration.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncWaitDuration.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncWaitTimestamp.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/echoclient/SyncWaitTimestamp.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/AsyncCreateUser.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/AsyncCreateUser.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/AsyncDeleteUser.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/AsyncDeleteUser.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/AsyncGetUser.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/AsyncGetUser.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/AsyncListUsers.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/AsyncListUsers.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/AsyncListUsersPaged.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/AsyncListUsersPaged.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/AsyncUpdateUser.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/AsyncUpdateUser.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/SyncCreateSetCredentialsProvider.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/SyncCreateSetCredentialsProvider.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/SyncCreateSetEndpoint.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/SyncCreateSetEndpoint.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/SyncCreateUser.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/SyncCreateUser.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/SyncCreateUserStringStringString.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/SyncCreateUserStringStringString.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/SyncCreateUserStringStringStringIntStringBooleanDouble.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/SyncCreateUserStringStringStringIntStringBooleanDouble.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/SyncCreateUserStringStringStringStringStringIntStringStringStringString.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/SyncCreateUserStringStringStringStringStringIntStringStringStringString.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/SyncDeleteUser.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/SyncDeleteUser.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/SyncDeleteUserString.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/SyncDeleteUserString.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/SyncDeleteUserUsername.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/SyncDeleteUserUsername.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/SyncGetUser.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/SyncGetUser.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/SyncGetUserString.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/SyncGetUserString.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/SyncGetUserUsername.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/SyncGetUserUsername.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/SyncListUsers.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/SyncListUsers.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/SyncUpdateUser.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/SyncUpdateUser.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncConnect.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncConnect.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncCreateBlurb.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncCreateBlurb.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncCreateRoom.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncCreateRoom.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncDeleteBlurb.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncDeleteBlurb.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncDeleteRoom.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncDeleteRoom.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncGetBlurb.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncGetBlurb.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncGetRoom.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncGetRoom.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncListBlurbs.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncListBlurbs.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncListBlurbsPaged.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncListBlurbsPaged.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncListRooms.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncListRooms.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncListRoomsPaged.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncListRoomsPaged.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncSearchBlurbs.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncSearchBlurbs.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncSearchBlurbsLRO.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncSearchBlurbsLRO.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncSendBlurbs.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncSendBlurbs.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncStreamBlurbs.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncStreamBlurbs.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncUpdateBlurb.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncUpdateBlurb.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncUpdateRoom.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncUpdateRoom.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncCreateBlurb.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncCreateBlurb.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncCreateBlurbProfilenameBytestring.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncCreateBlurbProfilenameBytestring.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncCreateBlurbProfilenameString.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncCreateBlurbProfilenameString.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncCreateBlurbRoomnameBytestring.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncCreateBlurbRoomnameBytestring.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncCreateBlurbRoomnameString.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncCreateBlurbRoomnameString.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncCreateBlurbStringBytestring.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncCreateBlurbStringBytestring.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncCreateBlurbStringString.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncCreateBlurbStringString.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncCreateRoom.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncCreateRoom.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncCreateRoomStringString.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncCreateRoomStringString.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncCreateSetCredentialsProvider.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncCreateSetCredentialsProvider.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncCreateSetEndpoint.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncCreateSetEndpoint.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncDeleteBlurb.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncDeleteBlurb.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncDeleteBlurbBlurbname.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncDeleteBlurbBlurbname.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncDeleteBlurbString.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncDeleteBlurbString.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncDeleteRoom.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncDeleteRoom.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncDeleteRoomRoomname.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncDeleteRoomRoomname.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncDeleteRoomString.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncDeleteRoomString.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncGetBlurb.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncGetBlurb.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncGetBlurbBlurbname.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncGetBlurbBlurbname.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncGetBlurbString.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncGetBlurbString.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncGetRoom.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncGetRoom.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncGetRoomRoomname.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncGetRoomRoomname.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncGetRoomString.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncGetRoomString.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncListBlurbs.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncListBlurbs.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncListBlurbsProfilename.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncListBlurbsProfilename.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncListBlurbsRoomname.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncListBlurbsRoomname.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncListBlurbsString.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncListBlurbsString.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncListRooms.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncListRooms.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncSearchBlurbs.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncSearchBlurbs.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncSearchBlurbsString.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncSearchBlurbsString.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncUpdateBlurb.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncUpdateBlurb.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncUpdateRoom.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncUpdateRoom.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/servicesettings/SyncEcho.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/servicesettings/SyncEcho.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/servicesettings/SyncFastFibonacci.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/servicesettings/SyncFastFibonacci.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/servicesettings/stub/SyncCreateTopic.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/servicesettings/stub/SyncCreateTopic.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/servicesettings/stub/SyncDeleteLog.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/servicesettings/stub/SyncDeleteLog.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/servicesettings/stub/SyncEcho.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/servicesettings/stub/SyncEcho.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/servicesettings/stub/SyncFastFibonacci.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/servicesettings/stub/SyncFastFibonacci.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/test/protoloader/TestProtoLoader.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/test/protoloader/TestProtoLoader.java
@@ -41,6 +41,8 @@ import com.google.showcase.v1beta1.IdentityOuterClass;
 import com.google.showcase.v1beta1.MessagingOuterClass;
 import com.google.showcase.v1beta1.TestingOuterClass;
 import com.google.testdata.v1.DeprecatedServiceOuterClass;
+import com.google.testgapic.v1beta1.NestedMessageProto;
+import com.google.types.testing.TypesTestingProto;
 import google.cloud.CommonResources;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -126,6 +128,30 @@ public class TestProtoLoader {
         .setResourceNames(resourceNames)
         .setServices(services)
         .setServiceConfig(config)
+        .setHelperResourceNames(outputResourceNames)
+        .setTransport(transport)
+        .build();
+  }
+
+  public GapicContext parseNestedMessage() {
+    FileDescriptor fileDescriptor = TypesTestingProto.getDescriptor();
+    ServiceDescriptor serviceDescriptor = fileDescriptor.getServices().get(0);
+    assertEquals(serviceDescriptor.getName(), "NestedMessageService");
+    Map<String, Message> messageTypes = Parser.parseMessages(fileDescriptor);
+
+    FileDescriptor messageFileDescriptor = NestedMessageProto.getDescriptor();
+    messageTypes.putAll(Parser.parseMessages(messageFileDescriptor));
+
+    Map<String, ResourceName> resourceNames = new HashMap<>();
+    Set<ResourceName> outputResourceNames = new HashSet<>();
+    List<Service> services =
+        Parser.parseService(
+            fileDescriptor, messageTypes, resourceNames, Optional.empty(), outputResourceNames);
+
+    return GapicContext.builder()
+        .setMessages(messageTypes)
+        .setResourceNames(resourceNames)
+        .setServices(services)
         .setHelperResourceNames(outputResourceNames)
         .setTransport(transport)
         .build();

--- a/gapic-generator-java/src/test/proto/types_testing.proto
+++ b/gapic-generator-java/src/test/proto/types_testing.proto
@@ -1,0 +1,32 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+import "google/api/client.proto";
+import "nested_message.proto";
+
+package google.types.testing;
+
+option java_package = "com.google.types.testing";
+option java_multiple_files = true;
+option java_outer_classname = "TypesTestingProto";
+
+// A service to test handling of deeply-nested types
+service NestedMessageService {
+  option (google.api.default_host) = "localhost:7469";
+  // Testing with nested message from a different package to require imports in generated code
+  rpc NestedMessageMethod(google.testgapic.Outer.Middle) returns (google.testgapic.Outer.Middle.Inner);
+}
+

--- a/gax-java/dependencies.properties
+++ b/gax-java/dependencies.properties
@@ -34,8 +34,8 @@ version.io_grpc=1.54.0
 #   2) Replace all characters which are neither alphabetic nor digits with the underscore ('_') character
 maven.com_google_api_grpc_proto_google_common_protos=com.google.api.grpc:proto-google-common-protos:2.15.0
 maven.com_google_api_grpc_grpc_google_common_protos=com.google.api.grpc:grpc-google-common-protos:2.15.0
-maven.com_google_auth_google_auth_library_oauth2_http=com.google.auth:google-auth-library-oauth2-http:1.16.0
-maven.com_google_auth_google_auth_library_credentials=com.google.auth:google-auth-library-credentials:1.16.0
+maven.com_google_auth_google_auth_library_oauth2_http=com.google.auth:google-auth-library-oauth2-http:1.16.1
+maven.com_google_auth_google_auth_library_credentials=com.google.auth:google-auth-library-credentials:1.16.1
 maven.io_opencensus_opencensus_api=io.opencensus:opencensus-api:0.31.1
 maven.io_opencensus_opencensus_contrib_grpc_metrics=io.opencensus:opencensus-contrib-grpc-metrics:0.31.1
 maven.io_opencensus_opencensus_contrib_http_util=io.opencensus:opencensus-contrib-http-util:0.31.1

--- a/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/InstantiatingHttpJsonChannelProvider.java
+++ b/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/InstantiatingHttpJsonChannelProvider.java
@@ -186,6 +186,8 @@ public final class InstantiatingHttpJsonChannelProvider implements TransportChan
       httpTransportToUse = createHttpTransport();
     }
 
+    // Pass the executor to the ManagedChannel. If no executor was provided (or null),
+    // the channel will use a default executor for the calls.
     ManagedHttpJsonChannel channel =
         ManagedHttpJsonChannel.newBuilder()
             .setEndpoint(endpoint)

--- a/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ManagedHttpJsonInterceptorChannel.java
+++ b/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ManagedHttpJsonInterceptorChannel.java
@@ -30,6 +30,7 @@
 package com.google.api.gax.httpjson;
 
 import com.google.api.core.BetaApi;
+import com.google.common.annotations.VisibleForTesting;
 import java.util.concurrent.TimeUnit;
 
 @BetaApi
@@ -43,6 +44,11 @@ class ManagedHttpJsonInterceptorChannel extends ManagedHttpJsonChannel {
     super();
     this.channel = channel;
     this.interceptor = interceptor;
+  }
+
+  @VisibleForTesting
+  ManagedHttpJsonChannel getChannel() {
+    return channel;
   }
 
   @Override

--- a/gax-java/gax-httpjson/src/test/java/com/google/api/gax/httpjson/InstantiatingHttpJsonChannelProviderTest.java
+++ b/gax-java/gax-httpjson/src/test/java/com/google/api/gax/httpjson/InstantiatingHttpJsonChannelProviderTest.java
@@ -39,6 +39,7 @@ import com.google.api.gax.rpc.mtls.MtlsProvider;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -50,20 +51,22 @@ import org.mockito.Mockito;
 @RunWith(JUnit4.class)
 public class InstantiatingHttpJsonChannelProviderTest extends AbstractMtlsTransportChannelTest {
 
+  private static final String DEFAULT_ENDPOINT = "localhost:8080";
+  private static final Map<String, String> DEFAULT_HEADER_MAP = Collections.emptyMap();
+
   @Test
   public void basicTest() throws IOException {
-    String endpoint = "localhost:8080";
     ScheduledExecutorService executor = new ScheduledThreadPoolExecutor(1);
     executor.shutdown();
 
     TransportChannelProvider provider = InstantiatingHttpJsonChannelProvider.newBuilder().build();
 
     assertThat(provider.needsEndpoint()).isTrue();
-    provider = provider.withEndpoint(endpoint);
+    provider = provider.withEndpoint(DEFAULT_ENDPOINT);
     assertThat(provider.needsEndpoint()).isFalse();
 
     assertThat(provider.needsHeaders()).isTrue();
-    provider = provider.withHeaders(Collections.<String, String>emptyMap());
+    provider = provider.withHeaders(DEFAULT_HEADER_MAP);
     assertThat(provider.needsHeaders()).isFalse();
 
     // Make sure getTransportChannel works without setting executor
@@ -101,6 +104,57 @@ public class InstantiatingHttpJsonChannelProviderTest extends AbstractMtlsTransp
 
     // Make sure we can create channels OK.
     provider.getTransportChannel().shutdownNow();
+  }
+
+  // Ensure that a default executor is created by the ManagedHttpJsonChannel even
+  // if not provided by the TransportChannelProvider
+  @Test
+  public void managedChannelUsesDefaultChannelExecutor() throws IOException {
+    InstantiatingHttpJsonChannelProvider instantiatingHttpJsonChannelProvider =
+        InstantiatingHttpJsonChannelProvider.newBuilder().setEndpoint(DEFAULT_ENDPOINT).build();
+    instantiatingHttpJsonChannelProvider =
+        (InstantiatingHttpJsonChannelProvider)
+            instantiatingHttpJsonChannelProvider.withHeaders(DEFAULT_HEADER_MAP);
+    HttpJsonTransportChannel httpJsonTransportChannel =
+        instantiatingHttpJsonChannelProvider.getTransportChannel();
+
+    // By default, the channel will be wrapped with ManagedHttpJsonInterceptorChannel
+    ManagedHttpJsonInterceptorChannel interceptorChannel =
+        (ManagedHttpJsonInterceptorChannel) httpJsonTransportChannel.getManagedChannel();
+    ManagedHttpJsonChannel managedHttpJsonChannel = interceptorChannel.getChannel();
+    assertThat(managedHttpJsonChannel.getExecutor()).isNotNull();
+
+    // Clean up the resources (executor, deadlineScheduler, httpTransport)
+    instantiatingHttpJsonChannelProvider.getTransportChannel().shutdownNow();
+  }
+
+  // Ensure that the user's executor is used by the ManagedHttpJsonChannel
+  @Test
+  public void managedChannelUsesCustomExecutor() throws IOException {
+    // Custom executor to use -- Lifecycle must be managed by this test
+    ScheduledExecutorService executor = new ScheduledThreadPoolExecutor(1);
+    executor.shutdown();
+
+    InstantiatingHttpJsonChannelProvider instantiatingHttpJsonChannelProvider =
+        InstantiatingHttpJsonChannelProvider.newBuilder()
+            .setEndpoint(DEFAULT_ENDPOINT)
+            .setExecutor(executor)
+            .build();
+    instantiatingHttpJsonChannelProvider =
+        (InstantiatingHttpJsonChannelProvider)
+            instantiatingHttpJsonChannelProvider.withHeaders(DEFAULT_HEADER_MAP);
+    HttpJsonTransportChannel httpJsonTransportChannel =
+        instantiatingHttpJsonChannelProvider.getTransportChannel();
+
+    // By default, the channel will be wrapped with ManagedHttpJsonInterceptorChannel
+    ManagedHttpJsonInterceptorChannel interceptorChannel =
+        (ManagedHttpJsonInterceptorChannel) httpJsonTransportChannel.getManagedChannel();
+    ManagedHttpJsonChannel managedHttpJsonChannel = interceptorChannel.getChannel();
+    assertThat(managedHttpJsonChannel.getExecutor()).isNotNull();
+    assertThat(managedHttpJsonChannel.getExecutor()).isEqualTo(executor);
+
+    // Clean up the resources (executor, deadlineScheduler, httpTransport)
+    instantiatingHttpJsonChannelProvider.getTransportChannel().shutdownNow();
   }
 
   @Override

--- a/gax-java/gax/src/main/java/com/google/api/gax/core/InstantiatingExecutorProvider.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/core/InstantiatingExecutorProvider.java
@@ -54,6 +54,9 @@ public abstract class InstantiatingExecutorProvider implements ExecutorProvider 
           return thread;
         }
       };
+  private static final int MIN_THREAD_AMOUNT = 4;
+  // Attempt to choose a reasonable default core pool multiplier for IO Bound operations
+  private static final int IO_THREAD_MULTIPLIER = 50;
 
   // Package-private constructor prevents others from subclassing.
   InstantiatingExecutorProvider() {}
@@ -76,9 +79,22 @@ public abstract class InstantiatingExecutorProvider implements ExecutorProvider 
 
   public abstract Builder toBuilder();
 
+  // Used for CPU Bound tasks as the thread count is at max the number of processors
+  // Thread count minimum is at least `MIN_CPU_AMOUNT`
   public static Builder newBuilder() {
     int numCpus = Runtime.getRuntime().availableProcessors();
-    int numThreads = Math.max(4, numCpus);
+    int numThreads = Math.max(MIN_THREAD_AMOUNT, numCpus);
+
+    return new AutoValue_InstantiatingExecutorProvider.Builder()
+        .setExecutorThreadCount(numThreads)
+        .setThreadFactory(DEFAULT_THREAD_FACTORY);
+  }
+
+  // Used for IO Bound tasks as the thread count scales with the number of processors
+  // Thread count minimum is at least `MIN_CPU_AMOUNT` * `IO_THREAD_MULTIPLIER`
+  public static Builder newIOBuilder() {
+    int numCpus = Runtime.getRuntime().availableProcessors();
+    int numThreads = IO_THREAD_MULTIPLIER * Math.max(MIN_THREAD_AMOUNT, numCpus);
 
     return new AutoValue_InstantiatingExecutorProvider.Builder()
         .setExecutorThreadCount(numThreads)

--- a/showcase/gapic-showcase/proto/src/main/java/com/google/showcase/v1beta1/BlurbName.java
+++ b/showcase/gapic-showcase/proto/src/main/java/com/google/showcase/v1beta1/BlurbName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/proto/src/main/java/com/google/showcase/v1beta1/ProfileName.java
+++ b/showcase/gapic-showcase/proto/src/main/java/com/google/showcase/v1beta1/ProfileName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/proto/src/main/java/com/google/showcase/v1beta1/RoomName.java
+++ b/showcase/gapic-showcase/proto/src/main/java/com/google/showcase/v1beta1/RoomName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/proto/src/main/java/com/google/showcase/v1beta1/SequenceName.java
+++ b/showcase/gapic-showcase/proto/src/main/java/com/google/showcase/v1beta1/SequenceName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/proto/src/main/java/com/google/showcase/v1beta1/SequenceReportName.java
+++ b/showcase/gapic-showcase/proto/src/main/java/com/google/showcase/v1beta1/SequenceReportName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/proto/src/main/java/com/google/showcase/v1beta1/SessionName.java
+++ b/showcase/gapic-showcase/proto/src/main/java/com/google/showcase/v1beta1/SessionName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/proto/src/main/java/com/google/showcase/v1beta1/StreamingSequenceName.java
+++ b/showcase/gapic-showcase/proto/src/main/java/com/google/showcase/v1beta1/StreamingSequenceName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/proto/src/main/java/com/google/showcase/v1beta1/StreamingSequenceReportName.java
+++ b/showcase/gapic-showcase/proto/src/main/java/com/google/showcase/v1beta1/StreamingSequenceReportName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/proto/src/main/java/com/google/showcase/v1beta1/TestName.java
+++ b/showcase/gapic-showcase/proto/src/main/java/com/google/showcase/v1beta1/TestName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/proto/src/main/java/com/google/showcase/v1beta1/UserName.java
+++ b/showcase/gapic-showcase/proto/src/main/java/com/google/showcase/v1beta1/UserName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/create/SyncCreateSetCredentialsProvider.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/create/SyncCreateSetCredentialsProvider1.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/create/SyncCreateSetCredentialsProvider1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/create/SyncCreateSetEndpoint.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/getenum/AsyncGetEnum.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/getenum/AsyncGetEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/getenum/SyncGetEnum.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/getenum/SyncGetEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/getlocation/AsyncGetLocation.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/getlocation/AsyncGetLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/getlocation/SyncGetLocation.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/getlocation/SyncGetLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/listlocations/AsyncListLocations.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/listlocations/AsyncListLocations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/listlocations/AsyncListLocationsPaged.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/listlocations/AsyncListLocationsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/listlocations/SyncListLocations.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/listlocations/SyncListLocations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/repeatdatabody/AsyncRepeatDataBody.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/repeatdatabody/AsyncRepeatDataBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/repeatdatabody/SyncRepeatDataBody.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/repeatdatabody/SyncRepeatDataBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/repeatdatabodyinfo/AsyncRepeatDataBodyInfo.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/repeatdatabodyinfo/AsyncRepeatDataBodyInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/repeatdatabodyinfo/SyncRepeatDataBodyInfo.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/repeatdatabodyinfo/SyncRepeatDataBodyInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/repeatdatabodypatch/AsyncRepeatDataBodyPatch.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/repeatdatabodypatch/AsyncRepeatDataBodyPatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/repeatdatabodypatch/SyncRepeatDataBodyPatch.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/repeatdatabodypatch/SyncRepeatDataBodyPatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/repeatdatabodyput/AsyncRepeatDataBodyPut.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/repeatdatabodyput/AsyncRepeatDataBodyPut.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/repeatdatabodyput/SyncRepeatDataBodyPut.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/repeatdatabodyput/SyncRepeatDataBodyPut.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/repeatdatapathresource/AsyncRepeatDataPathResource.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/repeatdatapathresource/AsyncRepeatDataPathResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/repeatdatapathresource/SyncRepeatDataPathResource.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/repeatdatapathresource/SyncRepeatDataPathResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/repeatdatapathtrailingresource/AsyncRepeatDataPathTrailingResource.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/repeatdatapathtrailingresource/AsyncRepeatDataPathTrailingResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/repeatdatapathtrailingresource/SyncRepeatDataPathTrailingResource.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/repeatdatapathtrailingresource/SyncRepeatDataPathTrailingResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/repeatdataquery/AsyncRepeatDataQuery.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/repeatdataquery/AsyncRepeatDataQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/repeatdataquery/SyncRepeatDataQuery.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/repeatdataquery/SyncRepeatDataQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/repeatdatasimplepath/AsyncRepeatDataSimplePath.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/repeatdatasimplepath/AsyncRepeatDataSimplePath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/repeatdatasimplepath/SyncRepeatDataSimplePath.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/repeatdatasimplepath/SyncRepeatDataSimplePath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/verifyenum/AsyncVerifyEnum.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/verifyenum/AsyncVerifyEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/verifyenum/SyncVerifyEnum.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliance/verifyenum/SyncVerifyEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliancesettings/repeatdatabody/SyncRepeatDataBody.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/compliancesettings/repeatdatabody/SyncRepeatDataBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/block/AsyncBlock.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/block/AsyncBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/block/SyncBlock.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/block/SyncBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/chat/AsyncChat.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/chat/AsyncChat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/collect/AsyncCollect.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/collect/AsyncCollect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/create/SyncCreateSetCredentialsProvider.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/create/SyncCreateSetCredentialsProvider1.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/create/SyncCreateSetCredentialsProvider1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/create/SyncCreateSetEndpoint.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/echo/AsyncEcho.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/echo/AsyncEcho.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/echo/SyncEcho.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/echo/SyncEcho.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/expand/AsyncExpand.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/expand/AsyncExpand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/getlocation/AsyncGetLocation.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/getlocation/AsyncGetLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/getlocation/SyncGetLocation.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/getlocation/SyncGetLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/listlocations/AsyncListLocations.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/listlocations/AsyncListLocations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/listlocations/AsyncListLocationsPaged.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/listlocations/AsyncListLocationsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/listlocations/SyncListLocations.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/listlocations/SyncListLocations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/pagedexpand/AsyncPagedExpand.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/pagedexpand/AsyncPagedExpand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/pagedexpand/AsyncPagedExpandPaged.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/pagedexpand/AsyncPagedExpandPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/pagedexpand/SyncPagedExpand.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/pagedexpand/SyncPagedExpand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/pagedexpandlegacy/AsyncPagedExpandLegacy.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/pagedexpandlegacy/AsyncPagedExpandLegacy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/pagedexpandlegacy/SyncPagedExpandLegacy.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/pagedexpandlegacy/SyncPagedExpandLegacy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/pagedexpandlegacymapped/AsyncPagedExpandLegacyMapped.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/pagedexpandlegacymapped/AsyncPagedExpandLegacyMapped.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/pagedexpandlegacymapped/AsyncPagedExpandLegacyMappedPaged.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/pagedexpandlegacymapped/AsyncPagedExpandLegacyMappedPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/pagedexpandlegacymapped/SyncPagedExpandLegacyMapped.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/pagedexpandlegacymapped/SyncPagedExpandLegacyMapped.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/wait/AsyncWait.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/wait/AsyncWait.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/wait/AsyncWaitLRO.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/wait/AsyncWaitLRO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/wait/SyncWait.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echo/wait/SyncWait.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echosettings/echo/SyncEcho.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/echosettings/echo/SyncEcho.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/create/SyncCreateSetCredentialsProvider.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/create/SyncCreateSetCredentialsProvider1.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/create/SyncCreateSetCredentialsProvider1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/create/SyncCreateSetEndpoint.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/createuser/AsyncCreateUser.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/createuser/AsyncCreateUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/createuser/SyncCreateUser.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/createuser/SyncCreateUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/createuser/SyncCreateUserStringString.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/createuser/SyncCreateUserStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/createuser/SyncCreateUserStringStringIntStringBooleanDouble.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/createuser/SyncCreateUserStringStringIntStringBooleanDouble.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/deleteuser/AsyncDeleteUser.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/deleteuser/AsyncDeleteUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/deleteuser/SyncDeleteUser.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/deleteuser/SyncDeleteUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/deleteuser/SyncDeleteUserString.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/deleteuser/SyncDeleteUserString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/deleteuser/SyncDeleteUserUsername.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/deleteuser/SyncDeleteUserUsername.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/getlocation/AsyncGetLocation.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/getlocation/AsyncGetLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/getlocation/SyncGetLocation.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/getlocation/SyncGetLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/getuser/AsyncGetUser.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/getuser/AsyncGetUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/getuser/SyncGetUser.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/getuser/SyncGetUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/getuser/SyncGetUserString.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/getuser/SyncGetUserString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/getuser/SyncGetUserUsername.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/getuser/SyncGetUserUsername.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/listlocations/AsyncListLocations.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/listlocations/AsyncListLocations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/listlocations/AsyncListLocationsPaged.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/listlocations/AsyncListLocationsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/listlocations/SyncListLocations.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/listlocations/SyncListLocations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/listusers/AsyncListUsers.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/listusers/AsyncListUsers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/listusers/AsyncListUsersPaged.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/listusers/AsyncListUsersPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/listusers/SyncListUsers.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/listusers/SyncListUsers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/updateuser/AsyncUpdateUser.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/updateuser/AsyncUpdateUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/updateuser/SyncUpdateUser.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identity/updateuser/SyncUpdateUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identitysettings/createuser/SyncCreateUser.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/identitysettings/createuser/SyncCreateUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/connect/AsyncConnect.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/connect/AsyncConnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/create/SyncCreateSetCredentialsProvider.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/create/SyncCreateSetCredentialsProvider1.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/create/SyncCreateSetCredentialsProvider1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/create/SyncCreateSetEndpoint.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/createblurb/AsyncCreateBlurb.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/createblurb/AsyncCreateBlurb.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/createblurb/SyncCreateBlurb.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/createblurb/SyncCreateBlurb.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/createblurb/SyncCreateBlurbProfilenameStringBytestring.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/createblurb/SyncCreateBlurbProfilenameStringBytestring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/createblurb/SyncCreateBlurbProfilenameStringString.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/createblurb/SyncCreateBlurbProfilenameStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/createblurb/SyncCreateBlurbProfilenameUsernameBytestring.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/createblurb/SyncCreateBlurbProfilenameUsernameBytestring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/createblurb/SyncCreateBlurbProfilenameUsernameString.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/createblurb/SyncCreateBlurbProfilenameUsernameString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/createblurb/SyncCreateBlurbRoomnameStringBytestring.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/createblurb/SyncCreateBlurbRoomnameStringBytestring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/createblurb/SyncCreateBlurbRoomnameStringString.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/createblurb/SyncCreateBlurbRoomnameStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/createblurb/SyncCreateBlurbRoomnameUsernameBytestring.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/createblurb/SyncCreateBlurbRoomnameUsernameBytestring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/createblurb/SyncCreateBlurbRoomnameUsernameString.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/createblurb/SyncCreateBlurbRoomnameUsernameString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/createblurb/SyncCreateBlurbStringStringBytestring.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/createblurb/SyncCreateBlurbStringStringBytestring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/createblurb/SyncCreateBlurbStringStringString.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/createblurb/SyncCreateBlurbStringStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/createblurb/SyncCreateBlurbStringUsernameBytestring.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/createblurb/SyncCreateBlurbStringUsernameBytestring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/createblurb/SyncCreateBlurbStringUsernameString.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/createblurb/SyncCreateBlurbStringUsernameString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/createroom/AsyncCreateRoom.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/createroom/AsyncCreateRoom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/createroom/SyncCreateRoom.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/createroom/SyncCreateRoom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/createroom/SyncCreateRoomStringString.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/createroom/SyncCreateRoomStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/deleteblurb/AsyncDeleteBlurb.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/deleteblurb/AsyncDeleteBlurb.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/deleteblurb/SyncDeleteBlurb.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/deleteblurb/SyncDeleteBlurb.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/deleteblurb/SyncDeleteBlurbBlurbname.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/deleteblurb/SyncDeleteBlurbBlurbname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/deleteblurb/SyncDeleteBlurbString.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/deleteblurb/SyncDeleteBlurbString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/deleteroom/AsyncDeleteRoom.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/deleteroom/AsyncDeleteRoom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/deleteroom/SyncDeleteRoom.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/deleteroom/SyncDeleteRoom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/deleteroom/SyncDeleteRoomRoomname.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/deleteroom/SyncDeleteRoomRoomname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/deleteroom/SyncDeleteRoomString.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/deleteroom/SyncDeleteRoomString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/getblurb/AsyncGetBlurb.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/getblurb/AsyncGetBlurb.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/getblurb/SyncGetBlurb.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/getblurb/SyncGetBlurb.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/getblurb/SyncGetBlurbBlurbname.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/getblurb/SyncGetBlurbBlurbname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/getblurb/SyncGetBlurbString.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/getblurb/SyncGetBlurbString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/getlocation/AsyncGetLocation.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/getlocation/AsyncGetLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/getlocation/SyncGetLocation.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/getlocation/SyncGetLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/getroom/AsyncGetRoom.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/getroom/AsyncGetRoom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/getroom/SyncGetRoom.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/getroom/SyncGetRoom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/getroom/SyncGetRoomRoomname.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/getroom/SyncGetRoomRoomname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/getroom/SyncGetRoomString.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/getroom/SyncGetRoomString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/listblurbs/AsyncListBlurbs.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/listblurbs/AsyncListBlurbs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/listblurbs/AsyncListBlurbsPaged.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/listblurbs/AsyncListBlurbsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/listblurbs/SyncListBlurbs.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/listblurbs/SyncListBlurbs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/listblurbs/SyncListBlurbsProfilename.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/listblurbs/SyncListBlurbsProfilename.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/listblurbs/SyncListBlurbsRoomname.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/listblurbs/SyncListBlurbsRoomname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/listblurbs/SyncListBlurbsString.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/listblurbs/SyncListBlurbsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/listlocations/AsyncListLocations.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/listlocations/AsyncListLocations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/listlocations/AsyncListLocationsPaged.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/listlocations/AsyncListLocationsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/listlocations/SyncListLocations.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/listlocations/SyncListLocations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/listrooms/AsyncListRooms.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/listrooms/AsyncListRooms.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/listrooms/AsyncListRoomsPaged.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/listrooms/AsyncListRoomsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/listrooms/SyncListRooms.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/listrooms/SyncListRooms.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/searchblurbs/AsyncSearchBlurbs.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/searchblurbs/AsyncSearchBlurbs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/searchblurbs/AsyncSearchBlurbsLRO.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/searchblurbs/AsyncSearchBlurbsLRO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/searchblurbs/SyncSearchBlurbs.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/searchblurbs/SyncSearchBlurbs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/searchblurbs/SyncSearchBlurbsProfilenameString.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/searchblurbs/SyncSearchBlurbsProfilenameString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/searchblurbs/SyncSearchBlurbsRoomnameString.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/searchblurbs/SyncSearchBlurbsRoomnameString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/searchblurbs/SyncSearchBlurbsStringString.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/searchblurbs/SyncSearchBlurbsStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/sendblurbs/AsyncSendBlurbs.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/sendblurbs/AsyncSendBlurbs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/streamblurbs/AsyncStreamBlurbs.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/streamblurbs/AsyncStreamBlurbs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/updateblurb/AsyncUpdateBlurb.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/updateblurb/AsyncUpdateBlurb.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/updateblurb/SyncUpdateBlurb.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/updateblurb/SyncUpdateBlurb.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/updateroom/AsyncUpdateRoom.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/updateroom/AsyncUpdateRoom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/updateroom/SyncUpdateRoom.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messaging/updateroom/SyncUpdateRoom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messagingsettings/createroom/SyncCreateRoom.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/messagingsettings/createroom/SyncCreateRoom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/attemptsequence/AsyncAttemptSequence.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/attemptsequence/AsyncAttemptSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/attemptsequence/SyncAttemptSequence.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/attemptsequence/SyncAttemptSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/attemptsequence/SyncAttemptSequenceSequencename.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/attemptsequence/SyncAttemptSequenceSequencename.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/attemptsequence/SyncAttemptSequenceString.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/attemptsequence/SyncAttemptSequenceString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/attemptstreamingsequence/AsyncAttemptStreamingSequence.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/attemptstreamingsequence/AsyncAttemptStreamingSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/create/SyncCreateSetCredentialsProvider.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/create/SyncCreateSetCredentialsProvider1.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/create/SyncCreateSetCredentialsProvider1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/create/SyncCreateSetEndpoint.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/createsequence/AsyncCreateSequence.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/createsequence/AsyncCreateSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/createsequence/SyncCreateSequence.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/createsequence/SyncCreateSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/createsequence/SyncCreateSequenceSequence.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/createsequence/SyncCreateSequenceSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/createstreamingsequence/AsyncCreateStreamingSequence.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/createstreamingsequence/AsyncCreateStreamingSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/createstreamingsequence/SyncCreateStreamingSequence.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/createstreamingsequence/SyncCreateStreamingSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/createstreamingsequence/SyncCreateStreamingSequenceStreamingsequence.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/createstreamingsequence/SyncCreateStreamingSequenceStreamingsequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/getlocation/AsyncGetLocation.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/getlocation/AsyncGetLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/getlocation/SyncGetLocation.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/getlocation/SyncGetLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/getsequencereport/AsyncGetSequenceReport.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/getsequencereport/AsyncGetSequenceReport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/getsequencereport/SyncGetSequenceReport.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/getsequencereport/SyncGetSequenceReport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/getsequencereport/SyncGetSequenceReportSequencereportname.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/getsequencereport/SyncGetSequenceReportSequencereportname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/getsequencereport/SyncGetSequenceReportString.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/getsequencereport/SyncGetSequenceReportString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/getstreamingsequencereport/AsyncGetStreamingSequenceReport.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/getstreamingsequencereport/AsyncGetStreamingSequenceReport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/getstreamingsequencereport/SyncGetStreamingSequenceReport.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/getstreamingsequencereport/SyncGetStreamingSequenceReport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/getstreamingsequencereport/SyncGetStreamingSequenceReportStreamingsequencereportname.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/getstreamingsequencereport/SyncGetStreamingSequenceReportStreamingsequencereportname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/getstreamingsequencereport/SyncGetStreamingSequenceReportString.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/getstreamingsequencereport/SyncGetStreamingSequenceReportString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/listlocations/AsyncListLocations.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/listlocations/AsyncListLocations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/listlocations/AsyncListLocationsPaged.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/listlocations/AsyncListLocationsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/listlocations/SyncListLocations.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservice/listlocations/SyncListLocations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservicesettings/createsequence/SyncCreateSequence.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/sequenceservicesettings/createsequence/SyncCreateSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/stub/compliancestubsettings/repeatdatabody/SyncRepeatDataBody.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/stub/compliancestubsettings/repeatdatabody/SyncRepeatDataBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/stub/echostubsettings/echo/SyncEcho.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/stub/echostubsettings/echo/SyncEcho.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/stub/identitystubsettings/createuser/SyncCreateUser.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/stub/identitystubsettings/createuser/SyncCreateUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/stub/messagingstubsettings/createroom/SyncCreateRoom.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/stub/messagingstubsettings/createroom/SyncCreateRoom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/stub/sequenceservicestubsettings/createsequence/SyncCreateSequence.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/stub/sequenceservicestubsettings/createsequence/SyncCreateSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/stub/testingstubsettings/createsession/SyncCreateSession.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/stub/testingstubsettings/createsession/SyncCreateSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/create/SyncCreateSetCredentialsProvider.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/create/SyncCreateSetCredentialsProvider1.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/create/SyncCreateSetCredentialsProvider1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/create/SyncCreateSetEndpoint.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/createsession/AsyncCreateSession.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/createsession/AsyncCreateSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/createsession/SyncCreateSession.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/createsession/SyncCreateSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/deletesession/AsyncDeleteSession.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/deletesession/AsyncDeleteSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/deletesession/SyncDeleteSession.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/deletesession/SyncDeleteSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/deletetest/AsyncDeleteTest.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/deletetest/AsyncDeleteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/deletetest/SyncDeleteTest.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/deletetest/SyncDeleteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/getlocation/AsyncGetLocation.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/getlocation/AsyncGetLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/getlocation/SyncGetLocation.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/getlocation/SyncGetLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/getsession/AsyncGetSession.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/getsession/AsyncGetSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/getsession/SyncGetSession.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/getsession/SyncGetSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/listlocations/AsyncListLocations.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/listlocations/AsyncListLocations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/listlocations/AsyncListLocationsPaged.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/listlocations/AsyncListLocationsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/listlocations/SyncListLocations.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/listlocations/SyncListLocations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/listsessions/AsyncListSessions.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/listsessions/AsyncListSessions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/listsessions/AsyncListSessionsPaged.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/listsessions/AsyncListSessionsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/listsessions/SyncListSessions.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/listsessions/SyncListSessions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/listtests/AsyncListTests.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/listtests/AsyncListTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/listtests/AsyncListTestsPaged.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/listtests/AsyncListTestsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/listtests/SyncListTests.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/listtests/SyncListTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/reportsession/AsyncReportSession.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/reportsession/AsyncReportSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/reportsession/SyncReportSession.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/reportsession/SyncReportSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/verifytest/AsyncVerifyTest.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/verifytest/AsyncVerifyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/verifytest/SyncVerifyTest.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testing/verifytest/SyncVerifyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testingsettings/createsession/SyncCreateSession.java
+++ b/showcase/gapic-showcase/samples/snippets/generated/src/main/java/com/google/showcase/v1beta1/testingsettings/createsession/SyncCreateSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/ComplianceClient.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/ComplianceClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/ComplianceSettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/ComplianceSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/EchoClient.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/EchoClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/EchoSettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/EchoSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/IdentityClient.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/IdentityClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/IdentitySettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/IdentitySettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/MessagingClient.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/MessagingClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/MessagingSettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/MessagingSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/SequenceServiceClient.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/SequenceServiceClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/SequenceServiceSettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/SequenceServiceSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/TestingClient.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/TestingClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/TestingSettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/TestingSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/package-info.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/ComplianceStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/ComplianceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/ComplianceStubSettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/ComplianceStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/EchoStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/EchoStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/EchoStubSettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/EchoStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcComplianceCallableFactory.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcComplianceCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcComplianceStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcComplianceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcEchoCallableFactory.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcEchoCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcEchoStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcEchoStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcIdentityCallableFactory.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcIdentityCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcIdentityStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcIdentityStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcMessagingCallableFactory.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcMessagingCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcMessagingStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcMessagingStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcSequenceServiceCallableFactory.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcSequenceServiceCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcSequenceServiceStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcSequenceServiceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcTestingCallableFactory.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcTestingCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcTestingStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcTestingStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonComplianceCallableFactory.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonComplianceCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonComplianceStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonComplianceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonEchoCallableFactory.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonEchoCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonEchoStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonEchoStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonIdentityCallableFactory.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonIdentityCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonIdentityStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonIdentityStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonMessagingCallableFactory.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonMessagingCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonMessagingStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonMessagingStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonSequenceServiceCallableFactory.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonSequenceServiceCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonSequenceServiceStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonSequenceServiceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonTestingCallableFactory.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonTestingCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonTestingStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonTestingStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/IdentityStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/IdentityStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/IdentityStubSettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/IdentityStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/MessagingStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/MessagingStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/MessagingStubSettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/MessagingStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/SequenceServiceStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/SequenceServiceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/SequenceServiceStubSettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/SequenceServiceStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/TestingStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/TestingStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/TestingStubSettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/TestingStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/ComplianceClientHttpJsonTest.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/ComplianceClientHttpJsonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/ComplianceClientTest.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/ComplianceClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/EchoClientHttpJsonTest.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/EchoClientHttpJsonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/EchoClientTest.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/EchoClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/IdentityClientHttpJsonTest.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/IdentityClientHttpJsonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/IdentityClientTest.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/IdentityClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/MessagingClientHttpJsonTest.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/MessagingClientHttpJsonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/MessagingClientTest.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/MessagingClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/MockCompliance.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/MockCompliance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/MockComplianceImpl.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/MockComplianceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/MockEcho.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/MockEcho.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/MockEchoImpl.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/MockEchoImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/MockIdentity.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/MockIdentity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/MockIdentityImpl.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/MockIdentityImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/MockLocations.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/MockLocations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/MockLocationsImpl.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/MockLocationsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/MockMessaging.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/MockMessaging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/MockMessagingImpl.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/MockMessagingImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/MockSequenceService.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/MockSequenceService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/MockSequenceServiceImpl.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/MockSequenceServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/MockTesting.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/MockTesting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/MockTestingImpl.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/MockTestingImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/SequenceServiceClientHttpJsonTest.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/SequenceServiceClientHttpJsonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/SequenceServiceClientTest.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/SequenceServiceClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/TestingClientHttpJsonTest.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/TestingClientHttpJsonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/TestingClientTest.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/TestingClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/BlurbName.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/BlurbName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ProfileName.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ProfileName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/RoomName.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/RoomName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/SequenceName.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/SequenceName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/SequenceReportName.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/SequenceReportName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/SessionName.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/SessionName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/StreamingSequenceName.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/StreamingSequenceName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/StreamingSequenceReportName.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/StreamingSequenceReportName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/TestName.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/TestName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/UserName.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/UserName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservice/create/SyncCreateSetCredentialsProvider.java
+++ b/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservice/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservice/create/SyncCreateSetCredentialsProvider1.java
+++ b/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservice/create/SyncCreateSetCredentialsProvider1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservice/create/SyncCreateSetEndpoint.java
+++ b/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservice/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservice/listconnections/AsyncListConnections.java
+++ b/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservice/listconnections/AsyncListConnections.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservice/listconnections/AsyncListConnectionsPaged.java
+++ b/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservice/listconnections/AsyncListConnectionsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservice/listconnections/SyncListConnections.java
+++ b/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservice/listconnections/SyncListConnections.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservice/listconnections/SyncListConnectionsEndpointname.java
+++ b/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservice/listconnections/SyncListConnectionsEndpointname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservice/listconnections/SyncListConnectionsString.java
+++ b/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservice/listconnections/SyncListConnectionsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservicesettings/listconnections/SyncListConnections.java
+++ b/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservicesettings/listconnections/SyncListConnections.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/stub/connectionservicestubsettings/listconnections/SyncListConnections.java
+++ b/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/stub/connectionservicestubsettings/listconnections/SyncListConnections.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/stub/tetherstubsettings/egress/SyncEgress.java
+++ b/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/stub/tetherstubsettings/egress/SyncEgress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/tether/create/SyncCreateSetCredentialsProvider.java
+++ b/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/tether/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/tether/create/SyncCreateSetEndpoint.java
+++ b/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/tether/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/tether/egress/AsyncEgress.java
+++ b/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/tether/egress/AsyncEgress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/tethersettings/egress/SyncEgress.java
+++ b/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/tethersettings/egress/SyncEgress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/ConnectionServiceClient.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/ConnectionServiceClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/ConnectionServiceClientHttpJsonTest.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/ConnectionServiceClientHttpJsonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/ConnectionServiceClientTest.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/ConnectionServiceClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/ConnectionServiceSettings.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/ConnectionServiceSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/EndpointName.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/EndpointName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/MockConnectionService.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/MockConnectionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/MockConnectionServiceImpl.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/MockConnectionServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/MockTether.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/MockTether.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/MockTetherImpl.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/MockTetherImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/TetherClient.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/TetherClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/TetherClientTest.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/TetherClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/TetherSettings.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/TetherSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/package-info.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/ConnectionServiceStub.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/ConnectionServiceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/ConnectionServiceStubSettings.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/ConnectionServiceStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/GrpcConnectionServiceCallableFactory.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/GrpcConnectionServiceCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/GrpcConnectionServiceStub.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/GrpcConnectionServiceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/GrpcTetherCallableFactory.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/GrpcTetherCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/GrpcTetherStub.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/GrpcTetherStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/HttpJsonConnectionServiceCallableFactory.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/HttpJsonConnectionServiceCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/HttpJsonConnectionServiceStub.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/HttpJsonConnectionServiceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/TetherStub.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/TetherStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/TetherStubSettings.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/TetherStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/analyzeiampolicy/AsyncAnalyzeIamPolicy.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/analyzeiampolicy/AsyncAnalyzeIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/analyzeiampolicy/SyncAnalyzeIamPolicy.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/analyzeiampolicy/SyncAnalyzeIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/analyzeiampolicylongrunning/AsyncAnalyzeIamPolicyLongrunning.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/analyzeiampolicylongrunning/AsyncAnalyzeIamPolicyLongrunning.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/analyzeiampolicylongrunning/AsyncAnalyzeIamPolicyLongrunningLRO.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/analyzeiampolicylongrunning/AsyncAnalyzeIamPolicyLongrunningLRO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/analyzeiampolicylongrunning/SyncAnalyzeIamPolicyLongrunning.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/analyzeiampolicylongrunning/SyncAnalyzeIamPolicyLongrunning.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/analyzemove/AsyncAnalyzeMove.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/analyzemove/AsyncAnalyzeMove.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/analyzemove/SyncAnalyzeMove.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/analyzemove/SyncAnalyzeMove.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/batchgetassetshistory/AsyncBatchGetAssetsHistory.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/batchgetassetshistory/AsyncBatchGetAssetsHistory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/batchgetassetshistory/SyncBatchGetAssetsHistory.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/batchgetassetshistory/SyncBatchGetAssetsHistory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/batchgeteffectiveiampolicies/AsyncBatchGetEffectiveIamPolicies.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/batchgeteffectiveiampolicies/AsyncBatchGetEffectiveIamPolicies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/batchgeteffectiveiampolicies/SyncBatchGetEffectiveIamPolicies.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/batchgeteffectiveiampolicies/SyncBatchGetEffectiveIamPolicies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/create/SyncCreateSetCredentialsProvider.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/create/SyncCreateSetCredentialsProvider1.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/create/SyncCreateSetCredentialsProvider1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/create/SyncCreateSetEndpoint.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/createfeed/AsyncCreateFeed.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/createfeed/AsyncCreateFeed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/createfeed/SyncCreateFeed.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/createfeed/SyncCreateFeed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/createfeed/SyncCreateFeedString.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/createfeed/SyncCreateFeedString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/createsavedquery/AsyncCreateSavedQuery.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/createsavedquery/AsyncCreateSavedQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/createsavedquery/SyncCreateSavedQuery.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/createsavedquery/SyncCreateSavedQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/createsavedquery/SyncCreateSavedQueryFoldernameSavedqueryString.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/createsavedquery/SyncCreateSavedQueryFoldernameSavedqueryString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/createsavedquery/SyncCreateSavedQueryOrganizationnameSavedqueryString.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/createsavedquery/SyncCreateSavedQueryOrganizationnameSavedqueryString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/createsavedquery/SyncCreateSavedQueryProjectnameSavedqueryString.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/createsavedquery/SyncCreateSavedQueryProjectnameSavedqueryString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/createsavedquery/SyncCreateSavedQueryStringSavedqueryString.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/createsavedquery/SyncCreateSavedQueryStringSavedqueryString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/deletefeed/AsyncDeleteFeed.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/deletefeed/AsyncDeleteFeed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/deletefeed/SyncDeleteFeed.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/deletefeed/SyncDeleteFeed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/deletefeed/SyncDeleteFeedFeedname.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/deletefeed/SyncDeleteFeedFeedname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/deletefeed/SyncDeleteFeedString.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/deletefeed/SyncDeleteFeedString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/deletesavedquery/AsyncDeleteSavedQuery.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/deletesavedquery/AsyncDeleteSavedQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/deletesavedquery/SyncDeleteSavedQuery.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/deletesavedquery/SyncDeleteSavedQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/deletesavedquery/SyncDeleteSavedQuerySavedqueryname.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/deletesavedquery/SyncDeleteSavedQuerySavedqueryname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/deletesavedquery/SyncDeleteSavedQueryString.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/deletesavedquery/SyncDeleteSavedQueryString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/exportassets/AsyncExportAssets.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/exportassets/AsyncExportAssets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/exportassets/AsyncExportAssetsLRO.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/exportassets/AsyncExportAssetsLRO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/exportassets/SyncExportAssets.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/exportassets/SyncExportAssets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/getfeed/AsyncGetFeed.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/getfeed/AsyncGetFeed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/getfeed/SyncGetFeed.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/getfeed/SyncGetFeed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/getfeed/SyncGetFeedFeedname.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/getfeed/SyncGetFeedFeedname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/getfeed/SyncGetFeedString.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/getfeed/SyncGetFeedString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/getsavedquery/AsyncGetSavedQuery.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/getsavedquery/AsyncGetSavedQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/getsavedquery/SyncGetSavedQuery.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/getsavedquery/SyncGetSavedQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/getsavedquery/SyncGetSavedQuerySavedqueryname.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/getsavedquery/SyncGetSavedQuerySavedqueryname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/getsavedquery/SyncGetSavedQueryString.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/getsavedquery/SyncGetSavedQueryString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listassets/AsyncListAssets.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listassets/AsyncListAssets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listassets/AsyncListAssetsPaged.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listassets/AsyncListAssetsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listassets/SyncListAssets.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listassets/SyncListAssets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listassets/SyncListAssetsResourcename.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listassets/SyncListAssetsResourcename.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listassets/SyncListAssetsString.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listassets/SyncListAssetsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listfeeds/AsyncListFeeds.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listfeeds/AsyncListFeeds.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listfeeds/SyncListFeeds.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listfeeds/SyncListFeeds.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listfeeds/SyncListFeedsString.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listfeeds/SyncListFeedsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listsavedqueries/AsyncListSavedQueries.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listsavedqueries/AsyncListSavedQueries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listsavedqueries/AsyncListSavedQueriesPaged.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listsavedqueries/AsyncListSavedQueriesPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listsavedqueries/SyncListSavedQueries.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listsavedqueries/SyncListSavedQueries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listsavedqueries/SyncListSavedQueriesFoldername.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listsavedqueries/SyncListSavedQueriesFoldername.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listsavedqueries/SyncListSavedQueriesOrganizationname.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listsavedqueries/SyncListSavedQueriesOrganizationname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listsavedqueries/SyncListSavedQueriesProjectname.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listsavedqueries/SyncListSavedQueriesProjectname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listsavedqueries/SyncListSavedQueriesString.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listsavedqueries/SyncListSavedQueriesString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/queryassets/AsyncQueryAssets.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/queryassets/AsyncQueryAssets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/queryassets/SyncQueryAssets.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/queryassets/SyncQueryAssets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/searchalliampolicies/AsyncSearchAllIamPolicies.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/searchalliampolicies/AsyncSearchAllIamPolicies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/searchalliampolicies/AsyncSearchAllIamPoliciesPaged.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/searchalliampolicies/AsyncSearchAllIamPoliciesPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/searchalliampolicies/SyncSearchAllIamPolicies.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/searchalliampolicies/SyncSearchAllIamPolicies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/searchalliampolicies/SyncSearchAllIamPoliciesStringString.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/searchalliampolicies/SyncSearchAllIamPoliciesStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/searchallresources/AsyncSearchAllResources.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/searchallresources/AsyncSearchAllResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/searchallresources/AsyncSearchAllResourcesPaged.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/searchallresources/AsyncSearchAllResourcesPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/searchallresources/SyncSearchAllResources.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/searchallresources/SyncSearchAllResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/searchallresources/SyncSearchAllResourcesStringStringListstring.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/searchallresources/SyncSearchAllResourcesStringStringListstring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/updatefeed/AsyncUpdateFeed.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/updatefeed/AsyncUpdateFeed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/updatefeed/SyncUpdateFeed.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/updatefeed/SyncUpdateFeed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/updatefeed/SyncUpdateFeedFeed.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/updatefeed/SyncUpdateFeedFeed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/updatesavedquery/AsyncUpdateSavedQuery.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/updatesavedquery/AsyncUpdateSavedQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/updatesavedquery/SyncUpdateSavedQuery.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/updatesavedquery/SyncUpdateSavedQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/updatesavedquery/SyncUpdateSavedQuerySavedqueryFieldmask.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/updatesavedquery/SyncUpdateSavedQuerySavedqueryFieldmask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservicesettings/batchgetassetshistory/SyncBatchGetAssetsHistory.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservicesettings/batchgetassetshistory/SyncBatchGetAssetsHistory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/stub/assetservicestubsettings/batchgetassetshistory/SyncBatchGetAssetsHistory.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/stub/assetservicestubsettings/batchgetassetshistory/SyncBatchGetAssetsHistory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/AssetServiceClient.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/AssetServiceClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/AssetServiceClientHttpJsonTest.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/AssetServiceClientHttpJsonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/AssetServiceClientTest.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/AssetServiceClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/AssetServiceSettings.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/AssetServiceSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/FeedName.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/FeedName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/FolderName.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/FolderName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/MockAssetService.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/MockAssetService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/MockAssetServiceImpl.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/MockAssetServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/OrganizationName.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/OrganizationName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/ProjectName.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/ProjectName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/SavedQueryName.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/SavedQueryName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/package-info.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/AssetServiceStub.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/AssetServiceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/AssetServiceStubSettings.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/AssetServiceStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/GrpcAssetServiceCallableFactory.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/GrpcAssetServiceCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/GrpcAssetServiceStub.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/GrpcAssetServiceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/HttpJsonAssetServiceCallableFactory.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/HttpJsonAssetServiceCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/HttpJsonAssetServiceStub.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/HttpJsonAssetServiceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/basebigtabledatasettings/mutaterow/SyncMutateRow.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/basebigtabledatasettings/mutaterow/SyncMutateRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/checkandmutaterow/AsyncCheckAndMutateRow.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/checkandmutaterow/AsyncCheckAndMutateRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/checkandmutaterow/SyncCheckAndMutateRow.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/checkandmutaterow/SyncCheckAndMutateRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/checkandmutaterow/SyncCheckAndMutateRowStringBytestringRowfilterListmutationListmutation.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/checkandmutaterow/SyncCheckAndMutateRowStringBytestringRowfilterListmutationListmutation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/checkandmutaterow/SyncCheckAndMutateRowStringBytestringRowfilterListmutationListmutationString.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/checkandmutaterow/SyncCheckAndMutateRowStringBytestringRowfilterListmutationListmutationString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/checkandmutaterow/SyncCheckAndMutateRowTablenameBytestringRowfilterListmutationListmutation.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/checkandmutaterow/SyncCheckAndMutateRowTablenameBytestringRowfilterListmutationListmutation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/checkandmutaterow/SyncCheckAndMutateRowTablenameBytestringRowfilterListmutationListmutationString.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/checkandmutaterow/SyncCheckAndMutateRowTablenameBytestringRowfilterListmutationListmutationString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/create/SyncCreateSetCredentialsProvider.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/create/SyncCreateSetEndpoint.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/mutaterow/AsyncMutateRow.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/mutaterow/AsyncMutateRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/mutaterow/SyncMutateRow.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/mutaterow/SyncMutateRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/mutaterow/SyncMutateRowStringBytestringListmutation.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/mutaterow/SyncMutateRowStringBytestringListmutation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/mutaterow/SyncMutateRowStringBytestringListmutationString.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/mutaterow/SyncMutateRowStringBytestringListmutationString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/mutaterow/SyncMutateRowTablenameBytestringListmutation.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/mutaterow/SyncMutateRowTablenameBytestringListmutation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/mutaterow/SyncMutateRowTablenameBytestringListmutationString.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/mutaterow/SyncMutateRowTablenameBytestringListmutationString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/mutaterows/AsyncMutateRows.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/mutaterows/AsyncMutateRows.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/pingandwarm/AsyncPingAndWarm.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/pingandwarm/AsyncPingAndWarm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/pingandwarm/SyncPingAndWarm.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/pingandwarm/SyncPingAndWarm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/pingandwarm/SyncPingAndWarmInstancename.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/pingandwarm/SyncPingAndWarmInstancename.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/pingandwarm/SyncPingAndWarmInstancenameString.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/pingandwarm/SyncPingAndWarmInstancenameString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/pingandwarm/SyncPingAndWarmString.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/pingandwarm/SyncPingAndWarmString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/pingandwarm/SyncPingAndWarmStringString.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/pingandwarm/SyncPingAndWarmStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/readmodifywriterow/AsyncReadModifyWriteRow.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/readmodifywriterow/AsyncReadModifyWriteRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/readmodifywriterow/SyncReadModifyWriteRow.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/readmodifywriterow/SyncReadModifyWriteRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/readmodifywriterow/SyncReadModifyWriteRowStringBytestringListreadmodifywriterule.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/readmodifywriterow/SyncReadModifyWriteRowStringBytestringListreadmodifywriterule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/readmodifywriterow/SyncReadModifyWriteRowStringBytestringListreadmodifywriteruleString.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/readmodifywriterow/SyncReadModifyWriteRowStringBytestringListreadmodifywriteruleString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/readmodifywriterow/SyncReadModifyWriteRowTablenameBytestringListreadmodifywriterule.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/readmodifywriterow/SyncReadModifyWriteRowTablenameBytestringListreadmodifywriterule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/readmodifywriterow/SyncReadModifyWriteRowTablenameBytestringListreadmodifywriteruleString.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/readmodifywriterow/SyncReadModifyWriteRowTablenameBytestringListreadmodifywriteruleString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/readrows/AsyncReadRows.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/readrows/AsyncReadRows.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/samplerowkeys/AsyncSampleRowKeys.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/samplerowkeys/AsyncSampleRowKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/stub/bigtablestubsettings/mutaterow/SyncMutateRow.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/stub/bigtablestubsettings/mutaterow/SyncMutateRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/src/com/google/bigtable/v2/InstanceName.java
+++ b/test/integration/goldens/bigtable/src/com/google/bigtable/v2/InstanceName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/src/com/google/bigtable/v2/TableName.java
+++ b/test/integration/goldens/bigtable/src/com/google/bigtable/v2/TableName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/BaseBigtableDataClient.java
+++ b/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/BaseBigtableDataClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/BaseBigtableDataClientTest.java
+++ b/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/BaseBigtableDataClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/BaseBigtableDataSettings.java
+++ b/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/BaseBigtableDataSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/MockBigtable.java
+++ b/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/MockBigtable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/MockBigtableImpl.java
+++ b/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/MockBigtableImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/package-info.java
+++ b/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/stub/BigtableStub.java
+++ b/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/stub/BigtableStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/stub/BigtableStubSettings.java
+++ b/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/stub/BigtableStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/stub/GrpcBigtableCallableFactory.java
+++ b/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/stub/GrpcBigtableCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/stub/GrpcBigtableStub.java
+++ b/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/stub/GrpcBigtableStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/aggregatedlist/AsyncAggregatedList.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/aggregatedlist/AsyncAggregatedList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/aggregatedlist/AsyncAggregatedListPaged.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/aggregatedlist/AsyncAggregatedListPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/aggregatedlist/SyncAggregatedList.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/aggregatedlist/SyncAggregatedList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/aggregatedlist/SyncAggregatedListString.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/aggregatedlist/SyncAggregatedListString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/create/SyncCreateSetCredentialsProvider.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/create/SyncCreateSetEndpoint.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/delete/AsyncDelete.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/delete/AsyncDelete.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/delete/AsyncDeleteLRO.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/delete/AsyncDeleteLRO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/delete/SyncDelete.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/delete/SyncDelete.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/delete/SyncDeleteStringStringString.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/delete/SyncDeleteStringStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/insert/AsyncInsert.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/insert/AsyncInsert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/insert/AsyncInsertLRO.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/insert/AsyncInsertLRO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/insert/SyncInsert.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/insert/SyncInsert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/insert/SyncInsertStringStringAddress.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/insert/SyncInsertStringStringAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/list/AsyncList.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/list/AsyncList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/list/AsyncListPaged.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/list/AsyncListPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/list/SyncList.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/list/SyncList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/list/SyncListStringStringString.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/list/SyncListStringStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addressessettings/aggregatedlist/SyncAggregatedList.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addressessettings/aggregatedlist/SyncAggregatedList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/regionoperations/create/SyncCreateSetCredentialsProvider.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/regionoperations/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/regionoperations/create/SyncCreateSetEndpoint.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/regionoperations/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/regionoperations/get/AsyncGet.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/regionoperations/get/AsyncGet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/regionoperations/get/SyncGet.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/regionoperations/get/SyncGet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/regionoperations/get/SyncGetStringStringString.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/regionoperations/get/SyncGetStringStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/regionoperations/wait/AsyncWait.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/regionoperations/wait/AsyncWait.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/regionoperations/wait/SyncWait.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/regionoperations/wait/SyncWait.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/regionoperations/wait/SyncWaitStringStringString.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/regionoperations/wait/SyncWaitStringStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/regionoperationssettings/get/SyncGet.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/regionoperationssettings/get/SyncGet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/stub/addressesstubsettings/aggregatedlist/SyncAggregatedList.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/stub/addressesstubsettings/aggregatedlist/SyncAggregatedList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/stub/regionoperationsstubsettings/get/SyncGet.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/stub/regionoperationsstubsettings/get/SyncGet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/AddressesClient.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/AddressesClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/AddressesClientTest.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/AddressesClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/AddressesSettings.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/AddressesSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/RegionOperationsClient.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/RegionOperationsClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/RegionOperationsClientTest.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/RegionOperationsClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/RegionOperationsSettings.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/RegionOperationsSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/package-info.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/AddressesStub.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/AddressesStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/AddressesStubSettings.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/AddressesStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/HttpJsonAddressesCallableFactory.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/HttpJsonAddressesCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/HttpJsonAddressesStub.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/HttpJsonAddressesStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/HttpJsonRegionOperationsCallableFactory.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/HttpJsonRegionOperationsCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/HttpJsonRegionOperationsStub.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/HttpJsonRegionOperationsStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/RegionOperationsStub.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/RegionOperationsStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/RegionOperationsStubSettings.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/RegionOperationsStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/create/SyncCreateSetCredentialsProvider.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/create/SyncCreateSetCredentialsProvider1.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/create/SyncCreateSetCredentialsProvider1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/create/SyncCreateSetEndpoint.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/generateaccesstoken/AsyncGenerateAccessToken.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/generateaccesstoken/AsyncGenerateAccessToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/generateaccesstoken/SyncGenerateAccessToken.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/generateaccesstoken/SyncGenerateAccessToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/generateaccesstoken/SyncGenerateAccessTokenServiceaccountnameListstringListstringDuration.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/generateaccesstoken/SyncGenerateAccessTokenServiceaccountnameListstringListstringDuration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/generateaccesstoken/SyncGenerateAccessTokenStringListstringListstringDuration.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/generateaccesstoken/SyncGenerateAccessTokenStringListstringListstringDuration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/generateidtoken/AsyncGenerateIdToken.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/generateidtoken/AsyncGenerateIdToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/generateidtoken/SyncGenerateIdToken.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/generateidtoken/SyncGenerateIdToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/generateidtoken/SyncGenerateIdTokenServiceaccountnameListstringStringBoolean.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/generateidtoken/SyncGenerateIdTokenServiceaccountnameListstringStringBoolean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/generateidtoken/SyncGenerateIdTokenStringListstringStringBoolean.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/generateidtoken/SyncGenerateIdTokenStringListstringStringBoolean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/signblob/AsyncSignBlob.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/signblob/AsyncSignBlob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/signblob/SyncSignBlob.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/signblob/SyncSignBlob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/signblob/SyncSignBlobServiceaccountnameListstringBytestring.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/signblob/SyncSignBlobServiceaccountnameListstringBytestring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/signblob/SyncSignBlobStringListstringBytestring.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/signblob/SyncSignBlobStringListstringBytestring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/signjwt/AsyncSignJwt.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/signjwt/AsyncSignJwt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/signjwt/SyncSignJwt.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/signjwt/SyncSignJwt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/signjwt/SyncSignJwtServiceaccountnameListstringString.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/signjwt/SyncSignJwtServiceaccountnameListstringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/signjwt/SyncSignJwtStringListstringString.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/signjwt/SyncSignJwtStringListstringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentialssettings/generateaccesstoken/SyncGenerateAccessToken.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentialssettings/generateaccesstoken/SyncGenerateAccessToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/stub/iamcredentialsstubsettings/generateaccesstoken/SyncGenerateAccessToken.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/stub/iamcredentialsstubsettings/generateaccesstoken/SyncGenerateAccessToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/IAMCredentialsClientHttpJsonTest.java
+++ b/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/IAMCredentialsClientHttpJsonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/IAMCredentialsClientTest.java
+++ b/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/IAMCredentialsClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/IamCredentialsClient.java
+++ b/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/IamCredentialsClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/IamCredentialsSettings.java
+++ b/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/IamCredentialsSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/MockIAMCredentials.java
+++ b/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/MockIAMCredentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/MockIAMCredentialsImpl.java
+++ b/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/MockIAMCredentialsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/ServiceAccountName.java
+++ b/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/ServiceAccountName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/package-info.java
+++ b/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/GrpcIamCredentialsCallableFactory.java
+++ b/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/GrpcIamCredentialsCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/GrpcIamCredentialsStub.java
+++ b/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/GrpcIamCredentialsStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/HttpJsonIamCredentialsCallableFactory.java
+++ b/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/HttpJsonIamCredentialsCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/HttpJsonIamCredentialsStub.java
+++ b/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/HttpJsonIamCredentialsStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/IamCredentialsStub.java
+++ b/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/IamCredentialsStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/IamCredentialsStubSettings.java
+++ b/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/IamCredentialsStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/iampolicy/create/SyncCreateSetCredentialsProvider.java
+++ b/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/iampolicy/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/iampolicy/create/SyncCreateSetEndpoint.java
+++ b/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/iampolicy/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/iampolicy/getiampolicy/AsyncGetIamPolicy.java
+++ b/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/iampolicy/getiampolicy/AsyncGetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/iampolicy/getiampolicy/SyncGetIamPolicy.java
+++ b/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/iampolicy/getiampolicy/SyncGetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/iampolicy/setiampolicy/AsyncSetIamPolicy.java
+++ b/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/iampolicy/setiampolicy/AsyncSetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/iampolicy/setiampolicy/SyncSetIamPolicy.java
+++ b/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/iampolicy/setiampolicy/SyncSetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/iampolicy/testiampermissions/AsyncTestIamPermissions.java
+++ b/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/iampolicy/testiampermissions/AsyncTestIamPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/iampolicy/testiampermissions/SyncTestIamPermissions.java
+++ b/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/iampolicy/testiampermissions/SyncTestIamPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/iampolicysettings/setiampolicy/SyncSetIamPolicy.java
+++ b/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/iampolicysettings/setiampolicy/SyncSetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/stub/iampolicystubsettings/setiampolicy/SyncSetIamPolicy.java
+++ b/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/stub/iampolicystubsettings/setiampolicy/SyncSetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/src/com/google/iam/v1/IAMPolicyClient.java
+++ b/test/integration/goldens/iam/src/com/google/iam/v1/IAMPolicyClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/src/com/google/iam/v1/IAMPolicyClientTest.java
+++ b/test/integration/goldens/iam/src/com/google/iam/v1/IAMPolicyClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/src/com/google/iam/v1/IAMPolicySettings.java
+++ b/test/integration/goldens/iam/src/com/google/iam/v1/IAMPolicySettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/src/com/google/iam/v1/MockIAMPolicy.java
+++ b/test/integration/goldens/iam/src/com/google/iam/v1/MockIAMPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/src/com/google/iam/v1/MockIAMPolicyImpl.java
+++ b/test/integration/goldens/iam/src/com/google/iam/v1/MockIAMPolicyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/src/com/google/iam/v1/package-info.java
+++ b/test/integration/goldens/iam/src/com/google/iam/v1/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/src/com/google/iam/v1/stub/GrpcIAMPolicyCallableFactory.java
+++ b/test/integration/goldens/iam/src/com/google/iam/v1/stub/GrpcIAMPolicyCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/src/com/google/iam/v1/stub/GrpcIAMPolicyStub.java
+++ b/test/integration/goldens/iam/src/com/google/iam/v1/stub/GrpcIAMPolicyStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/src/com/google/iam/v1/stub/IAMPolicyStub.java
+++ b/test/integration/goldens/iam/src/com/google/iam/v1/stub/IAMPolicyStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/src/com/google/iam/v1/stub/IAMPolicyStubSettings.java
+++ b/test/integration/goldens/iam/src/com/google/iam/v1/stub/IAMPolicyStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/asymmetricdecrypt/AsyncAsymmetricDecrypt.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/asymmetricdecrypt/AsyncAsymmetricDecrypt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/asymmetricdecrypt/SyncAsymmetricDecrypt.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/asymmetricdecrypt/SyncAsymmetricDecrypt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/asymmetricdecrypt/SyncAsymmetricDecryptCryptokeyversionnameBytestring.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/asymmetricdecrypt/SyncAsymmetricDecryptCryptokeyversionnameBytestring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/asymmetricdecrypt/SyncAsymmetricDecryptStringBytestring.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/asymmetricdecrypt/SyncAsymmetricDecryptStringBytestring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/asymmetricsign/AsyncAsymmetricSign.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/asymmetricsign/AsyncAsymmetricSign.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/asymmetricsign/SyncAsymmetricSign.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/asymmetricsign/SyncAsymmetricSign.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/asymmetricsign/SyncAsymmetricSignCryptokeyversionnameDigest.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/asymmetricsign/SyncAsymmetricSignCryptokeyversionnameDigest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/asymmetricsign/SyncAsymmetricSignStringDigest.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/asymmetricsign/SyncAsymmetricSignStringDigest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/create/SyncCreateSetCredentialsProvider.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/create/SyncCreateSetEndpoint.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createcryptokey/AsyncCreateCryptoKey.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createcryptokey/AsyncCreateCryptoKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createcryptokey/SyncCreateCryptoKey.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createcryptokey/SyncCreateCryptoKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createcryptokey/SyncCreateCryptoKeyKeyringnameStringCryptokey.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createcryptokey/SyncCreateCryptoKeyKeyringnameStringCryptokey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createcryptokey/SyncCreateCryptoKeyStringStringCryptokey.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createcryptokey/SyncCreateCryptoKeyStringStringCryptokey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createcryptokeyversion/AsyncCreateCryptoKeyVersion.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createcryptokeyversion/AsyncCreateCryptoKeyVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createcryptokeyversion/SyncCreateCryptoKeyVersion.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createcryptokeyversion/SyncCreateCryptoKeyVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createcryptokeyversion/SyncCreateCryptoKeyVersionCryptokeynameCryptokeyversion.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createcryptokeyversion/SyncCreateCryptoKeyVersionCryptokeynameCryptokeyversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createcryptokeyversion/SyncCreateCryptoKeyVersionStringCryptokeyversion.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createcryptokeyversion/SyncCreateCryptoKeyVersionStringCryptokeyversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createimportjob/AsyncCreateImportJob.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createimportjob/AsyncCreateImportJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createimportjob/SyncCreateImportJob.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createimportjob/SyncCreateImportJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createimportjob/SyncCreateImportJobKeyringnameStringImportjob.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createimportjob/SyncCreateImportJobKeyringnameStringImportjob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createimportjob/SyncCreateImportJobStringStringImportjob.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createimportjob/SyncCreateImportJobStringStringImportjob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createkeyring/AsyncCreateKeyRing.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createkeyring/AsyncCreateKeyRing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createkeyring/SyncCreateKeyRing.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createkeyring/SyncCreateKeyRing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createkeyring/SyncCreateKeyRingLocationnameStringKeyring.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createkeyring/SyncCreateKeyRingLocationnameStringKeyring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createkeyring/SyncCreateKeyRingStringStringKeyring.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createkeyring/SyncCreateKeyRingStringStringKeyring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/decrypt/AsyncDecrypt.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/decrypt/AsyncDecrypt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/decrypt/SyncDecrypt.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/decrypt/SyncDecrypt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/decrypt/SyncDecryptCryptokeynameBytestring.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/decrypt/SyncDecryptCryptokeynameBytestring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/decrypt/SyncDecryptStringBytestring.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/decrypt/SyncDecryptStringBytestring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/destroycryptokeyversion/AsyncDestroyCryptoKeyVersion.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/destroycryptokeyversion/AsyncDestroyCryptoKeyVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/destroycryptokeyversion/SyncDestroyCryptoKeyVersion.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/destroycryptokeyversion/SyncDestroyCryptoKeyVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/destroycryptokeyversion/SyncDestroyCryptoKeyVersionCryptokeyversionname.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/destroycryptokeyversion/SyncDestroyCryptoKeyVersionCryptokeyversionname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/destroycryptokeyversion/SyncDestroyCryptoKeyVersionString.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/destroycryptokeyversion/SyncDestroyCryptoKeyVersionString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/encrypt/AsyncEncrypt.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/encrypt/AsyncEncrypt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/encrypt/SyncEncrypt.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/encrypt/SyncEncrypt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/encrypt/SyncEncryptResourcenameBytestring.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/encrypt/SyncEncryptResourcenameBytestring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/encrypt/SyncEncryptStringBytestring.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/encrypt/SyncEncryptStringBytestring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getcryptokey/AsyncGetCryptoKey.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getcryptokey/AsyncGetCryptoKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getcryptokey/SyncGetCryptoKey.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getcryptokey/SyncGetCryptoKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getcryptokey/SyncGetCryptoKeyCryptokeyname.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getcryptokey/SyncGetCryptoKeyCryptokeyname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getcryptokey/SyncGetCryptoKeyString.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getcryptokey/SyncGetCryptoKeyString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getcryptokeyversion/AsyncGetCryptoKeyVersion.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getcryptokeyversion/AsyncGetCryptoKeyVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getcryptokeyversion/SyncGetCryptoKeyVersion.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getcryptokeyversion/SyncGetCryptoKeyVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getcryptokeyversion/SyncGetCryptoKeyVersionCryptokeyversionname.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getcryptokeyversion/SyncGetCryptoKeyVersionCryptokeyversionname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getcryptokeyversion/SyncGetCryptoKeyVersionString.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getcryptokeyversion/SyncGetCryptoKeyVersionString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getiampolicy/AsyncGetIamPolicy.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getiampolicy/AsyncGetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getiampolicy/SyncGetIamPolicy.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getiampolicy/SyncGetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getimportjob/AsyncGetImportJob.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getimportjob/AsyncGetImportJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getimportjob/SyncGetImportJob.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getimportjob/SyncGetImportJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getimportjob/SyncGetImportJobImportjobname.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getimportjob/SyncGetImportJobImportjobname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getimportjob/SyncGetImportJobString.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getimportjob/SyncGetImportJobString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getkeyring/AsyncGetKeyRing.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getkeyring/AsyncGetKeyRing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getkeyring/SyncGetKeyRing.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getkeyring/SyncGetKeyRing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getkeyring/SyncGetKeyRingKeyringname.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getkeyring/SyncGetKeyRingKeyringname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getkeyring/SyncGetKeyRingString.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getkeyring/SyncGetKeyRingString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getlocation/AsyncGetLocation.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getlocation/AsyncGetLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getlocation/SyncGetLocation.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getlocation/SyncGetLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getpublickey/AsyncGetPublicKey.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getpublickey/AsyncGetPublicKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getpublickey/SyncGetPublicKey.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getpublickey/SyncGetPublicKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getpublickey/SyncGetPublicKeyCryptokeyversionname.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getpublickey/SyncGetPublicKeyCryptokeyversionname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getpublickey/SyncGetPublicKeyString.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getpublickey/SyncGetPublicKeyString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/importcryptokeyversion/AsyncImportCryptoKeyVersion.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/importcryptokeyversion/AsyncImportCryptoKeyVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/importcryptokeyversion/SyncImportCryptoKeyVersion.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/importcryptokeyversion/SyncImportCryptoKeyVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeys/AsyncListCryptoKeys.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeys/AsyncListCryptoKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeys/AsyncListCryptoKeysPaged.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeys/AsyncListCryptoKeysPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeys/SyncListCryptoKeys.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeys/SyncListCryptoKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeys/SyncListCryptoKeysKeyringname.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeys/SyncListCryptoKeysKeyringname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeys/SyncListCryptoKeysString.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeys/SyncListCryptoKeysString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeyversions/AsyncListCryptoKeyVersions.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeyversions/AsyncListCryptoKeyVersions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeyversions/AsyncListCryptoKeyVersionsPaged.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeyversions/AsyncListCryptoKeyVersionsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeyversions/SyncListCryptoKeyVersions.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeyversions/SyncListCryptoKeyVersions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeyversions/SyncListCryptoKeyVersionsCryptokeyname.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeyversions/SyncListCryptoKeyVersionsCryptokeyname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeyversions/SyncListCryptoKeyVersionsString.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeyversions/SyncListCryptoKeyVersionsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listimportjobs/AsyncListImportJobs.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listimportjobs/AsyncListImportJobs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listimportjobs/AsyncListImportJobsPaged.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listimportjobs/AsyncListImportJobsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listimportjobs/SyncListImportJobs.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listimportjobs/SyncListImportJobs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listimportjobs/SyncListImportJobsKeyringname.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listimportjobs/SyncListImportJobsKeyringname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listimportjobs/SyncListImportJobsString.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listimportjobs/SyncListImportJobsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listkeyrings/AsyncListKeyRings.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listkeyrings/AsyncListKeyRings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listkeyrings/AsyncListKeyRingsPaged.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listkeyrings/AsyncListKeyRingsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listkeyrings/SyncListKeyRings.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listkeyrings/SyncListKeyRings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listkeyrings/SyncListKeyRingsLocationname.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listkeyrings/SyncListKeyRingsLocationname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listkeyrings/SyncListKeyRingsString.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listkeyrings/SyncListKeyRingsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listlocations/AsyncListLocations.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listlocations/AsyncListLocations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listlocations/AsyncListLocationsPaged.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listlocations/AsyncListLocationsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listlocations/SyncListLocations.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listlocations/SyncListLocations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/restorecryptokeyversion/AsyncRestoreCryptoKeyVersion.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/restorecryptokeyversion/AsyncRestoreCryptoKeyVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/restorecryptokeyversion/SyncRestoreCryptoKeyVersion.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/restorecryptokeyversion/SyncRestoreCryptoKeyVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/restorecryptokeyversion/SyncRestoreCryptoKeyVersionCryptokeyversionname.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/restorecryptokeyversion/SyncRestoreCryptoKeyVersionCryptokeyversionname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/restorecryptokeyversion/SyncRestoreCryptoKeyVersionString.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/restorecryptokeyversion/SyncRestoreCryptoKeyVersionString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/testiampermissions/AsyncTestIamPermissions.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/testiampermissions/AsyncTestIamPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/testiampermissions/SyncTestIamPermissions.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/testiampermissions/SyncTestIamPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokey/AsyncUpdateCryptoKey.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokey/AsyncUpdateCryptoKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokey/SyncUpdateCryptoKey.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokey/SyncUpdateCryptoKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokey/SyncUpdateCryptoKeyCryptokeyFieldmask.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokey/SyncUpdateCryptoKeyCryptokeyFieldmask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokeyprimaryversion/AsyncUpdateCryptoKeyPrimaryVersion.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokeyprimaryversion/AsyncUpdateCryptoKeyPrimaryVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokeyprimaryversion/SyncUpdateCryptoKeyPrimaryVersion.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokeyprimaryversion/SyncUpdateCryptoKeyPrimaryVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokeyprimaryversion/SyncUpdateCryptoKeyPrimaryVersionCryptokeynameString.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokeyprimaryversion/SyncUpdateCryptoKeyPrimaryVersionCryptokeynameString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokeyprimaryversion/SyncUpdateCryptoKeyPrimaryVersionStringString.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokeyprimaryversion/SyncUpdateCryptoKeyPrimaryVersionStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokeyversion/AsyncUpdateCryptoKeyVersion.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokeyversion/AsyncUpdateCryptoKeyVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokeyversion/SyncUpdateCryptoKeyVersion.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokeyversion/SyncUpdateCryptoKeyVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokeyversion/SyncUpdateCryptoKeyVersionCryptokeyversionFieldmask.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokeyversion/SyncUpdateCryptoKeyVersionCryptokeyversionFieldmask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservicesettings/getkeyring/SyncGetKeyRing.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservicesettings/getkeyring/SyncGetKeyRing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/stub/keymanagementservicestubsettings/getkeyring/SyncGetKeyRing.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/stub/keymanagementservicestubsettings/getkeyring/SyncGetKeyRing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/CryptoKeyName.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/CryptoKeyName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/CryptoKeyVersionName.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/CryptoKeyVersionName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/ImportJobName.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/ImportJobName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/KeyManagementServiceClient.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/KeyManagementServiceClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/KeyManagementServiceClientTest.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/KeyManagementServiceClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/KeyManagementServiceSettings.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/KeyManagementServiceSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/KeyRingName.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/KeyRingName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/LocationName.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/LocationName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/MockIAMPolicy.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/MockIAMPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/MockIAMPolicyImpl.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/MockIAMPolicyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/MockKeyManagementService.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/MockKeyManagementService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/MockKeyManagementServiceImpl.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/MockKeyManagementServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/MockLocations.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/MockLocations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/MockLocationsImpl.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/MockLocationsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/package-info.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/stub/GrpcKeyManagementServiceCallableFactory.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/stub/GrpcKeyManagementServiceCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/stub/GrpcKeyManagementServiceStub.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/stub/GrpcKeyManagementServiceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/stub/KeyManagementServiceStub.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/stub/KeyManagementServiceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/stub/KeyManagementServiceStubSettings.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/stub/KeyManagementServiceStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/create/SyncCreateSetCredentialsProvider.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/create/SyncCreateSetCredentialsProvider1.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/create/SyncCreateSetCredentialsProvider1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/create/SyncCreateSetEndpoint.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/createbook/AsyncCreateBook.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/createbook/AsyncCreateBook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/createbook/SyncCreateBook.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/createbook/SyncCreateBook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/createbook/SyncCreateBookShelfnameBook.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/createbook/SyncCreateBookShelfnameBook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/createbook/SyncCreateBookStringBook.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/createbook/SyncCreateBookStringBook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/createshelf/AsyncCreateShelf.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/createshelf/AsyncCreateShelf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/createshelf/SyncCreateShelf.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/createshelf/SyncCreateShelf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/createshelf/SyncCreateShelfShelf.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/createshelf/SyncCreateShelfShelf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/deletebook/AsyncDeleteBook.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/deletebook/AsyncDeleteBook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/deletebook/SyncDeleteBook.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/deletebook/SyncDeleteBook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/deletebook/SyncDeleteBookBookname.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/deletebook/SyncDeleteBookBookname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/deletebook/SyncDeleteBookString.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/deletebook/SyncDeleteBookString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/deleteshelf/AsyncDeleteShelf.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/deleteshelf/AsyncDeleteShelf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/deleteshelf/SyncDeleteShelf.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/deleteshelf/SyncDeleteShelf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/deleteshelf/SyncDeleteShelfShelfname.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/deleteshelf/SyncDeleteShelfShelfname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/deleteshelf/SyncDeleteShelfString.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/deleteshelf/SyncDeleteShelfString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/getbook/AsyncGetBook.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/getbook/AsyncGetBook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/getbook/SyncGetBook.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/getbook/SyncGetBook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/getbook/SyncGetBookBookname.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/getbook/SyncGetBookBookname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/getbook/SyncGetBookString.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/getbook/SyncGetBookString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/getshelf/AsyncGetShelf.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/getshelf/AsyncGetShelf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/getshelf/SyncGetShelf.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/getshelf/SyncGetShelf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/getshelf/SyncGetShelfShelfname.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/getshelf/SyncGetShelfShelfname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/getshelf/SyncGetShelfString.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/getshelf/SyncGetShelfString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/listbooks/AsyncListBooks.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/listbooks/AsyncListBooks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/listbooks/AsyncListBooksPaged.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/listbooks/AsyncListBooksPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/listbooks/SyncListBooks.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/listbooks/SyncListBooks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/listbooks/SyncListBooksShelfname.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/listbooks/SyncListBooksShelfname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/listbooks/SyncListBooksString.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/listbooks/SyncListBooksString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/listshelves/AsyncListShelves.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/listshelves/AsyncListShelves.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/listshelves/AsyncListShelvesPaged.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/listshelves/AsyncListShelvesPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/listshelves/SyncListShelves.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/listshelves/SyncListShelves.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/mergeshelves/AsyncMergeShelves.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/mergeshelves/AsyncMergeShelves.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/mergeshelves/SyncMergeShelves.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/mergeshelves/SyncMergeShelves.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/mergeshelves/SyncMergeShelvesShelfnameShelfname.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/mergeshelves/SyncMergeShelvesShelfnameShelfname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/mergeshelves/SyncMergeShelvesShelfnameString.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/mergeshelves/SyncMergeShelvesShelfnameString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/mergeshelves/SyncMergeShelvesStringShelfname.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/mergeshelves/SyncMergeShelvesStringShelfname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/mergeshelves/SyncMergeShelvesStringString.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/mergeshelves/SyncMergeShelvesStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/movebook/AsyncMoveBook.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/movebook/AsyncMoveBook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/movebook/SyncMoveBook.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/movebook/SyncMoveBook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/movebook/SyncMoveBookBooknameShelfname.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/movebook/SyncMoveBookBooknameShelfname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/movebook/SyncMoveBookBooknameString.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/movebook/SyncMoveBookBooknameString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/movebook/SyncMoveBookStringShelfname.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/movebook/SyncMoveBookStringShelfname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/movebook/SyncMoveBookStringString.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/movebook/SyncMoveBookStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/updatebook/AsyncUpdateBook.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/updatebook/AsyncUpdateBook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/updatebook/SyncUpdateBook.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/updatebook/SyncUpdateBook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/updatebook/SyncUpdateBookBookFieldmask.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/updatebook/SyncUpdateBookBookFieldmask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservicesettings/createshelf/SyncCreateShelf.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservicesettings/createshelf/SyncCreateShelf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/stub/libraryservicestubsettings/createshelf/SyncCreateShelf.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/stub/libraryservicestubsettings/createshelf/SyncCreateShelf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/src/com/google/cloud/example/library/v1/LibraryServiceClient.java
+++ b/test/integration/goldens/library/src/com/google/cloud/example/library/v1/LibraryServiceClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/src/com/google/cloud/example/library/v1/LibraryServiceClientHttpJsonTest.java
+++ b/test/integration/goldens/library/src/com/google/cloud/example/library/v1/LibraryServiceClientHttpJsonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/src/com/google/cloud/example/library/v1/LibraryServiceClientTest.java
+++ b/test/integration/goldens/library/src/com/google/cloud/example/library/v1/LibraryServiceClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/src/com/google/cloud/example/library/v1/LibraryServiceSettings.java
+++ b/test/integration/goldens/library/src/com/google/cloud/example/library/v1/LibraryServiceSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/src/com/google/cloud/example/library/v1/MockLibraryService.java
+++ b/test/integration/goldens/library/src/com/google/cloud/example/library/v1/MockLibraryService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/src/com/google/cloud/example/library/v1/MockLibraryServiceImpl.java
+++ b/test/integration/goldens/library/src/com/google/cloud/example/library/v1/MockLibraryServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/src/com/google/cloud/example/library/v1/package-info.java
+++ b/test/integration/goldens/library/src/com/google/cloud/example/library/v1/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/GrpcLibraryServiceCallableFactory.java
+++ b/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/GrpcLibraryServiceCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/GrpcLibraryServiceStub.java
+++ b/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/GrpcLibraryServiceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/HttpJsonLibraryServiceCallableFactory.java
+++ b/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/HttpJsonLibraryServiceCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/HttpJsonLibraryServiceStub.java
+++ b/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/HttpJsonLibraryServiceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/LibraryServiceStub.java
+++ b/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/LibraryServiceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/LibraryServiceStubSettings.java
+++ b/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/LibraryServiceStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/src/com/google/example/library/v1/BookName.java
+++ b/test/integration/goldens/library/src/com/google/example/library/v1/BookName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/src/com/google/example/library/v1/ShelfName.java
+++ b/test/integration/goldens/library/src/com/google/example/library/v1/ShelfName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/copylogentries/AsyncCopyLogEntries.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/copylogentries/AsyncCopyLogEntries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/copylogentries/AsyncCopyLogEntriesLRO.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/copylogentries/AsyncCopyLogEntriesLRO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/copylogentries/SyncCopyLogEntries.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/copylogentries/SyncCopyLogEntries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/create/SyncCreateSetCredentialsProvider.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/create/SyncCreateSetEndpoint.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createbucket/AsyncCreateBucket.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createbucket/AsyncCreateBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createbucket/SyncCreateBucket.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createbucket/SyncCreateBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createexclusion/AsyncCreateExclusion.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createexclusion/AsyncCreateExclusion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createexclusion/SyncCreateExclusion.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createexclusion/SyncCreateExclusion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createexclusion/SyncCreateExclusionBillingaccountnameLogexclusion.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createexclusion/SyncCreateExclusionBillingaccountnameLogexclusion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createexclusion/SyncCreateExclusionFoldernameLogexclusion.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createexclusion/SyncCreateExclusionFoldernameLogexclusion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createexclusion/SyncCreateExclusionOrganizationnameLogexclusion.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createexclusion/SyncCreateExclusionOrganizationnameLogexclusion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createexclusion/SyncCreateExclusionProjectnameLogexclusion.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createexclusion/SyncCreateExclusionProjectnameLogexclusion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createexclusion/SyncCreateExclusionStringLogexclusion.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createexclusion/SyncCreateExclusionStringLogexclusion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createsink/AsyncCreateSink.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createsink/AsyncCreateSink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createsink/SyncCreateSink.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createsink/SyncCreateSink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createsink/SyncCreateSinkBillingaccountnameLogsink.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createsink/SyncCreateSinkBillingaccountnameLogsink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createsink/SyncCreateSinkFoldernameLogsink.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createsink/SyncCreateSinkFoldernameLogsink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createsink/SyncCreateSinkOrganizationnameLogsink.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createsink/SyncCreateSinkOrganizationnameLogsink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createsink/SyncCreateSinkProjectnameLogsink.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createsink/SyncCreateSinkProjectnameLogsink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createsink/SyncCreateSinkStringLogsink.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createsink/SyncCreateSinkStringLogsink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createview/AsyncCreateView.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createview/AsyncCreateView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createview/SyncCreateView.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createview/SyncCreateView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deletebucket/AsyncDeleteBucket.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deletebucket/AsyncDeleteBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deletebucket/SyncDeleteBucket.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deletebucket/SyncDeleteBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deleteexclusion/AsyncDeleteExclusion.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deleteexclusion/AsyncDeleteExclusion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deleteexclusion/SyncDeleteExclusion.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deleteexclusion/SyncDeleteExclusion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deleteexclusion/SyncDeleteExclusionLogexclusionname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deleteexclusion/SyncDeleteExclusionLogexclusionname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deleteexclusion/SyncDeleteExclusionString.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deleteexclusion/SyncDeleteExclusionString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deletesink/AsyncDeleteSink.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deletesink/AsyncDeleteSink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deletesink/SyncDeleteSink.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deletesink/SyncDeleteSink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deletesink/SyncDeleteSinkLogsinkname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deletesink/SyncDeleteSinkLogsinkname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deletesink/SyncDeleteSinkString.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deletesink/SyncDeleteSinkString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deleteview/AsyncDeleteView.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deleteview/AsyncDeleteView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deleteview/SyncDeleteView.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deleteview/SyncDeleteView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getbucket/AsyncGetBucket.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getbucket/AsyncGetBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getbucket/SyncGetBucket.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getbucket/SyncGetBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getcmeksettings/AsyncGetCmekSettings.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getcmeksettings/AsyncGetCmekSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getcmeksettings/SyncGetCmekSettings.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getcmeksettings/SyncGetCmekSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getexclusion/AsyncGetExclusion.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getexclusion/AsyncGetExclusion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getexclusion/SyncGetExclusion.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getexclusion/SyncGetExclusion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getexclusion/SyncGetExclusionLogexclusionname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getexclusion/SyncGetExclusionLogexclusionname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getexclusion/SyncGetExclusionString.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getexclusion/SyncGetExclusionString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getsettings/AsyncGetSettings.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getsettings/AsyncGetSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getsettings/SyncGetSettings.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getsettings/SyncGetSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getsettings/SyncGetSettingsSettingsname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getsettings/SyncGetSettingsSettingsname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getsettings/SyncGetSettingsString.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getsettings/SyncGetSettingsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getsink/AsyncGetSink.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getsink/AsyncGetSink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getsink/SyncGetSink.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getsink/SyncGetSink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getsink/SyncGetSinkLogsinkname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getsink/SyncGetSinkLogsinkname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getsink/SyncGetSinkString.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getsink/SyncGetSinkString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getview/AsyncGetView.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getview/AsyncGetView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getview/SyncGetView.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getview/SyncGetView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listbuckets/AsyncListBuckets.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listbuckets/AsyncListBuckets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listbuckets/AsyncListBucketsPaged.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listbuckets/AsyncListBucketsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listbuckets/SyncListBuckets.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listbuckets/SyncListBuckets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listbuckets/SyncListBucketsBillingaccountlocationname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listbuckets/SyncListBucketsBillingaccountlocationname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listbuckets/SyncListBucketsFolderlocationname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listbuckets/SyncListBucketsFolderlocationname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listbuckets/SyncListBucketsLocationname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listbuckets/SyncListBucketsLocationname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listbuckets/SyncListBucketsOrganizationlocationname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listbuckets/SyncListBucketsOrganizationlocationname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listbuckets/SyncListBucketsString.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listbuckets/SyncListBucketsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listexclusions/AsyncListExclusions.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listexclusions/AsyncListExclusions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listexclusions/AsyncListExclusionsPaged.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listexclusions/AsyncListExclusionsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listexclusions/SyncListExclusions.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listexclusions/SyncListExclusions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listexclusions/SyncListExclusionsBillingaccountname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listexclusions/SyncListExclusionsBillingaccountname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listexclusions/SyncListExclusionsFoldername.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listexclusions/SyncListExclusionsFoldername.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listexclusions/SyncListExclusionsOrganizationname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listexclusions/SyncListExclusionsOrganizationname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listexclusions/SyncListExclusionsProjectname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listexclusions/SyncListExclusionsProjectname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listexclusions/SyncListExclusionsString.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listexclusions/SyncListExclusionsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listsinks/AsyncListSinks.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listsinks/AsyncListSinks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listsinks/AsyncListSinksPaged.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listsinks/AsyncListSinksPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listsinks/SyncListSinks.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listsinks/SyncListSinks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listsinks/SyncListSinksBillingaccountname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listsinks/SyncListSinksBillingaccountname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listsinks/SyncListSinksFoldername.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listsinks/SyncListSinksFoldername.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listsinks/SyncListSinksOrganizationname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listsinks/SyncListSinksOrganizationname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listsinks/SyncListSinksProjectname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listsinks/SyncListSinksProjectname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listsinks/SyncListSinksString.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listsinks/SyncListSinksString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listviews/AsyncListViews.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listviews/AsyncListViews.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listviews/AsyncListViewsPaged.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listviews/AsyncListViewsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listviews/SyncListViews.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listviews/SyncListViews.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listviews/SyncListViewsString.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listviews/SyncListViewsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/undeletebucket/AsyncUndeleteBucket.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/undeletebucket/AsyncUndeleteBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/undeletebucket/SyncUndeleteBucket.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/undeletebucket/SyncUndeleteBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatebucket/AsyncUpdateBucket.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatebucket/AsyncUpdateBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatebucket/SyncUpdateBucket.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatebucket/SyncUpdateBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatecmeksettings/AsyncUpdateCmekSettings.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatecmeksettings/AsyncUpdateCmekSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatecmeksettings/SyncUpdateCmekSettings.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatecmeksettings/SyncUpdateCmekSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updateexclusion/AsyncUpdateExclusion.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updateexclusion/AsyncUpdateExclusion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updateexclusion/SyncUpdateExclusion.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updateexclusion/SyncUpdateExclusion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updateexclusion/SyncUpdateExclusionLogexclusionnameLogexclusionFieldmask.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updateexclusion/SyncUpdateExclusionLogexclusionnameLogexclusionFieldmask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updateexclusion/SyncUpdateExclusionStringLogexclusionFieldmask.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updateexclusion/SyncUpdateExclusionStringLogexclusionFieldmask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatesettings/AsyncUpdateSettings.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatesettings/AsyncUpdateSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatesettings/SyncUpdateSettings.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatesettings/SyncUpdateSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatesettings/SyncUpdateSettingsSettingsFieldmask.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatesettings/SyncUpdateSettingsSettingsFieldmask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatesink/AsyncUpdateSink.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatesink/AsyncUpdateSink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatesink/SyncUpdateSink.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatesink/SyncUpdateSink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatesink/SyncUpdateSinkLogsinknameLogsink.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatesink/SyncUpdateSinkLogsinknameLogsink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatesink/SyncUpdateSinkLogsinknameLogsinkFieldmask.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatesink/SyncUpdateSinkLogsinknameLogsinkFieldmask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatesink/SyncUpdateSinkStringLogsink.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatesink/SyncUpdateSinkStringLogsink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatesink/SyncUpdateSinkStringLogsinkFieldmask.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatesink/SyncUpdateSinkStringLogsinkFieldmask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updateview/AsyncUpdateView.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updateview/AsyncUpdateView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updateview/SyncUpdateView.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updateview/SyncUpdateView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configsettings/getbucket/SyncGetBucket.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configsettings/getbucket/SyncGetBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/create/SyncCreateSetCredentialsProvider.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/create/SyncCreateSetEndpoint.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/deletelog/AsyncDeleteLog.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/deletelog/AsyncDeleteLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/deletelog/SyncDeleteLog.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/deletelog/SyncDeleteLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/deletelog/SyncDeleteLogLogname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/deletelog/SyncDeleteLogLogname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/deletelog/SyncDeleteLogString.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/deletelog/SyncDeleteLogString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogentries/AsyncListLogEntries.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogentries/AsyncListLogEntries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogentries/AsyncListLogEntriesPaged.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogentries/AsyncListLogEntriesPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogentries/SyncListLogEntries.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogentries/SyncListLogEntries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogentries/SyncListLogEntriesListstringStringString.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogentries/SyncListLogEntriesListstringStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogs/AsyncListLogs.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogs/AsyncListLogs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogs/AsyncListLogsPaged.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogs/AsyncListLogsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogs/SyncListLogs.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogs/SyncListLogs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogs/SyncListLogsBillingaccountname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogs/SyncListLogsBillingaccountname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogs/SyncListLogsFoldername.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogs/SyncListLogsFoldername.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogs/SyncListLogsOrganizationname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogs/SyncListLogsOrganizationname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogs/SyncListLogsProjectname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogs/SyncListLogsProjectname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogs/SyncListLogsString.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogs/SyncListLogsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listmonitoredresourcedescriptors/AsyncListMonitoredResourceDescriptors.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listmonitoredresourcedescriptors/AsyncListMonitoredResourceDescriptors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listmonitoredresourcedescriptors/AsyncListMonitoredResourceDescriptorsPaged.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listmonitoredresourcedescriptors/AsyncListMonitoredResourceDescriptorsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listmonitoredresourcedescriptors/SyncListMonitoredResourceDescriptors.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listmonitoredresourcedescriptors/SyncListMonitoredResourceDescriptors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/taillogentries/AsyncTailLogEntries.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/taillogentries/AsyncTailLogEntries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/writelogentries/AsyncWriteLogEntries.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/writelogentries/AsyncWriteLogEntries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/writelogentries/SyncWriteLogEntries.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/writelogentries/SyncWriteLogEntries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/writelogentries/SyncWriteLogEntriesLognameMonitoredresourceMapstringstringListlogentry.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/writelogentries/SyncWriteLogEntriesLognameMonitoredresourceMapstringstringListlogentry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/writelogentries/SyncWriteLogEntriesStringMonitoredresourceMapstringstringListlogentry.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/writelogentries/SyncWriteLogEntriesStringMonitoredresourceMapstringstringListlogentry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingsettings/deletelog/SyncDeleteLog.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingsettings/deletelog/SyncDeleteLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/create/SyncCreateSetCredentialsProvider.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/create/SyncCreateSetEndpoint.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/createlogmetric/AsyncCreateLogMetric.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/createlogmetric/AsyncCreateLogMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/createlogmetric/SyncCreateLogMetric.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/createlogmetric/SyncCreateLogMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/createlogmetric/SyncCreateLogMetricProjectnameLogmetric.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/createlogmetric/SyncCreateLogMetricProjectnameLogmetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/createlogmetric/SyncCreateLogMetricStringLogmetric.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/createlogmetric/SyncCreateLogMetricStringLogmetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/deletelogmetric/AsyncDeleteLogMetric.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/deletelogmetric/AsyncDeleteLogMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/deletelogmetric/SyncDeleteLogMetric.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/deletelogmetric/SyncDeleteLogMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/deletelogmetric/SyncDeleteLogMetricLogmetricname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/deletelogmetric/SyncDeleteLogMetricLogmetricname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/deletelogmetric/SyncDeleteLogMetricString.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/deletelogmetric/SyncDeleteLogMetricString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/getlogmetric/AsyncGetLogMetric.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/getlogmetric/AsyncGetLogMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/getlogmetric/SyncGetLogMetric.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/getlogmetric/SyncGetLogMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/getlogmetric/SyncGetLogMetricLogmetricname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/getlogmetric/SyncGetLogMetricLogmetricname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/getlogmetric/SyncGetLogMetricString.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/getlogmetric/SyncGetLogMetricString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/listlogmetrics/AsyncListLogMetrics.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/listlogmetrics/AsyncListLogMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/listlogmetrics/AsyncListLogMetricsPaged.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/listlogmetrics/AsyncListLogMetricsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/listlogmetrics/SyncListLogMetrics.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/listlogmetrics/SyncListLogMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/listlogmetrics/SyncListLogMetricsProjectname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/listlogmetrics/SyncListLogMetricsProjectname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/listlogmetrics/SyncListLogMetricsString.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/listlogmetrics/SyncListLogMetricsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/updatelogmetric/AsyncUpdateLogMetric.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/updatelogmetric/AsyncUpdateLogMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/updatelogmetric/SyncUpdateLogMetric.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/updatelogmetric/SyncUpdateLogMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/updatelogmetric/SyncUpdateLogMetricLogmetricnameLogmetric.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/updatelogmetric/SyncUpdateLogMetricLogmetricnameLogmetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/updatelogmetric/SyncUpdateLogMetricStringLogmetric.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/updatelogmetric/SyncUpdateLogMetricStringLogmetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricssettings/getlogmetric/SyncGetLogMetric.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricssettings/getlogmetric/SyncGetLogMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/stub/configservicev2stubsettings/getbucket/SyncGetBucket.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/stub/configservicev2stubsettings/getbucket/SyncGetBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/stub/loggingservicev2stubsettings/deletelog/SyncDeleteLog.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/stub/loggingservicev2stubsettings/deletelog/SyncDeleteLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/stub/metricsservicev2stubsettings/getlogmetric/SyncGetLogMetric.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/stub/metricsservicev2stubsettings/getlogmetric/SyncGetLogMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/ConfigClient.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/ConfigClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/ConfigClientTest.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/ConfigClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/ConfigSettings.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/ConfigSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/LoggingClient.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/LoggingClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/LoggingClientTest.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/LoggingClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/LoggingSettings.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/LoggingSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MetricsClient.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MetricsClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MetricsClientTest.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MetricsClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MetricsSettings.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MetricsSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MockConfigServiceV2.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MockConfigServiceV2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MockConfigServiceV2Impl.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MockConfigServiceV2Impl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MockLoggingServiceV2.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MockLoggingServiceV2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MockLoggingServiceV2Impl.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MockLoggingServiceV2Impl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MockMetricsServiceV2.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MockMetricsServiceV2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MockMetricsServiceV2Impl.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MockMetricsServiceV2Impl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/package-info.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/ConfigServiceV2Stub.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/ConfigServiceV2Stub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/ConfigServiceV2StubSettings.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/ConfigServiceV2StubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/GrpcConfigServiceV2CallableFactory.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/GrpcConfigServiceV2CallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/GrpcConfigServiceV2Stub.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/GrpcConfigServiceV2Stub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/GrpcLoggingServiceV2CallableFactory.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/GrpcLoggingServiceV2CallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/GrpcLoggingServiceV2Stub.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/GrpcLoggingServiceV2Stub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/GrpcMetricsServiceV2CallableFactory.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/GrpcMetricsServiceV2CallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/GrpcMetricsServiceV2Stub.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/GrpcMetricsServiceV2Stub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/LoggingServiceV2Stub.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/LoggingServiceV2Stub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/LoggingServiceV2StubSettings.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/LoggingServiceV2StubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/MetricsServiceV2Stub.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/MetricsServiceV2Stub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/MetricsServiceV2StubSettings.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/MetricsServiceV2StubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/logging/v2/BillingAccountLocationName.java
+++ b/test/integration/goldens/logging/src/com/google/logging/v2/BillingAccountLocationName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/logging/v2/BillingAccountName.java
+++ b/test/integration/goldens/logging/src/com/google/logging/v2/BillingAccountName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/logging/v2/CmekSettingsName.java
+++ b/test/integration/goldens/logging/src/com/google/logging/v2/CmekSettingsName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/logging/v2/FolderLocationName.java
+++ b/test/integration/goldens/logging/src/com/google/logging/v2/FolderLocationName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/logging/v2/FolderName.java
+++ b/test/integration/goldens/logging/src/com/google/logging/v2/FolderName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/logging/v2/LocationName.java
+++ b/test/integration/goldens/logging/src/com/google/logging/v2/LocationName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/logging/v2/LogBucketName.java
+++ b/test/integration/goldens/logging/src/com/google/logging/v2/LogBucketName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/logging/v2/LogExclusionName.java
+++ b/test/integration/goldens/logging/src/com/google/logging/v2/LogExclusionName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/logging/v2/LogMetricName.java
+++ b/test/integration/goldens/logging/src/com/google/logging/v2/LogMetricName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/logging/v2/LogName.java
+++ b/test/integration/goldens/logging/src/com/google/logging/v2/LogName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/logging/v2/LogSinkName.java
+++ b/test/integration/goldens/logging/src/com/google/logging/v2/LogSinkName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/logging/v2/LogViewName.java
+++ b/test/integration/goldens/logging/src/com/google/logging/v2/LogViewName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/logging/v2/OrganizationLocationName.java
+++ b/test/integration/goldens/logging/src/com/google/logging/v2/OrganizationLocationName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/logging/v2/OrganizationName.java
+++ b/test/integration/goldens/logging/src/com/google/logging/v2/OrganizationName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/logging/v2/ProjectName.java
+++ b/test/integration/goldens/logging/src/com/google/logging/v2/ProjectName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/logging/v2/SettingsName.java
+++ b/test/integration/goldens/logging/src/com/google/logging/v2/SettingsName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/create/SyncCreateSetCredentialsProvider.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/create/SyncCreateSetEndpoint.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/createtopic/AsyncCreateTopic.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/createtopic/AsyncCreateTopic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/createtopic/SyncCreateTopic.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/createtopic/SyncCreateTopic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/createtopic/SyncCreateTopicString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/createtopic/SyncCreateTopicString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/createtopic/SyncCreateTopicTopicname.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/createtopic/SyncCreateTopicTopicname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/deletetopic/AsyncDeleteTopic.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/deletetopic/AsyncDeleteTopic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/deletetopic/SyncDeleteTopic.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/deletetopic/SyncDeleteTopic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/deletetopic/SyncDeleteTopicString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/deletetopic/SyncDeleteTopicString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/deletetopic/SyncDeleteTopicTopicname.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/deletetopic/SyncDeleteTopicTopicname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/detachsubscription/AsyncDetachSubscription.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/detachsubscription/AsyncDetachSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/detachsubscription/SyncDetachSubscription.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/detachsubscription/SyncDetachSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/getiampolicy/AsyncGetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/getiampolicy/AsyncGetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/getiampolicy/SyncGetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/getiampolicy/SyncGetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/gettopic/AsyncGetTopic.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/gettopic/AsyncGetTopic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/gettopic/SyncGetTopic.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/gettopic/SyncGetTopic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/gettopic/SyncGetTopicString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/gettopic/SyncGetTopicString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/gettopic/SyncGetTopicTopicname.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/gettopic/SyncGetTopicTopicname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopics/AsyncListTopics.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopics/AsyncListTopics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopics/AsyncListTopicsPaged.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopics/AsyncListTopicsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopics/SyncListTopics.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopics/SyncListTopics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopics/SyncListTopicsProjectname.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopics/SyncListTopicsProjectname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopics/SyncListTopicsString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopics/SyncListTopicsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsnapshots/AsyncListTopicSnapshots.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsnapshots/AsyncListTopicSnapshots.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsnapshots/AsyncListTopicSnapshotsPaged.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsnapshots/AsyncListTopicSnapshotsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsnapshots/SyncListTopicSnapshots.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsnapshots/SyncListTopicSnapshots.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsnapshots/SyncListTopicSnapshotsString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsnapshots/SyncListTopicSnapshotsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsnapshots/SyncListTopicSnapshotsTopicname.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsnapshots/SyncListTopicSnapshotsTopicname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsubscriptions/AsyncListTopicSubscriptions.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsubscriptions/AsyncListTopicSubscriptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsubscriptions/AsyncListTopicSubscriptionsPaged.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsubscriptions/AsyncListTopicSubscriptionsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsubscriptions/SyncListTopicSubscriptions.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsubscriptions/SyncListTopicSubscriptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsubscriptions/SyncListTopicSubscriptionsString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsubscriptions/SyncListTopicSubscriptionsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsubscriptions/SyncListTopicSubscriptionsTopicname.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsubscriptions/SyncListTopicSubscriptionsTopicname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/publish/AsyncPublish.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/publish/AsyncPublish.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/publish/SyncPublish.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/publish/SyncPublish.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/publish/SyncPublishStringListpubsubmessage.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/publish/SyncPublishStringListpubsubmessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/publish/SyncPublishTopicnameListpubsubmessage.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/publish/SyncPublishTopicnameListpubsubmessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/setiampolicy/AsyncSetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/setiampolicy/AsyncSetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/setiampolicy/SyncSetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/setiampolicy/SyncSetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/testiampermissions/AsyncTestIamPermissions.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/testiampermissions/AsyncTestIamPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/testiampermissions/SyncTestIamPermissions.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/testiampermissions/SyncTestIamPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/updatetopic/AsyncUpdateTopic.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/updatetopic/AsyncUpdateTopic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/updatetopic/SyncUpdateTopic.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/updatetopic/SyncUpdateTopic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/commitschema/AsyncCommitSchema.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/commitschema/AsyncCommitSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/commitschema/SyncCommitSchema.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/commitschema/SyncCommitSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/commitschema/SyncCommitSchemaSchemanameSchema.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/commitschema/SyncCommitSchemaSchemanameSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/commitschema/SyncCommitSchemaStringSchema.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/commitschema/SyncCommitSchemaStringSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/create/SyncCreateSetCredentialsProvider.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/create/SyncCreateSetEndpoint.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/createschema/AsyncCreateSchema.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/createschema/AsyncCreateSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/createschema/SyncCreateSchema.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/createschema/SyncCreateSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/createschema/SyncCreateSchemaProjectnameSchemaString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/createschema/SyncCreateSchemaProjectnameSchemaString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/createschema/SyncCreateSchemaStringSchemaString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/createschema/SyncCreateSchemaStringSchemaString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/deleteschema/AsyncDeleteSchema.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/deleteschema/AsyncDeleteSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/deleteschema/SyncDeleteSchema.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/deleteschema/SyncDeleteSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/deleteschema/SyncDeleteSchemaSchemaname.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/deleteschema/SyncDeleteSchemaSchemaname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/deleteschema/SyncDeleteSchemaString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/deleteschema/SyncDeleteSchemaString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/deleteschemarevision/AsyncDeleteSchemaRevision.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/deleteschemarevision/AsyncDeleteSchemaRevision.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/deleteschemarevision/SyncDeleteSchemaRevision.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/deleteschemarevision/SyncDeleteSchemaRevision.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/deleteschemarevision/SyncDeleteSchemaRevisionSchemanameString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/deleteschemarevision/SyncDeleteSchemaRevisionSchemanameString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/deleteschemarevision/SyncDeleteSchemaRevisionStringString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/deleteschemarevision/SyncDeleteSchemaRevisionStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/getiampolicy/AsyncGetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/getiampolicy/AsyncGetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/getiampolicy/SyncGetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/getiampolicy/SyncGetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/getschema/AsyncGetSchema.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/getschema/AsyncGetSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/getschema/SyncGetSchema.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/getschema/SyncGetSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/getschema/SyncGetSchemaSchemaname.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/getschema/SyncGetSchemaSchemaname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/getschema/SyncGetSchemaString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/getschema/SyncGetSchemaString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemarevisions/AsyncListSchemaRevisions.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemarevisions/AsyncListSchemaRevisions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemarevisions/AsyncListSchemaRevisionsPaged.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemarevisions/AsyncListSchemaRevisionsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemarevisions/SyncListSchemaRevisions.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemarevisions/SyncListSchemaRevisions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemarevisions/SyncListSchemaRevisionsSchemaname.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemarevisions/SyncListSchemaRevisionsSchemaname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemarevisions/SyncListSchemaRevisionsString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemarevisions/SyncListSchemaRevisionsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemas/AsyncListSchemas.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemas/AsyncListSchemas.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemas/AsyncListSchemasPaged.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemas/AsyncListSchemasPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemas/SyncListSchemas.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemas/SyncListSchemas.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemas/SyncListSchemasProjectname.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemas/SyncListSchemasProjectname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemas/SyncListSchemasString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemas/SyncListSchemasString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/rollbackschema/AsyncRollbackSchema.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/rollbackschema/AsyncRollbackSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/rollbackschema/SyncRollbackSchema.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/rollbackschema/SyncRollbackSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/rollbackschema/SyncRollbackSchemaSchemanameString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/rollbackschema/SyncRollbackSchemaSchemanameString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/rollbackschema/SyncRollbackSchemaStringString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/rollbackschema/SyncRollbackSchemaStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/setiampolicy/AsyncSetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/setiampolicy/AsyncSetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/setiampolicy/SyncSetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/setiampolicy/SyncSetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/testiampermissions/AsyncTestIamPermissions.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/testiampermissions/AsyncTestIamPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/testiampermissions/SyncTestIamPermissions.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/testiampermissions/SyncTestIamPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/validatemessage/AsyncValidateMessage.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/validatemessage/AsyncValidateMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/validatemessage/SyncValidateMessage.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/validatemessage/SyncValidateMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/validateschema/AsyncValidateSchema.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/validateschema/AsyncValidateSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/validateschema/SyncValidateSchema.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/validateschema/SyncValidateSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/validateschema/SyncValidateSchemaProjectnameSchema.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/validateschema/SyncValidateSchemaProjectnameSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/validateschema/SyncValidateSchemaStringSchema.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/validateschema/SyncValidateSchemaStringSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservicesettings/createschema/SyncCreateSchema.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservicesettings/createschema/SyncCreateSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/stub/publisherstubsettings/createtopic/SyncCreateTopic.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/stub/publisherstubsettings/createtopic/SyncCreateTopic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/stub/schemaservicestubsettings/createschema/SyncCreateSchema.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/stub/schemaservicestubsettings/createschema/SyncCreateSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/stub/subscriberstubsettings/createsubscription/SyncCreateSubscription.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/stub/subscriberstubsettings/createsubscription/SyncCreateSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/acknowledge/AsyncAcknowledge.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/acknowledge/AsyncAcknowledge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/acknowledge/SyncAcknowledge.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/acknowledge/SyncAcknowledge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/acknowledge/SyncAcknowledgeStringListstring.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/acknowledge/SyncAcknowledgeStringListstring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/acknowledge/SyncAcknowledgeSubscriptionnameListstring.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/acknowledge/SyncAcknowledgeSubscriptionnameListstring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/create/SyncCreateSetCredentialsProvider.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/create/SyncCreateSetEndpoint.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsnapshot/AsyncCreateSnapshot.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsnapshot/AsyncCreateSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsnapshot/SyncCreateSnapshot.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsnapshot/SyncCreateSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsnapshot/SyncCreateSnapshotSnapshotnameString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsnapshot/SyncCreateSnapshotSnapshotnameString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsnapshot/SyncCreateSnapshotSnapshotnameSubscriptionname.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsnapshot/SyncCreateSnapshotSnapshotnameSubscriptionname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsnapshot/SyncCreateSnapshotStringString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsnapshot/SyncCreateSnapshotStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsnapshot/SyncCreateSnapshotStringSubscriptionname.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsnapshot/SyncCreateSnapshotStringSubscriptionname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsubscription/AsyncCreateSubscription.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsubscription/AsyncCreateSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsubscription/SyncCreateSubscription.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsubscription/SyncCreateSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsubscription/SyncCreateSubscriptionStringStringPushconfigInt.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsubscription/SyncCreateSubscriptionStringStringPushconfigInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsubscription/SyncCreateSubscriptionStringTopicnamePushconfigInt.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsubscription/SyncCreateSubscriptionStringTopicnamePushconfigInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsubscription/SyncCreateSubscriptionSubscriptionnameStringPushconfigInt.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsubscription/SyncCreateSubscriptionSubscriptionnameStringPushconfigInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsubscription/SyncCreateSubscriptionSubscriptionnameTopicnamePushconfigInt.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsubscription/SyncCreateSubscriptionSubscriptionnameTopicnamePushconfigInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/deletesnapshot/AsyncDeleteSnapshot.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/deletesnapshot/AsyncDeleteSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/deletesnapshot/SyncDeleteSnapshot.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/deletesnapshot/SyncDeleteSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/deletesnapshot/SyncDeleteSnapshotSnapshotname.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/deletesnapshot/SyncDeleteSnapshotSnapshotname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/deletesnapshot/SyncDeleteSnapshotString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/deletesnapshot/SyncDeleteSnapshotString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/deletesubscription/AsyncDeleteSubscription.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/deletesubscription/AsyncDeleteSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/deletesubscription/SyncDeleteSubscription.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/deletesubscription/SyncDeleteSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/deletesubscription/SyncDeleteSubscriptionString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/deletesubscription/SyncDeleteSubscriptionString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/deletesubscription/SyncDeleteSubscriptionSubscriptionname.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/deletesubscription/SyncDeleteSubscriptionSubscriptionname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getiampolicy/AsyncGetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getiampolicy/AsyncGetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getiampolicy/SyncGetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getiampolicy/SyncGetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getsnapshot/AsyncGetSnapshot.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getsnapshot/AsyncGetSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getsnapshot/SyncGetSnapshot.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getsnapshot/SyncGetSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getsnapshot/SyncGetSnapshotSnapshotname.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getsnapshot/SyncGetSnapshotSnapshotname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getsnapshot/SyncGetSnapshotString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getsnapshot/SyncGetSnapshotString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getsubscription/AsyncGetSubscription.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getsubscription/AsyncGetSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getsubscription/SyncGetSubscription.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getsubscription/SyncGetSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getsubscription/SyncGetSubscriptionString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getsubscription/SyncGetSubscriptionString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getsubscription/SyncGetSubscriptionSubscriptionname.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getsubscription/SyncGetSubscriptionSubscriptionname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsnapshots/AsyncListSnapshots.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsnapshots/AsyncListSnapshots.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsnapshots/AsyncListSnapshotsPaged.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsnapshots/AsyncListSnapshotsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsnapshots/SyncListSnapshots.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsnapshots/SyncListSnapshots.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsnapshots/SyncListSnapshotsProjectname.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsnapshots/SyncListSnapshotsProjectname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsnapshots/SyncListSnapshotsString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsnapshots/SyncListSnapshotsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsubscriptions/AsyncListSubscriptions.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsubscriptions/AsyncListSubscriptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsubscriptions/AsyncListSubscriptionsPaged.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsubscriptions/AsyncListSubscriptionsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsubscriptions/SyncListSubscriptions.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsubscriptions/SyncListSubscriptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsubscriptions/SyncListSubscriptionsProjectname.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsubscriptions/SyncListSubscriptionsProjectname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsubscriptions/SyncListSubscriptionsString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsubscriptions/SyncListSubscriptionsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/modifyackdeadline/AsyncModifyAckDeadline.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/modifyackdeadline/AsyncModifyAckDeadline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/modifyackdeadline/SyncModifyAckDeadline.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/modifyackdeadline/SyncModifyAckDeadline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/modifyackdeadline/SyncModifyAckDeadlineStringListstringInt.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/modifyackdeadline/SyncModifyAckDeadlineStringListstringInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/modifyackdeadline/SyncModifyAckDeadlineSubscriptionnameListstringInt.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/modifyackdeadline/SyncModifyAckDeadlineSubscriptionnameListstringInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/modifypushconfig/AsyncModifyPushConfig.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/modifypushconfig/AsyncModifyPushConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/modifypushconfig/SyncModifyPushConfig.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/modifypushconfig/SyncModifyPushConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/modifypushconfig/SyncModifyPushConfigStringPushconfig.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/modifypushconfig/SyncModifyPushConfigStringPushconfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/modifypushconfig/SyncModifyPushConfigSubscriptionnamePushconfig.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/modifypushconfig/SyncModifyPushConfigSubscriptionnamePushconfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/pull/AsyncPull.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/pull/AsyncPull.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/pull/SyncPull.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/pull/SyncPull.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/pull/SyncPullStringBooleanInt.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/pull/SyncPullStringBooleanInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/pull/SyncPullStringInt.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/pull/SyncPullStringInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/pull/SyncPullSubscriptionnameBooleanInt.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/pull/SyncPullSubscriptionnameBooleanInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/pull/SyncPullSubscriptionnameInt.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/pull/SyncPullSubscriptionnameInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/seek/AsyncSeek.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/seek/AsyncSeek.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/seek/SyncSeek.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/seek/SyncSeek.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/setiampolicy/AsyncSetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/setiampolicy/AsyncSetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/setiampolicy/SyncSetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/setiampolicy/SyncSetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/streamingpull/AsyncStreamingPull.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/streamingpull/AsyncStreamingPull.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/testiampermissions/AsyncTestIamPermissions.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/testiampermissions/AsyncTestIamPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/testiampermissions/SyncTestIamPermissions.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/testiampermissions/SyncTestIamPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/updatesnapshot/AsyncUpdateSnapshot.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/updatesnapshot/AsyncUpdateSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/updatesnapshot/SyncUpdateSnapshot.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/updatesnapshot/SyncUpdateSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/updatesubscription/AsyncUpdateSubscription.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/updatesubscription/AsyncUpdateSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/updatesubscription/SyncUpdateSubscription.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/updatesubscription/SyncUpdateSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriptionadminsettings/createsubscription/SyncCreateSubscription.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriptionadminsettings/createsubscription/SyncCreateSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/topicadminsettings/createtopic/SyncCreateTopic.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/topicadminsettings/createtopic/SyncCreateTopic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/MockIAMPolicy.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/MockIAMPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/MockIAMPolicyImpl.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/MockIAMPolicyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/MockPublisher.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/MockPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/MockPublisherImpl.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/MockPublisherImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/MockSchemaService.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/MockSchemaService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/MockSchemaServiceImpl.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/MockSchemaServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/MockSubscriber.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/MockSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/MockSubscriberImpl.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/MockSubscriberImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SchemaServiceClient.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SchemaServiceClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SchemaServiceClientTest.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SchemaServiceClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SchemaServiceSettings.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SchemaServiceSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SubscriptionAdminClient.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SubscriptionAdminClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SubscriptionAdminClientTest.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SubscriptionAdminClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SubscriptionAdminSettings.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SubscriptionAdminSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/TopicAdminClient.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/TopicAdminClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/TopicAdminClientTest.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/TopicAdminClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/TopicAdminSettings.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/TopicAdminSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/package-info.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/GrpcPublisherCallableFactory.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/GrpcPublisherCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/GrpcPublisherStub.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/GrpcPublisherStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/GrpcSchemaServiceCallableFactory.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/GrpcSchemaServiceCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/GrpcSchemaServiceStub.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/GrpcSchemaServiceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/GrpcSubscriberCallableFactory.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/GrpcSubscriberCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/GrpcSubscriberStub.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/GrpcSubscriberStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/PublisherStub.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/PublisherStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/PublisherStubSettings.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/PublisherStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/SchemaServiceStub.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/SchemaServiceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/SchemaServiceStubSettings.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/SchemaServiceStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/SubscriberStub.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/SubscriberStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/SubscriberStubSettings.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/SubscriberStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/pubsub/v1/ProjectName.java
+++ b/test/integration/goldens/pubsub/src/com/google/pubsub/v1/ProjectName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/pubsub/v1/SchemaName.java
+++ b/test/integration/goldens/pubsub/src/com/google/pubsub/v1/SchemaName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/pubsub/v1/SnapshotName.java
+++ b/test/integration/goldens/pubsub/src/com/google/pubsub/v1/SnapshotName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/pubsub/v1/SubscriptionName.java
+++ b/test/integration/goldens/pubsub/src/com/google/pubsub/v1/SubscriptionName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/pubsub/v1/TopicName.java
+++ b/test/integration/goldens/pubsub/src/com/google/pubsub/v1/TopicName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/create/SyncCreateSetCredentialsProvider.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/create/SyncCreateSetCredentialsProvider1.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/create/SyncCreateSetCredentialsProvider1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/create/SyncCreateSetEndpoint.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/createinstance/AsyncCreateInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/createinstance/AsyncCreateInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/createinstance/AsyncCreateInstanceLRO.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/createinstance/AsyncCreateInstanceLRO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/createinstance/SyncCreateInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/createinstance/SyncCreateInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/createinstance/SyncCreateInstanceLocationnameStringInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/createinstance/SyncCreateInstanceLocationnameStringInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/createinstance/SyncCreateInstanceStringStringInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/createinstance/SyncCreateInstanceStringStringInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/deleteinstance/AsyncDeleteInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/deleteinstance/AsyncDeleteInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/deleteinstance/AsyncDeleteInstanceLRO.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/deleteinstance/AsyncDeleteInstanceLRO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/deleteinstance/SyncDeleteInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/deleteinstance/SyncDeleteInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/deleteinstance/SyncDeleteInstanceInstancename.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/deleteinstance/SyncDeleteInstanceInstancename.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/deleteinstance/SyncDeleteInstanceString.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/deleteinstance/SyncDeleteInstanceString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/exportinstance/AsyncExportInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/exportinstance/AsyncExportInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/exportinstance/AsyncExportInstanceLRO.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/exportinstance/AsyncExportInstanceLRO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/exportinstance/SyncExportInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/exportinstance/SyncExportInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/exportinstance/SyncExportInstanceStringOutputconfig.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/exportinstance/SyncExportInstanceStringOutputconfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/failoverinstance/AsyncFailoverInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/failoverinstance/AsyncFailoverInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/failoverinstance/AsyncFailoverInstanceLRO.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/failoverinstance/AsyncFailoverInstanceLRO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/failoverinstance/SyncFailoverInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/failoverinstance/SyncFailoverInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/failoverinstance/SyncFailoverInstanceInstancenameFailoverinstancerequestdataprotectionmode.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/failoverinstance/SyncFailoverInstanceInstancenameFailoverinstancerequestdataprotectionmode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/failoverinstance/SyncFailoverInstanceStringFailoverinstancerequestdataprotectionmode.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/failoverinstance/SyncFailoverInstanceStringFailoverinstancerequestdataprotectionmode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/getinstance/AsyncGetInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/getinstance/AsyncGetInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/getinstance/SyncGetInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/getinstance/SyncGetInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/getinstance/SyncGetInstanceInstancename.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/getinstance/SyncGetInstanceInstancename.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/getinstance/SyncGetInstanceString.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/getinstance/SyncGetInstanceString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/getinstanceauthstring/AsyncGetInstanceAuthString.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/getinstanceauthstring/AsyncGetInstanceAuthString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/getinstanceauthstring/SyncGetInstanceAuthString.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/getinstanceauthstring/SyncGetInstanceAuthString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/getinstanceauthstring/SyncGetInstanceAuthStringInstancename.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/getinstanceauthstring/SyncGetInstanceAuthStringInstancename.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/getinstanceauthstring/SyncGetInstanceAuthStringString.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/getinstanceauthstring/SyncGetInstanceAuthStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/importinstance/AsyncImportInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/importinstance/AsyncImportInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/importinstance/AsyncImportInstanceLRO.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/importinstance/AsyncImportInstanceLRO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/importinstance/SyncImportInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/importinstance/SyncImportInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/importinstance/SyncImportInstanceStringInputconfig.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/importinstance/SyncImportInstanceStringInputconfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/listinstances/AsyncListInstances.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/listinstances/AsyncListInstances.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/listinstances/AsyncListInstancesPaged.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/listinstances/AsyncListInstancesPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/listinstances/SyncListInstances.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/listinstances/SyncListInstances.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/listinstances/SyncListInstancesLocationname.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/listinstances/SyncListInstancesLocationname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/listinstances/SyncListInstancesString.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/listinstances/SyncListInstancesString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/reschedulemaintenance/AsyncRescheduleMaintenance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/reschedulemaintenance/AsyncRescheduleMaintenance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/reschedulemaintenance/AsyncRescheduleMaintenanceLRO.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/reschedulemaintenance/AsyncRescheduleMaintenanceLRO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/reschedulemaintenance/SyncRescheduleMaintenance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/reschedulemaintenance/SyncRescheduleMaintenance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/reschedulemaintenance/SyncRescheduleMaintenanceInstancenameReschedulemaintenancerequestrescheduletypeTimestamp.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/reschedulemaintenance/SyncRescheduleMaintenanceInstancenameReschedulemaintenancerequestrescheduletypeTimestamp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/reschedulemaintenance/SyncRescheduleMaintenanceStringReschedulemaintenancerequestrescheduletypeTimestamp.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/reschedulemaintenance/SyncRescheduleMaintenanceStringReschedulemaintenancerequestrescheduletypeTimestamp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/updateinstance/AsyncUpdateInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/updateinstance/AsyncUpdateInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/updateinstance/AsyncUpdateInstanceLRO.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/updateinstance/AsyncUpdateInstanceLRO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/updateinstance/SyncUpdateInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/updateinstance/SyncUpdateInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/updateinstance/SyncUpdateInstanceFieldmaskInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/updateinstance/SyncUpdateInstanceFieldmaskInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/upgradeinstance/AsyncUpgradeInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/upgradeinstance/AsyncUpgradeInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/upgradeinstance/AsyncUpgradeInstanceLRO.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/upgradeinstance/AsyncUpgradeInstanceLRO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/upgradeinstance/SyncUpgradeInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/upgradeinstance/SyncUpgradeInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/upgradeinstance/SyncUpgradeInstanceInstancenameString.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/upgradeinstance/SyncUpgradeInstanceInstancenameString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/upgradeinstance/SyncUpgradeInstanceStringString.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/upgradeinstance/SyncUpgradeInstanceStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredissettings/getinstance/SyncGetInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredissettings/getinstance/SyncGetInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/stub/cloudredisstubsettings/getinstance/SyncGetInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/stub/cloudredisstubsettings/getinstance/SyncGetInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/CloudRedisClient.java
+++ b/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/CloudRedisClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/CloudRedisClientHttpJsonTest.java
+++ b/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/CloudRedisClientHttpJsonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/CloudRedisClientTest.java
+++ b/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/CloudRedisClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/CloudRedisSettings.java
+++ b/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/CloudRedisSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/InstanceName.java
+++ b/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/InstanceName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/LocationName.java
+++ b/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/LocationName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/MockCloudRedis.java
+++ b/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/MockCloudRedis.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/MockCloudRedisImpl.java
+++ b/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/MockCloudRedisImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/package-info.java
+++ b/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/CloudRedisStub.java
+++ b/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/CloudRedisStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/CloudRedisStubSettings.java
+++ b/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/CloudRedisStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/GrpcCloudRedisCallableFactory.java
+++ b/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/GrpcCloudRedisCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/GrpcCloudRedisStub.java
+++ b/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/GrpcCloudRedisStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/HttpJsonCloudRedisCallableFactory.java
+++ b/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/HttpJsonCloudRedisCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/HttpJsonCloudRedisStub.java
+++ b/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/HttpJsonCloudRedisStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/cancelresumablewrite/AsyncCancelResumableWrite.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/cancelresumablewrite/AsyncCancelResumableWrite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/cancelresumablewrite/SyncCancelResumableWrite.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/cancelresumablewrite/SyncCancelResumableWrite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/cancelresumablewrite/SyncCancelResumableWriteString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/cancelresumablewrite/SyncCancelResumableWriteString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/composeobject/AsyncComposeObject.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/composeobject/AsyncComposeObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/composeobject/SyncComposeObject.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/composeobject/SyncComposeObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/create/SyncCreateSetCredentialsProvider.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/create/SyncCreateSetEndpoint.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createbucket/AsyncCreateBucket.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createbucket/AsyncCreateBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createbucket/SyncCreateBucket.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createbucket/SyncCreateBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createbucket/SyncCreateBucketProjectnameBucketString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createbucket/SyncCreateBucketProjectnameBucketString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createbucket/SyncCreateBucketStringBucketString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createbucket/SyncCreateBucketStringBucketString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createhmackey/AsyncCreateHmacKey.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createhmackey/AsyncCreateHmacKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createhmackey/SyncCreateHmacKey.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createhmackey/SyncCreateHmacKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createhmackey/SyncCreateHmacKeyProjectnameString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createhmackey/SyncCreateHmacKeyProjectnameString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createhmackey/SyncCreateHmacKeyStringString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createhmackey/SyncCreateHmacKeyStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createnotification/AsyncCreateNotification.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createnotification/AsyncCreateNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createnotification/SyncCreateNotification.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createnotification/SyncCreateNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createnotification/SyncCreateNotificationProjectnameNotification.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createnotification/SyncCreateNotificationProjectnameNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createnotification/SyncCreateNotificationStringNotification.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createnotification/SyncCreateNotificationStringNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletebucket/AsyncDeleteBucket.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletebucket/AsyncDeleteBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletebucket/SyncDeleteBucket.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletebucket/SyncDeleteBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletebucket/SyncDeleteBucketBucketname.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletebucket/SyncDeleteBucketBucketname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletebucket/SyncDeleteBucketString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletebucket/SyncDeleteBucketString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletehmackey/AsyncDeleteHmacKey.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletehmackey/AsyncDeleteHmacKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletehmackey/SyncDeleteHmacKey.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletehmackey/SyncDeleteHmacKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletehmackey/SyncDeleteHmacKeyStringProjectname.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletehmackey/SyncDeleteHmacKeyStringProjectname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletehmackey/SyncDeleteHmacKeyStringString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletehmackey/SyncDeleteHmacKeyStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletenotification/AsyncDeleteNotification.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletenotification/AsyncDeleteNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletenotification/SyncDeleteNotification.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletenotification/SyncDeleteNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletenotification/SyncDeleteNotificationNotificationname.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletenotification/SyncDeleteNotificationNotificationname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletenotification/SyncDeleteNotificationString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletenotification/SyncDeleteNotificationString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deleteobject/AsyncDeleteObject.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deleteobject/AsyncDeleteObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deleteobject/SyncDeleteObject.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deleteobject/SyncDeleteObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deleteobject/SyncDeleteObjectStringString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deleteobject/SyncDeleteObjectStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deleteobject/SyncDeleteObjectStringStringLong.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deleteobject/SyncDeleteObjectStringStringLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getbucket/AsyncGetBucket.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getbucket/AsyncGetBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getbucket/SyncGetBucket.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getbucket/SyncGetBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getbucket/SyncGetBucketBucketname.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getbucket/SyncGetBucketBucketname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getbucket/SyncGetBucketString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getbucket/SyncGetBucketString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/gethmackey/AsyncGetHmacKey.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/gethmackey/AsyncGetHmacKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/gethmackey/SyncGetHmacKey.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/gethmackey/SyncGetHmacKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/gethmackey/SyncGetHmacKeyStringProjectname.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/gethmackey/SyncGetHmacKeyStringProjectname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/gethmackey/SyncGetHmacKeyStringString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/gethmackey/SyncGetHmacKeyStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getiampolicy/AsyncGetIamPolicy.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getiampolicy/AsyncGetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getiampolicy/SyncGetIamPolicy.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getiampolicy/SyncGetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getiampolicy/SyncGetIamPolicyResourcename.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getiampolicy/SyncGetIamPolicyResourcename.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getiampolicy/SyncGetIamPolicyString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getiampolicy/SyncGetIamPolicyString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getnotification/AsyncGetNotification.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getnotification/AsyncGetNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getnotification/SyncGetNotification.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getnotification/SyncGetNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getnotification/SyncGetNotificationBucketname.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getnotification/SyncGetNotificationBucketname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getnotification/SyncGetNotificationString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getnotification/SyncGetNotificationString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getobject/AsyncGetObject.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getobject/AsyncGetObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getobject/SyncGetObject.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getobject/SyncGetObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getobject/SyncGetObjectStringString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getobject/SyncGetObjectStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getobject/SyncGetObjectStringStringLong.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getobject/SyncGetObjectStringStringLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getserviceaccount/AsyncGetServiceAccount.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getserviceaccount/AsyncGetServiceAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getserviceaccount/SyncGetServiceAccount.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getserviceaccount/SyncGetServiceAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getserviceaccount/SyncGetServiceAccountProjectname.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getserviceaccount/SyncGetServiceAccountProjectname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getserviceaccount/SyncGetServiceAccountString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getserviceaccount/SyncGetServiceAccountString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listbuckets/AsyncListBuckets.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listbuckets/AsyncListBuckets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listbuckets/AsyncListBucketsPaged.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listbuckets/AsyncListBucketsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listbuckets/SyncListBuckets.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listbuckets/SyncListBuckets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listbuckets/SyncListBucketsProjectname.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listbuckets/SyncListBucketsProjectname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listbuckets/SyncListBucketsString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listbuckets/SyncListBucketsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listhmackeys/AsyncListHmacKeys.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listhmackeys/AsyncListHmacKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listhmackeys/AsyncListHmacKeysPaged.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listhmackeys/AsyncListHmacKeysPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listhmackeys/SyncListHmacKeys.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listhmackeys/SyncListHmacKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listhmackeys/SyncListHmacKeysProjectname.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listhmackeys/SyncListHmacKeysProjectname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listhmackeys/SyncListHmacKeysString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listhmackeys/SyncListHmacKeysString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listnotifications/AsyncListNotifications.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listnotifications/AsyncListNotifications.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listnotifications/AsyncListNotificationsPaged.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listnotifications/AsyncListNotificationsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listnotifications/SyncListNotifications.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listnotifications/SyncListNotifications.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listnotifications/SyncListNotificationsProjectname.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listnotifications/SyncListNotificationsProjectname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listnotifications/SyncListNotificationsString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listnotifications/SyncListNotificationsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listobjects/AsyncListObjects.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listobjects/AsyncListObjects.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listobjects/AsyncListObjectsPaged.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listobjects/AsyncListObjectsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listobjects/SyncListObjects.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listobjects/SyncListObjects.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listobjects/SyncListObjectsProjectname.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listobjects/SyncListObjectsProjectname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listobjects/SyncListObjectsString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listobjects/SyncListObjectsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/lockbucketretentionpolicy/AsyncLockBucketRetentionPolicy.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/lockbucketretentionpolicy/AsyncLockBucketRetentionPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/lockbucketretentionpolicy/SyncLockBucketRetentionPolicy.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/lockbucketretentionpolicy/SyncLockBucketRetentionPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/lockbucketretentionpolicy/SyncLockBucketRetentionPolicyBucketname.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/lockbucketretentionpolicy/SyncLockBucketRetentionPolicyBucketname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/lockbucketretentionpolicy/SyncLockBucketRetentionPolicyString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/lockbucketretentionpolicy/SyncLockBucketRetentionPolicyString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/querywritestatus/AsyncQueryWriteStatus.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/querywritestatus/AsyncQueryWriteStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/querywritestatus/SyncQueryWriteStatus.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/querywritestatus/SyncQueryWriteStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/querywritestatus/SyncQueryWriteStatusString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/querywritestatus/SyncQueryWriteStatusString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/readobject/AsyncReadObject.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/readobject/AsyncReadObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/rewriteobject/AsyncRewriteObject.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/rewriteobject/AsyncRewriteObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/rewriteobject/SyncRewriteObject.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/rewriteobject/SyncRewriteObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/setiampolicy/AsyncSetIamPolicy.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/setiampolicy/AsyncSetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/setiampolicy/SyncSetIamPolicy.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/setiampolicy/SyncSetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/setiampolicy/SyncSetIamPolicyResourcenamePolicy.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/setiampolicy/SyncSetIamPolicyResourcenamePolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/setiampolicy/SyncSetIamPolicyStringPolicy.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/setiampolicy/SyncSetIamPolicyStringPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/startresumablewrite/AsyncStartResumableWrite.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/startresumablewrite/AsyncStartResumableWrite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/startresumablewrite/SyncStartResumableWrite.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/startresumablewrite/SyncStartResumableWrite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/testiampermissions/AsyncTestIamPermissions.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/testiampermissions/AsyncTestIamPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/testiampermissions/SyncTestIamPermissions.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/testiampermissions/SyncTestIamPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/testiampermissions/SyncTestIamPermissionsResourcenameListstring.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/testiampermissions/SyncTestIamPermissionsResourcenameListstring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/testiampermissions/SyncTestIamPermissionsStringListstring.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/testiampermissions/SyncTestIamPermissionsStringListstring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/updatebucket/AsyncUpdateBucket.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/updatebucket/AsyncUpdateBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/updatebucket/SyncUpdateBucket.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/updatebucket/SyncUpdateBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/updatebucket/SyncUpdateBucketBucketFieldmask.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/updatebucket/SyncUpdateBucketBucketFieldmask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/updatehmackey/AsyncUpdateHmacKey.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/updatehmackey/AsyncUpdateHmacKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/updatehmackey/SyncUpdateHmacKey.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/updatehmackey/SyncUpdateHmacKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/updatehmackey/SyncUpdateHmacKeyHmackeymetadataFieldmask.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/updatehmackey/SyncUpdateHmacKeyHmackeymetadataFieldmask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/updateobject/AsyncUpdateObject.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/updateobject/AsyncUpdateObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/updateobject/SyncUpdateObject.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/updateobject/SyncUpdateObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/updateobject/SyncUpdateObjectObjectFieldmask.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/updateobject/SyncUpdateObjectObjectFieldmask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/writeobject/AsyncWriteObject.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/writeobject/AsyncWriteObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storagesettings/deletebucket/SyncDeleteBucket.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storagesettings/deletebucket/SyncDeleteBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/stub/storagestubsettings/deletebucket/SyncDeleteBucket.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/stub/storagestubsettings/deletebucket/SyncDeleteBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/src/com/google/storage/v2/BucketName.java
+++ b/test/integration/goldens/storage/src/com/google/storage/v2/BucketName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/src/com/google/storage/v2/CryptoKeyName.java
+++ b/test/integration/goldens/storage/src/com/google/storage/v2/CryptoKeyName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/src/com/google/storage/v2/MockStorage.java
+++ b/test/integration/goldens/storage/src/com/google/storage/v2/MockStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/src/com/google/storage/v2/MockStorageImpl.java
+++ b/test/integration/goldens/storage/src/com/google/storage/v2/MockStorageImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/src/com/google/storage/v2/NotificationName.java
+++ b/test/integration/goldens/storage/src/com/google/storage/v2/NotificationName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/src/com/google/storage/v2/ProjectName.java
+++ b/test/integration/goldens/storage/src/com/google/storage/v2/ProjectName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/src/com/google/storage/v2/StorageClient.java
+++ b/test/integration/goldens/storage/src/com/google/storage/v2/StorageClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/src/com/google/storage/v2/StorageClientTest.java
+++ b/test/integration/goldens/storage/src/com/google/storage/v2/StorageClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/src/com/google/storage/v2/StorageSettings.java
+++ b/test/integration/goldens/storage/src/com/google/storage/v2/StorageSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/src/com/google/storage/v2/package-info.java
+++ b/test/integration/goldens/storage/src/com/google/storage/v2/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/src/com/google/storage/v2/stub/GrpcStorageCallableFactory.java
+++ b/test/integration/goldens/storage/src/com/google/storage/v2/stub/GrpcStorageCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/src/com/google/storage/v2/stub/GrpcStorageStub.java
+++ b/test/integration/goldens/storage/src/com/google/storage/v2/stub/GrpcStorageStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/src/com/google/storage/v2/stub/StorageStub.java
+++ b/test/integration/goldens/storage/src/com/google/storage/v2/stub/StorageStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/src/com/google/storage/v2/stub/StorageStubSettings.java
+++ b/test/integration/goldens/storage/src/com/google/storage/v2/stub/StorageStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
1.16.1 has been available since start of April 2023. Hopefully a patch bump is not too contentious. Happy to bump to 1.17.0 too, although that seems to only have been available for about 10 days at the time of writing.

- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)

_Output of mvn dependency:tree from the gax-java folder from master:_

![image](https://github.com/googleapis/sdk-platform-java/assets/8066384/c27ac87a-5391-4a29-be2c-719c5cdaee46)

_Output of mvn dependency:tree from the gax-java folder from this branch:_
![image](https://github.com/googleapis/sdk-platform-java/assets/8066384/325406bf-b701-451d-a3f4-019286f08848)
