### PR TITLE
chore: copy and update PROPERTIES using widely supported syntax

### DIFF
--- a/rules_java_gapic/java_gapic_pkg.bzl
+++ b/rules_java_gapic/java_gapic_pkg.bzl
@@ -25,7 +25,8 @@ def _wrapPropertyNamesInBraces(properties):
 # the version of protobuf defined in googleapis is higher than protobuf
 # defined in gax-java/dependencies.properties, use this replacement to
 # sync the two versions.
-SYNCED_PROPERTIES = PROPERTIES | {"version.com_google_protobuf": PROTOBUF_JAVA_VERSION}
+SYNCED_PROPERTIES = dict(PROPERTIES)
+SYNCED_PROPERTIES.update({"version.com_google_protobuf": PROTOBUF_JAVA_VERSION})
 _PROPERTIES = _wrapPropertyNamesInBraces(SYNCED_PROPERTIES)
 
 # ========================================================================


### PR DESCRIPTION
The `dict | dict` syntax is only supported in Python 3.9+ which is not available in all test environments.

This PR uses a syntax that is supported more widely.