### PR TITLE
chore: eliminate duplicate guava version declarations

### DIFF
--- a/coverage-report/pom.xml
+++ b/coverage-report/pom.xml
@@ -41,7 +41,7 @@
             <dependency>
                 <groupId>com.google.api</groupId>
                 <artifactId>gax-httpjson</artifactId>
-                <version>0.114.1-SNAPSHOT</version> <!-- {x-version-update:gax-httpjson:current} -->
+                <version>2.29.1-SNAPSHOT</version> <!-- {x-version-update:gax:current} -->
             </dependency>
             <dependency>
                 <groupId>com.google.api</groupId>

--- a/gapic-generator-java/pom.xml
+++ b/gapic-generator-java/pom.xml
@@ -382,7 +382,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>32.0.0-jre</version>
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>

--- a/gapic-generator-java/pom.xml
+++ b/gapic-generator-java/pom.xml
@@ -382,7 +382,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>31.1-jre</version>
+      <version>32.0.0-jre</version>
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>

--- a/gax-java/dependencies.properties
+++ b/gax-java/dependencies.properties
@@ -16,7 +16,7 @@ version.gax_grpc=2.29.1-SNAPSHOT
 # {x-version-update-start:gax:current}
 version.gax_bom=2.29.1-SNAPSHOT
 # {x-version-update-end}
-# {x-version-update-start:gax-httpjson:current}
+# {x-version-update-start:gax:current}
 version.gax_httpjson=2.29.1-SNAPSHOT
 # {x-version-update-end}
 

--- a/gax-java/dependencies.properties
+++ b/gax-java/dependencies.properties
@@ -17,7 +17,7 @@ version.gax_grpc=2.29.1-SNAPSHOT
 version.gax_bom=2.29.1-SNAPSHOT
 # {x-version-update-end}
 # {x-version-update-start:gax-httpjson:current}
-version.gax_httpjson=0.114.1-SNAPSHOT
+version.gax_httpjson=2.29.1-SNAPSHOT
 # {x-version-update-end}
 
 # Versions for dependencies which actual artifacts differ between Bazel and Gradle.

--- a/gax-java/gax-bom/pom.xml
+++ b/gax-java/gax-bom/pom.xml
@@ -79,19 +79,19 @@
       <dependency>
         <groupId>com.google.api</groupId>
         <artifactId>gax-httpjson</artifactId>
-        <version>0.114.1-SNAPSHOT</version><!-- {x-version-update:gax-httpjson:current} -->
+        <version>2.29.1-SNAPSHOT</version><!-- {x-version-update:gax:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api</groupId>
         <artifactId>gax-httpjson</artifactId>
-        <version>0.114.1-SNAPSHOT</version><!-- {x-version-update:gax-httpjson:current} -->
+        <version>2.29.1-SNAPSHOT</version><!-- {x-version-update:gax:current} -->
         <type>test-jar</type>
         <classifier>testlib</classifier>
       </dependency>
       <dependency>
         <groupId>com.google.api</groupId>
         <artifactId>gax-httpjson</artifactId>
-        <version>0.114.1-SNAPSHOT</version><!-- {x-version-update:gax-httpjson:current} -->
+        <version>2.29.1-SNAPSHOT</version><!-- {x-version-update:gax:current} -->
         <classifier>testlib</classifier>
       </dependency>
     </dependencies>

--- a/gax-java/gax-httpjson/pom.xml
+++ b/gax-java/gax-httpjson/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>gax-httpjson</artifactId>
-  <version>0.114.1-SNAPSHOT</version> <!-- {x-version-update:gax-httpjson:current} -->
+  <version>2.29.1-SNAPSHOT</version> <!-- {x-version-update:gax:current} -->
   <packaging>jar</packaging>
   <name>GAX (Google Api eXtensions) for Java (HTTP JSON)</name>
   <description>Google Api eXtensions for Java (HTTP JSON)</description>

--- a/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ApiMethodDescriptor.java
+++ b/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ApiMethodDescriptor.java
@@ -29,11 +29,9 @@
  */
 package com.google.api.gax.httpjson;
 
-import com.google.api.core.BetaApi;
 import com.google.auto.value.AutoValue;
 import javax.annotation.Nullable;
 
-@BetaApi
 @AutoValue
 /* Method descriptor for messages to be transmitted over HTTP. */
 public abstract class ApiMethodDescriptor<RequestT, ResponseT> {

--- a/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ForwardingHttpJsonClientCall.java
+++ b/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ForwardingHttpJsonClientCall.java
@@ -29,14 +29,12 @@
  */
 package com.google.api.gax.httpjson;
 
-import com.google.api.core.BetaApi;
 import javax.annotation.Nullable;
 
 /**
  * A {@link HttpJsonClientCall} which forwards all of its methods to another {@link
  * HttpJsonClientCall}.
  */
-@BetaApi
 public abstract class ForwardingHttpJsonClientCall<RequestT, ResponseT>
     extends HttpJsonClientCall<RequestT, ResponseT> {
 

--- a/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ForwardingHttpJsonClientCallListener.java
+++ b/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ForwardingHttpJsonClientCallListener.java
@@ -30,13 +30,10 @@
 
 package com.google.api.gax.httpjson;
 
-import com.google.api.core.BetaApi;
-
 /**
  * A {@link HttpJsonClientCall.Listener} which forwards all of its methods to another {@link
  * HttpJsonClientCall.Listener}.
  */
-@BetaApi
 public abstract class ForwardingHttpJsonClientCallListener<ResponseT>
     extends HttpJsonClientCall.Listener<ResponseT> {
 

--- a/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
+++ b/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
@@ -59,7 +59,6 @@ import org.threeten.bp.Instant;
  * copies of the object, but with one field changed. The immutability and thread safety of the
  * arguments solely depends on the arguments themselves.
  */
-@BetaApi("Reference ApiCallContext instead - this class is likely to experience breaking changes")
 public final class HttpJsonCallContext implements ApiCallContext {
   private final HttpJsonChannel channel;
   private final HttpJsonCallOptions callOptions;

--- a/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallOptions.java
+++ b/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallOptions.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.httpjson;
 
-import com.google.api.core.BetaApi;
 import com.google.auth.Credentials;
 import com.google.auto.value.AutoValue;
 import com.google.protobuf.TypeRegistry;
@@ -38,7 +37,6 @@ import javax.annotation.Nullable;
 import org.threeten.bp.Instant;
 
 /** Options for an http-json call, including deadline and credentials. */
-@BetaApi
 @AutoValue
 public abstract class HttpJsonCallOptions {
   public static final HttpJsonCallOptions DEFAULT = newBuilder().build();

--- a/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonChannel.java
+++ b/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonChannel.java
@@ -29,10 +29,7 @@
  */
 package com.google.api.gax.httpjson;
 
-import com.google.api.core.BetaApi;
-
 /** HttpJsonChannel contains the functionality to issue http-json calls. */
-@BetaApi
 public interface HttpJsonChannel {
   <RequestT, ResponseT> HttpJsonClientCall<RequestT, ResponseT> newCall(
       ApiMethodDescriptor<RequestT, ResponseT> methodDescriptor, HttpJsonCallOptions callOptions);

--- a/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonClientCall.java
+++ b/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonClientCall.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.httpjson;
 
-import com.google.api.core.BetaApi;
 import javax.annotation.Nullable;
 
 // This class mimics the structure and behavior of the corresponding ClientCall from gRPC package as
@@ -58,7 +57,6 @@ import javax.annotation.Nullable;
  * @param <RequestT> type of message sent to the server
  * @param <ResponseT> type of message received one or more times from the server
  */
-@BetaApi
 public abstract class HttpJsonClientCall<RequestT, ResponseT> {
   /**
    * Callbacks for receiving metadata, response messages and completion status from the server.
@@ -67,7 +65,6 @@ public abstract class HttpJsonClientCall<RequestT, ResponseT> {
    * not required to be thread-safe, but they must not be thread-hostile. The caller is free to call
    * an instance from multiple threads, but only one call simultaneously.
    */
-  @BetaApi
   public abstract static class Listener<T> {
     /**
      * The response headers have been received. Headers always precede messages.

--- a/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonClientInterceptor.java
+++ b/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonClientInterceptor.java
@@ -29,8 +29,6 @@
  */
 package com.google.api.gax.httpjson;
 
-import com.google.api.core.BetaApi;
-
 /**
  * Interface for intercepting outgoing calls before they are dispatched by a {@link
  * HttpJsonChannel}.
@@ -38,7 +36,6 @@ import com.google.api.core.BetaApi;
  * <p>The interceptor may be called for multiple {@link HttpJsonClientCall calls} by one or more
  * threads without completing the previous ones first. The implementations must be thread-safe.
  */
-@BetaApi
 public interface HttpJsonClientInterceptor {
   /**
    * Intercept {@link HttpJsonClientCall} creation by the {@code next} {@link HttpJsonChannel}.

--- a/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonHeaderEnhancer.java
+++ b/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonHeaderEnhancer.java
@@ -30,10 +30,8 @@
 package com.google.api.gax.httpjson;
 
 import com.google.api.client.http.HttpHeaders;
-import com.google.api.core.BetaApi;
 
 /** Interface for functionality to enhance headers for an http-json call. */
-@BetaApi
 public interface HttpJsonHeaderEnhancer {
   void enhance(HttpHeaders headers);
 }

--- a/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonHeaderEnhancers.java
+++ b/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonHeaderEnhancers.java
@@ -30,10 +30,8 @@
 package com.google.api.gax.httpjson;
 
 import com.google.api.client.http.HttpHeaders;
-import com.google.api.core.BetaApi;
 
 /** Utility class that creates instances of {@link HttpJsonHeaderEnhancer}. */
-@BetaApi
 public class HttpJsonHeaderEnhancers {
 
   private HttpJsonHeaderEnhancers() {}

--- a/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonInterceptorProvider.java
+++ b/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonInterceptorProvider.java
@@ -29,12 +29,9 @@
  */
 package com.google.api.gax.httpjson;
 
-import com.google.api.core.BetaApi;
 import java.util.List;
 
 /** Provider of custom REST ClientInterceptors. */
-@BetaApi(
-    "The surface for adding custom interceptors is not stable yet and may change in the future.")
 public interface HttpJsonInterceptorProvider {
 
   /**

--- a/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonMetadata.java
+++ b/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonMetadata.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.httpjson;
 
-import com.google.api.core.BetaApi;
 import com.google.api.core.InternalExtensionOnly;
 import com.google.auto.value.AutoValue;
 import java.util.Collections;
@@ -39,7 +38,6 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 @AutoValue
-@BetaApi
 @InternalExtensionOnly
 public abstract class HttpJsonMetadata {
   public abstract Map<String, Object> getHeaders();

--- a/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonOperationSnapshot.java
+++ b/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonOperationSnapshot.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.httpjson;
 
-import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import com.google.api.gax.longrunning.OperationSnapshot;
 import com.google.api.gax.rpc.StatusCode;
@@ -41,7 +40,6 @@ import com.google.longrunning.Operation;
  *
  * <p>Public for technical reasons. For internal use only.
  */
-@BetaApi
 @InternalApi
 public class HttpJsonOperationSnapshot implements OperationSnapshot {
   private final String name;

--- a/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonOperationSnapshotCallable.java
+++ b/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonOperationSnapshotCallable.java
@@ -34,7 +34,6 @@ import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
-import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import com.google.api.gax.longrunning.OperationSnapshot;
 import com.google.api.gax.rpc.ApiCallContext;
@@ -46,7 +45,6 @@ import com.google.api.gax.rpc.UnaryCallable;
  *
  * <p>Public for technical reasons. For internal use only.
  */
-@BetaApi
 @InternalApi
 public class HttpJsonOperationSnapshotCallable<RequestT, OperationT>
     extends UnaryCallable<RequestT, OperationSnapshot> {

--- a/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonStatusCode.java
+++ b/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonStatusCode.java
@@ -29,13 +29,11 @@
  */
 package com.google.api.gax.httpjson;
 
-import com.google.api.core.BetaApi;
 import com.google.api.core.InternalExtensionOnly;
 import com.google.api.gax.rpc.StatusCode;
 import java.util.Objects;
 
 /** A failure code specific to an HTTP call. */
-@BetaApi
 @InternalExtensionOnly
 public class HttpJsonStatusCode implements StatusCode {
   private final int httpStatus;

--- a/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpRequestFormatter.java
+++ b/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpRequestFormatter.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.httpjson;
 
-import com.google.api.core.BetaApi;
 import com.google.api.pathtemplate.PathTemplate;
 import java.util.Collections;
 import java.util.List;
@@ -52,7 +51,6 @@ public interface HttpRequestFormatter<MessageFormatT> {
   PathTemplate getPathTemplate();
 
   /** Additional (alternative) path templates for endpoint URL path. */
-  @BetaApi
   default List<PathTemplate> getAdditionalPathTemplates() {
     return Collections.emptyList();
   }

--- a/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/InstantiatingHttpJsonChannelProvider.java
+++ b/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/InstantiatingHttpJsonChannelProvider.java
@@ -31,7 +31,6 @@ package com.google.api.gax.httpjson;
 
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
-import com.google.api.core.BetaApi;
 import com.google.api.core.InternalExtensionOnly;
 import com.google.api.gax.core.ExecutorProvider;
 import com.google.api.gax.rpc.FixedHeaderProvider;
@@ -59,7 +58,6 @@ import java.util.concurrent.ScheduledExecutorService;
  * <p>The client lib header and generator header values are used to form a value that goes into the
  * http header of requests to the service.
  */
-@BetaApi
 @InternalExtensionOnly
 public final class InstantiatingHttpJsonChannelProvider implements TransportChannelProvider {
 

--- a/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ManagedHttpJsonChannel.java
+++ b/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ManagedHttpJsonChannel.java
@@ -31,7 +31,6 @@ package com.google.api.gax.httpjson;
 
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
-import com.google.api.core.BetaApi;
 import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
 import com.google.common.annotations.VisibleForTesting;
@@ -45,7 +44,6 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 /** Implementation of HttpJsonChannel which can issue http-json calls. */
-@BetaApi
 public class ManagedHttpJsonChannel implements HttpJsonChannel, BackgroundResource {
 
   private final Executor executor;

--- a/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ManagedHttpJsonInterceptorChannel.java
+++ b/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ManagedHttpJsonInterceptorChannel.java
@@ -29,11 +29,9 @@
  */
 package com.google.api.gax.httpjson;
 
-import com.google.api.core.BetaApi;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.concurrent.TimeUnit;
 
-@BetaApi
 class ManagedHttpJsonInterceptorChannel extends ManagedHttpJsonChannel {
 
   private final ManagedHttpJsonChannel channel;

--- a/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ProtoMessageRequestFormatter.java
+++ b/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ProtoMessageRequestFormatter.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.httpjson;
 
-import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import com.google.api.pathtemplate.PathTemplate;
 import com.google.protobuf.Message;
@@ -121,7 +120,6 @@ public class ProtoMessageRequestFormatter<RequestT extends Message>
     return path;
   }
 
-  @BetaApi
   @Override
   public List<PathTemplate> getAdditionalPathTemplates() {
     return additionalPathTemplates;
@@ -161,7 +159,6 @@ public class ProtoMessageRequestFormatter<RequestT extends Message>
       return this;
     }
 
-    @BetaApi
     public Builder<RequestT> setAdditionalPaths(String... rawAdditionalPaths) {
       this.rawAdditionalPaths = Arrays.asList(rawAdditionalPaths);
       return this;

--- a/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ProtoRestSerializer.java
+++ b/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ProtoRestSerializer.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.httpjson;
 
-import com.google.api.core.BetaApi;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
@@ -50,7 +49,6 @@ import java.util.Map;
  * URL path parameters, and query parameters. It deserializes JSON responses into response protobuf
  * message.
  */
-@BetaApi
 public class ProtoRestSerializer<RequestT extends Message> {
 
   private final TypeRegistry registry;

--- a/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/RestSerializationException.java
+++ b/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/RestSerializationException.java
@@ -29,13 +29,10 @@
  */
 package com.google.api.gax.httpjson;
 
-import com.google.api.core.BetaApi;
-
 /**
  * An exception thrown when a protobuf message cannot be serialized/deserialized for REST
  * interactions.
  */
-@BetaApi
 public class RestSerializationException extends RuntimeException {
 
   private static final long serialVersionUID = -6485633460933364916L;

--- a/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/longrunning/OperationsClient.java
+++ b/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/longrunning/OperationsClient.java
@@ -32,7 +32,6 @@ package com.google.api.gax.httpjson.longrunning;
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
-import com.google.api.core.BetaApi;
 import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.httpjson.longrunning.stub.OperationsStub;
 import com.google.api.gax.httpjson.longrunning.stub.OperationsStubSettings;
@@ -120,7 +119,6 @@ import java.util.concurrent.TimeUnit;
  *
  * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
  */
-@BetaApi
 public class OperationsClient implements BackgroundResource {
   private final OperationsSettings settings;
   private final OperationsStub stub;
@@ -163,7 +161,6 @@ public class OperationsClient implements BackgroundResource {
     this.stub = ((OperationsStubSettings) settings.getStubSettings()).createStub();
   }
 
-  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
   protected OperationsClient(OperationsStub stub) {
     this.settings = null;
     this.stub = stub;
@@ -173,7 +170,6 @@ public class OperationsClient implements BackgroundResource {
     return settings;
   }
 
-  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
   public OperationsStub getStub() {
     return stub;
   }

--- a/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/longrunning/OperationsSettings.java
+++ b/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/longrunning/OperationsSettings.java
@@ -32,7 +32,6 @@ package com.google.api.gax.httpjson.longrunning;
 import static com.google.api.gax.httpjson.longrunning.OperationsClient.ListOperationsPagedResponse;
 
 import com.google.api.core.ApiFunction;
-import com.google.api.core.BetaApi;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
 import com.google.api.gax.httpjson.InstantiatingHttpJsonChannelProvider;
@@ -84,7 +83,6 @@ import java.util.List;
  * OperationsSettings operationsSettings = operationsSettingsBuilder.build();
  * }</pre>
  */
-@BetaApi
 public class OperationsSettings extends ClientSettings<OperationsSettings> {
 
   /** Returns the object with the settings used for calls to listOperations. */

--- a/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/longrunning/stub/HttpJsonOperationsCallableFactory.java
+++ b/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/longrunning/stub/HttpJsonOperationsCallableFactory.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.httpjson.longrunning.stub;
 
-import com.google.api.core.BetaApi;
 import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.httpjson.HttpJsonCallSettings;
 import com.google.api.gax.httpjson.HttpJsonCallableFactory;
@@ -49,7 +48,6 @@ import com.google.longrunning.Operation;
  *
  * <p>This class is for advanced usage.
  */
-@BetaApi
 public class HttpJsonOperationsCallableFactory
     implements HttpJsonStubCallableFactory<Operation, BackgroundResource> {
 

--- a/java-common-protos/pom.xml
+++ b/java-common-protos/pom.xml
@@ -54,7 +54,7 @@
     <github.global.server>github</github.global.server>
     <site.installationModule>google-iam-parent</site.installationModule>
     <junit.version>4.13.2</junit.version>
-    <guava.version>31.1-jre</guava.version>
+    <guava.version>32.0.0-jre</guava.version>
   </properties>
 
   <dependencyManagement>

--- a/java-common-protos/pom.xml
+++ b/java-common-protos/pom.xml
@@ -54,7 +54,6 @@
     <github.global.server>github</github.global.server>
     <site.installationModule>google-iam-parent</site.installationModule>
     <junit.version>4.13.2</junit.version>
-    <guava.version>32.0.0-jre</guava.version>
   </properties>
 
   <dependencyManagement>

--- a/java-shared-dependencies/dependency-convergence-check/pom.xml
+++ b/java-shared-dependencies/dependency-convergence-check/pom.xml
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>31.0.1-jre</version>
+      <version>32.0.0-jre</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/java-shared-dependencies/dependency-convergence-check/pom.xml
+++ b/java-shared-dependencies/dependency-convergence-check/pom.xml
@@ -21,7 +21,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>32.0.0-jre</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -33,6 +32,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/rules_java_gapic/java_gapic_pkg.bzl
+++ b/rules_java_gapic/java_gapic_pkg.bzl
@@ -25,7 +25,8 @@ def _wrapPropertyNamesInBraces(properties):
 # the version of protobuf defined in googleapis is higher than protobuf
 # defined in gax-java/dependencies.properties, use this replacement to
 # sync the two versions.
-SYNCED_PROPERTIES = PROPERTIES | {"version.com_google_protobuf": PROTOBUF_JAVA_VERSION}
+SYNCED_PROPERTIES = dict(PROPERTIES)
+SYNCED_PROPERTIES.update({"version.com_google_protobuf": PROTOBUF_JAVA_VERSION})
 _PROPERTIES = _wrapPropertyNamesInBraces(SYNCED_PROPERTIES)
 
 # ========================================================================

--- a/versions.txt
+++ b/versions.txt
@@ -5,7 +5,7 @@ gapic-generator-java:2.21.0:2.21.1-SNAPSHOT
 api-common:2.12.0:2.12.1-SNAPSHOT
 gax:2.29.0:2.29.1-SNAPSHOT
 gax-grpc:2.29.0:2.29.1-SNAPSHOT
-gax-httpjson:0.114.0:0.114.1-SNAPSHOT
+gax-httpjson:0.114.0:2.29.1-SNAPSHOT
 proto-google-common-protos:2.20.0:2.20.1-SNAPSHOT
 grpc-google-common-protos:2.20.0:2.20.1-SNAPSHOT
 proto-google-iam-v1:1.15.0:1.15.1-SNAPSHOT


### PR DESCRIPTION
The guava version is now exclusively defined at https://github.com/googleapis/sdk-platform-java/blob/main/gapic-generator-java-pom-parent/pom.xml#L32