### PR TITLE
feat: add library generation tools

### DIFF
--- a/library_generation/compare.sh
+++ b/library_generation/compare.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+PROTO_PATH=$1
+IS_CLOUD_SDK=$2
+OUT_LAYER_FOLDER="${PROTO_PATH////-}-java"
+if [ "${IS_CLOUD_SDK}" == true ]; then
+  OUT_LAYER_FOLDER="${OUT_LAYER_FOLDER//google/google-cloud}"
+fi
+
+GOLDEN_ROOT=$(dirname "$(readlink -f "$0")")/golden
+LIBRARY_GEN_OUT="${GOLDEN_ROOT}"/../../library_gen_out
+
+# exclude gradle files since we do not use them.
+diff -r "${GOLDEN_ROOT}"/"${OUT_LAYER_FOLDER}"/ "${LIBRARY_GEN_OUT}"/"${PROTO_PATH}"/"${OUT_LAYER_FOLDER}" -x "*gradle*"

--- a/library_generation/gapic-generator-java-wrapper
+++ b/library_generation/gapic-generator-java-wrapper
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+
+# the script is running in google-cloud-java/googleapis.
+JAR_PATH=$(pwd)
+
+exec java -classpath "${JAR_PATH}"/../library_gen_out/gapic-generator-java.jar com.google.api.generator.Main

--- a/library_generation/generate_library.sh
+++ b/library_generation/generate_library.sh
@@ -192,3 +192,8 @@ for proto_src in ${PROTO_FILES}; do
     mkdir -p "${LIBRARY_GEN_OUT}"/"${PROTO_PATH}"/"${OUT_LAYER_FOLDER}"/proto-"${OUT_LAYER_FOLDER}"/src/main/proto
     cp -f --parents "${proto_src}" "${LIBRARY_GEN_OUT}"/"${PROTO_PATH}"/"${OUT_LAYER_FOLDER}"/proto-"${OUT_LAYER_FOLDER}"/src/main/proto
 done
+##################### Section 4 #####################
+# rm tar files
+#####################################################
+cd "${LIBRARY_GEN_OUT}/${PROTO_PATH}"
+rm -rf java_gapic_srcjar java_gapic_srcjar_raw.srcjar.zip java_grpc.jar java_proto.jar temp-codegen.srcjar

--- a/library_generation/generate_library.sh
+++ b/library_generation/generate_library.sh
@@ -42,18 +42,24 @@ git checkout "${GOOGLEAPIS_COMMIT}"
 PROTO_FILES=$(find "${PROTO_PATH}" -type f  -name "*.proto" | sort)
 # pull proto files and protoc from protobuf repository
 # maven central doesn't have proto files
-cd "${LIBRARY_GEN_OUT}"
-curl -LJ -o protobuf.zip https://github.com/protocolbuffers/protobuf/releases/download/v"${PROTOBUF_VERSION}"/protoc-"${PROTOBUF_VERSION}"-linux-x86_64.zip
-unzip -o -q protobuf.zip -d protobuf/
-cp -r protobuf/include/google "${GOOGLEAPIS_ROOT}"
 PROTOC_ROOT=${LIBRARY_GEN_OUT}/protobuf/bin
-echo "protoc version: $("${PROTOC_ROOT}"/protoc --version)"
+cd "${LIBRARY_GEN_OUT}"
+if [ ! -d protobuf ]; then
+  curl -LJ -o protobuf.zip https://github.com/protocolbuffers/protobuf/releases/download/v"${PROTOBUF_VERSION}"/protoc-"${PROTOBUF_VERSION}"-linux-x86_64.zip
+  unzip -o -q protobuf.zip -d protobuf/
+  cp -r protobuf/include/google "${GOOGLEAPIS_ROOT}"
+  echo "protoc version: $("${PROTOC_ROOT}"/protoc --version)"
+fi
 # pull protoc-gen-grpc-java plugin from maven central
 cd "${LIBRARY_GEN_OUT}"
-curl -LJ -o protoc-gen-grpc-java https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/"${GRPC_VERSION}"/protoc-gen-grpc-java-"${GRPC_VERSION}"-linux-x86_64.exe
-chmod +x protoc-gen-grpc-java
+if [ ! -f protoc-gen-grpc-java ]; then
+  curl -LJ -o protoc-gen-grpc-java https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/"${GRPC_VERSION}"/protoc-gen-grpc-java-"${GRPC_VERSION}"-linux-x86_64.exe
+  chmod +x protoc-gen-grpc-java
+fi
 # gapic-generator-java
-curl -LJ -o gapic-generator-java.jar https://repo1.maven.org/maven2/com/google/api/gapic-generator-java/"${GAPIC_GENERATOR_VERSION}"/gapic-generator-java-"${GAPIC_GENERATOR_VERSION}".jar
+if [ ! -f gapic-generator-java.jar ]; then
+  curl -LJ -o gapic-generator-java.jar https://repo1.maven.org/maven2/com/google/api/gapic-generator-java/"${GAPIC_GENERATOR_VERSION}"/gapic-generator-java-"${GAPIC_GENERATOR_VERSION}".jar
+fi
 # define utility functions
 remove_empty_files() {
   FOLDER=$1

--- a/library_generation/generate_library.sh
+++ b/library_generation/generate_library.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+
+set -xe
+
+GOOGLEAPIS_COMMIT=$1
+PROTOBUF_VERSION=$2
+GRPC_VERSION=$3
+GAPIC_GENERATOR_VERSION=$4
+PROTO_PATH=$5
+CONTAINS_CLOUD=$6
+TRANSPORT=$7 # grpc+rest or grpc
+REST_NUMERIC_ENUMS=$8 # true or false
+INCLUDE_SAMPLES=$9 # true or false
+if [ -z "${INCLUDE_SAMPLES}" ]; then
+  INCLUDE_SAMPLES="true"
+fi
+OUT_LAYER_FOLDER="${PROTO_PATH////-}-java"
+if [ "${CONTAINS_CLOUD}" == true ]; then
+  OUT_LAYER_FOLDER="${OUT_LAYER_FOLDER//google/google-cloud}"
+fi
+
+LIBRARY_GEN_OUT=$(dirname "$(readlink -f "$0")")/../library_gen_out
+REPO_ROOT="${LIBRARY_GEN_OUT}"/..
+mkdir -p "${LIBRARY_GEN_OUT}/${PROTO_PATH}"
+
+##################### Section 0 #####################
+# prepare tooling
+#####################################################
+# proto files from googleapis repository
+cd "${REPO_ROOT}"
+
+if [ ! -d googleapis ]; then
+  git clone https://github.com/googleapis/googleapis.git
+fi
+
+GOOGLEAPIS_ROOT=${REPO_ROOT}/googleapis
+cd "${GOOGLEAPIS_ROOT}"
+git checkout "${GOOGLEAPIS_COMMIT}"
+# the order of services entries in gapic_metadata.json is relevant to the
+# order of proto file, sort the proto files with respect to their name to
+# get a fixed order.
+PROTO_FILES=$(find "${PROTO_PATH}" -type f  -name "*.proto" | sort)
+# pull proto files and protoc from protobuf repository
+# maven central doesn't have proto files
+cd "${LIBRARY_GEN_OUT}"
+curl -LJ -o protobuf.zip https://github.com/protocolbuffers/protobuf/releases/download/v"${PROTOBUF_VERSION}"/protoc-"${PROTOBUF_VERSION}"-linux-x86_64.zip
+unzip -o -q protobuf.zip -d protobuf/
+cp -r protobuf/include/google "${GOOGLEAPIS_ROOT}"
+PROTOC_ROOT=${LIBRARY_GEN_OUT}/protobuf/bin
+echo "protoc version: $("${PROTOC_ROOT}"/protoc --version)"
+# pull protoc-gen-grpc-java plugin from maven central
+cd "${LIBRARY_GEN_OUT}"
+curl -LJ -o protoc-gen-grpc-java https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/"${GRPC_VERSION}"/protoc-gen-grpc-java-"${GRPC_VERSION}"-linux-x86_64.exe
+chmod +x protoc-gen-grpc-java
+# gapic-generator-java
+curl -LJ -o gapic-generator-java.jar https://repo1.maven.org/maven2/com/google/api/gapic-generator-java/"${GAPIC_GENERATOR_VERSION}"/gapic-generator-java-"${GAPIC_GENERATOR_VERSION}".jar
+# define utility functions
+remove_empty_files() {
+  FOLDER=$1
+  find "${LIBRARY_GEN_OUT}"/"${PROTO_PATH}"/"${OUT_LAYER_FOLDER}"/"${FOLDER}"-"${OUT_LAYER_FOLDER}"/src/main/java -type f -size 0 | while read -r f; do rm -f "${f}"; done
+  if [ -d "${LIBRARY_GEN_OUT}"/"${PROTO_PATH}"/"${OUT_LAYER_FOLDER}"/"${FOLDER}"-"${OUT_LAYER_FOLDER}"/src/main/java/samples ]; then
+      mv "${LIBRARY_GEN_OUT}"/"${PROTO_PATH}"/"${OUT_LAYER_FOLDER}"/"${FOLDER}"-"${OUT_LAYER_FOLDER}"/src/main/java/samples "${LIBRARY_GEN_OUT}"/"${PROTO_PATH}"/"${OUT_LAYER_FOLDER}"/"${FOLDER}"-"${OUT_LAYER_FOLDER}"
+  fi
+}
+
+mv_src_files() {
+  FOLDER=$1 # one of gapic, proto, samples
+  TYPE=$2 # one of main, test
+  if [ "${FOLDER}" == "samples" ]; then
+    FOLDER_SUFFIX="samples/snippets/generated"
+    SRC_SUFFIX="samples/snippets/generated/src/main/java/com"
+  elif [ "${FOLDER}" == "proto" ]; then
+    FOLDER_SUFFIX="${FOLDER}"-"${OUT_LAYER_FOLDER}"/src/"${TYPE}"
+    SRC_SUFFIX="${FOLDER}/src/${TYPE}/java"
+  else
+    FOLDER_SUFFIX="${FOLDER}"-"${OUT_LAYER_FOLDER}"/src/"${TYPE}"
+    SRC_SUFFIX="src/${TYPE}/java"
+  fi
+  mkdir -p "${LIBRARY_GEN_OUT}"/"${PROTO_PATH}"/"${OUT_LAYER_FOLDER}"/"${FOLDER_SUFFIX}"
+  cp -r "${LIBRARY_GEN_OUT}"/"${PROTO_PATH}"/java_gapic_srcjar/"${SRC_SUFFIX}" "${LIBRARY_GEN_OUT}"/"${PROTO_PATH}"/"${OUT_LAYER_FOLDER}"/"${FOLDER_SUFFIX}"
+  if [ "${FOLDER}" != "samples" ]; then
+    rm -r -f "${LIBRARY_GEN_OUT}"/"${PROTO_PATH}"/"${OUT_LAYER_FOLDER}"/"${FOLDER_SUFFIX}"/java/META-INF
+  fi
+}
+
+unzip_src_files() {
+  FOLDER=$1
+  JAR_FILE=java_"${FOLDER}".jar
+  mkdir -p "${LIBRARY_GEN_OUT}"/"${PROTO_PATH}"/"${OUT_LAYER_FOLDER}"/"${FOLDER}"-"${OUT_LAYER_FOLDER}"/src/main/java
+  unzip -q -o "${LIBRARY_GEN_OUT}"/"${PROTO_PATH}"/"${JAR_FILE}" -d "${LIBRARY_GEN_OUT}"/"${PROTO_PATH}"/"${OUT_LAYER_FOLDER}"/"${FOLDER}"-"${OUT_LAYER_FOLDER}"/src/main/java
+  rm -r -f "${LIBRARY_GEN_OUT}"/"${PROTO_PATH}"/"${OUT_LAYER_FOLDER}"/"${FOLDER}"-"${OUT_LAYER_FOLDER}"/src/main/java/META-INF
+}
+
+find_additional_protos_in_yaml() {
+  PATTERN=$1
+  FIND_RESULT=$(grep --include=\*.yaml -rw "${PROTO_PATH}" -e "${PATTERN}")
+  if [ -n "${FIND_RESULT}" ]; then
+    echo "${FIND_RESULT}"
+  fi
+}
+
+search_additional_protos() {
+  ADDITIONAL_PROTOS="google/cloud/common_resources.proto" # used by every library
+  IAM_POLICY=$(find_additional_protos_in_yaml "name: google.iam.v1.IAMPolicy")
+  if [ -n "${IAM_POLICY}" ]; then
+    ADDITIONAL_PROTOS="${ADDITIONAL_PROTOS} google/iam/v1/iam_policy.proto"
+  fi
+  LOCATIONS=$(find_additional_protos_in_yaml "name: google.cloud.location.Locations")
+  if [ -n "${LOCATIONS}" ]; then
+    ADDITIONAL_PROTOS="${ADDITIONAL_PROTOS} google/cloud/location/locations.proto"
+  fi
+  echo "${ADDITIONAL_PROTOS}"
+}
+
+get_gapic_opts() {
+  GAPIC_CONFIG=$(find "${PROTO_PATH}" -type f -name "*gapic.yaml")
+  if [ -z "${GAPIC_CONFIG}" ]; then
+    GAPIC_CONFIG=""
+  else
+    GAPIC_CONFIG="gapic-config=${GAPIC_CONFIG},"
+  fi
+  GRPC_SERVICE_CONFIG=$(find "${PROTO_PATH}" -type f -name "*service_config.json")
+  API_SERVICE_CONFIG=$(find "${PROTO_PATH}" -maxdepth 1 -type f \( -name "*.yaml" ! -name "*gapic.yaml" \))
+  if [ "${REST_NUMERIC_ENUMS}" == "true" ]; then
+    REST_NUMERIC_ENUMS="rest-numeric-enums,"
+  else
+    REST_NUMERIC_ENUMS=""
+  fi
+  echo "transport=${TRANSPORT},${REST_NUMERIC_ENUMS}grpc-service-config=${GRPC_SERVICE_CONFIG},${GAPIC_CONFIG}api-service-config=${API_SERVICE_CONFIG}"
+}
+
+##################### Section 1 #####################
+# generate grpc-*/
+#####################################################
+cd "${GOOGLEAPIS_ROOT}"
+"${PROTOC_ROOT}"/protoc "--plugin=protoc-gen-rpc-plugin=${LIBRARY_GEN_OUT}/protoc-gen-grpc-java" \
+"--rpc-plugin_out=:${LIBRARY_GEN_OUT}/${PROTO_PATH}/java_grpc.jar" \
+${PROTO_FILES}
+
+unzip_src_files "grpc"
+remove_empty_files "grpc"
+##################### Section 2 #####################
+# generate gapic-*/, proto-*/, samples/
+#####################################################
+"${PROTOC_ROOT}"/protoc --experimental_allow_proto3_optional \
+"--plugin=protoc-gen-java_gapic=${REPO_ROOT}/library_generation/gapic-generator-java-wrapper" \
+"--java_gapic_out=metadata:${LIBRARY_GEN_OUT}/${PROTO_PATH}/java_gapic_srcjar_raw.srcjar.zip" \
+"--java_gapic_opt=$(get_gapic_opts)" \
+${PROTO_FILES} $(search_additional_protos)
+
+unzip -o -q "${LIBRARY_GEN_OUT}"/"${PROTO_PATH}"/java_gapic_srcjar_raw.srcjar.zip -d "${LIBRARY_GEN_OUT}"/${PROTO_PATH}
+# Sync'\''d to the output file name in Writer.java.
+unzip -o -q "${LIBRARY_GEN_OUT}"/"${PROTO_PATH}"/temp-codegen.srcjar -d "${LIBRARY_GEN_OUT}"/"${PROTO_PATH}"/java_gapic_srcjar
+# Resource name source files.
+PROTO_DIR=${LIBRARY_GEN_OUT}/${PROTO_PATH}/java_gapic_srcjar/proto/src/main/java
+if [ ! -d "${PROTO_DIR}" ]
+then
+  # Some APIs don'\''t have resource name helpers, like BigQuery v2.
+  # Create an empty file so we can finish building. Gating the resource name rule definition
+  # on file existences go against Bazel'\''s design patterns, so we'\''ll simply delete all empty
+  # files during the final packaging process (see java_gapic_pkg.bzl)
+  mkdir -p "${PROTO_DIR}"
+  touch "${PROTO_DIR}"/PlaceholderFile.java
+fi
+
+cd "${LIBRARY_GEN_OUT}"
+# Main source files.
+mv_src_files "gapic" "main"
+remove_empty_files "gapic"
+# Test source files.
+mv_src_files "gapic" "test"
+if [ "${INCLUDE_SAMPLES}" == "true" ]; then
+  # Sample source files.
+  mv_src_files "samples" "main"
+fi
+##################### Section 3 #####################
+# generate proto-*/
+#####################################################
+cd "${GOOGLEAPIS_ROOT}"
+"${PROTOC_ROOT}"/protoc "--java_out=${LIBRARY_GEN_OUT}/${PROTO_PATH}/java_proto.jar" ${PROTO_FILES}
+mv_src_files "proto" "main"
+unzip_src_files "proto"
+remove_empty_files "proto"
+
+for proto_src in ${PROTO_FILES}; do
+    mkdir -p "${LIBRARY_GEN_OUT}"/"${PROTO_PATH}"/"${OUT_LAYER_FOLDER}"/proto-"${OUT_LAYER_FOLDER}"/src/main/proto
+    cp -f --parents "${proto_src}" "${LIBRARY_GEN_OUT}"/"${PROTO_PATH}"/"${OUT_LAYER_FOLDER}"/proto-"${OUT_LAYER_FOLDER}"/src/main/proto
+done

--- a/library_generation/generate_library.sh
+++ b/library_generation/generate_library.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -xe
+set -e
 
 GOOGLEAPIS_COMMIT=$1
 PROTOBUF_VERSION=$2

--- a/library_generation/generate_library_with_fixed_dependencies.sh
+++ b/library_generation/generate_library_with_fixed_dependencies.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -xe
+set -e
 
 PROTO_PATH=$1
 CONTAINS_CLOUD=$2

--- a/library_generation/generate_library_with_fixed_dependencies.sh
+++ b/library_generation/generate_library_with_fixed_dependencies.sh
@@ -6,7 +6,8 @@ PROTO_PATH=$1
 CONTAINS_CLOUD=$2
 TRANSPORT=$3 # grpc+rest or grpc
 REST_NUMERIC_ENUMS=$4 # true or false
-INCLUDE_SAMPLES=$5 # true or false
+IS_GAPIC_LIBRARY=$5 # true or false
+INCLUDE_SAMPLES=$6 # true or false
 
 cd "$(dirname "$(readlink -f "$0")")"
 chmod +x generate_library.sh
@@ -19,4 +20,5 @@ chmod +x generate_library.sh
 "${CONTAINS_CLOUD}" \
 "${TRANSPORT}" \
 "${REST_NUMERIC_ENUMS}" \
+"${IS_GAPIC_LIBRARY}" \
 "${INCLUDE_SAMPLES}"

--- a/library_generation/generate_library_with_fixed_dependencies.sh
+++ b/library_generation/generate_library_with_fixed_dependencies.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -xe
+
+PROTO_PATH=$1
+CONTAINS_CLOUD=$2
+TRANSPORT=$3 # grpc+rest or grpc
+REST_NUMERIC_ENUMS=$4 # true or false
+INCLUDE_SAMPLES=$5 # true or false
+
+cd "$(dirname "$(readlink -f "$0")")"
+chmod +x generate_library.sh
+./generate_library.sh \
+53a0be29c4a95a1d3b4c0d3a7a2ac8b52af2a3c0 \
+21.12 \
+1.54.1 \
+2.19.0 \
+"${PROTO_PATH}" \
+"${CONTAINS_CLOUD}" \
+"${TRANSPORT}" \
+"${REST_NUMERIC_ENUMS}" \
+"${INCLUDE_SAMPLES}"


### PR DESCRIPTION
# Add scripts to generate a java client library with `protoc` commands
## `generate_library.sh`
This script is used to generate a java gapic library given the proto path in googleapis repository.
### High-level structure of `generate_library.sh`
- prepare the tooling
- run `protoc` to generate `grpc-*/` folder
- run `protoc` to generate `gapic-*/` and `samples/` folder
- run `protoc` to generate `proto-*/` folder
### Usage
The generate a client library with `generate_library.sh`, we need the following parameters:
- a commit hash in googleapis repository, e.g., `53a0be29c4a95a1d3b4c0d3a7a2ac8b52af2a3c0`
- protobuf version, e.g., `21.12`
- grpc version, e.g., `1.54.1`
- gapic-generator-java version, e.g., `2.19.0`
- proto path, a relative path in googleapis root directory, e.g., `google/monitoring/v3`
- whether the output directory has a `cloud` subdirectory, `true` or `false` 
- transport, `grpc+rest` or `grpc`
- whether pass `rest-numeric-enums` to gapic-generator-java, `true` or `false`
- [optional] whether include samples, `true` of `false`, default value is 'true` if not set

Note that `transport` and `rest-numeric-enums` can't be parsed from files in `proto path` since service owners need to set them with respect to the service-side capability.
### Known issue
- [trivial] compared with libraries in `googleapis-gen` (generated by `bazel build`), the *.java files in `grpc-*/` has a different comment:
  - in `googleapis-gen`: `value = "by gRPC proto compiler",`
  - in generated library: `value = "by gRPC proto compiler (version x.xx.x)",`

## `generate_library_with_fixed_dependencies.sh`
Generate the library with fixed version of proto files, proto compiler, grpc and gapic-generator-java. 

It's a wrapper of `generate_library.sh` and will be invoked by downstream libraries (we want all libraries are generated with the same version of dependencies).