### PR TITLE
deps: Update dependency com.google.auth:google-auth-library-credentials and google-auth-library-oauth2-http to v1.16.1

### DIFF
--- a/gapic-generator-java-pom-parent/pom.xml
+++ b/gapic-generator-java-pom-parent/pom.xml
@@ -27,7 +27,7 @@
         consistent across modules in this repository -->
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
     <grpc.version>1.55.1</grpc.version>
-    <google.auth.version>1.16.0</google.auth.version>
+    <google.auth.version>1.16.1</google.auth.version>
     <gson.version>2.10.1</gson.version>
     <guava.version>31.1-jre</guava.version>
     <protobuf.version>3.23.1</protobuf.version>

--- a/gax-java/dependencies.properties
+++ b/gax-java/dependencies.properties
@@ -34,8 +34,8 @@ version.io_grpc=1.54.0
 #   2) Replace all characters which are neither alphabetic nor digits with the underscore ('_') character
 maven.com_google_api_grpc_proto_google_common_protos=com.google.api.grpc:proto-google-common-protos:2.15.0
 maven.com_google_api_grpc_grpc_google_common_protos=com.google.api.grpc:grpc-google-common-protos:2.15.0
-maven.com_google_auth_google_auth_library_oauth2_http=com.google.auth:google-auth-library-oauth2-http:1.16.0
-maven.com_google_auth_google_auth_library_credentials=com.google.auth:google-auth-library-credentials:1.16.0
+maven.com_google_auth_google_auth_library_oauth2_http=com.google.auth:google-auth-library-oauth2-http:1.16.1
+maven.com_google_auth_google_auth_library_credentials=com.google.auth:google-auth-library-credentials:1.16.1
 maven.io_opencensus_opencensus_api=io.opencensus:opencensus-api:0.31.1
 maven.io_opencensus_opencensus_contrib_grpc_metrics=io.opencensus:opencensus-contrib-grpc-metrics:0.31.1
 maven.io_opencensus_opencensus_contrib_http_util=io.opencensus:opencensus-contrib-http-util:0.31.1


### PR DESCRIPTION
1.16.1 has been available since start of April 2023. Hopefully a patch bump is not too contentious. Happy to bump to 1.17.0 too, although that seems to only have been available for about 10 days at the time of writing.

- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)

_Output of mvn dependency:tree from the gax-java folder from master:_

![image](https://github.com/googleapis/sdk-platform-java/assets/8066384/c27ac87a-5391-4a29-be2c-719c5cdaee46)

_Output of mvn dependency:tree from the gax-java folder from this branch:_
![image](https://github.com/googleapis/sdk-platform-java/assets/8066384/325406bf-b701-451d-a3f4-019286f08848)