### PR TITLE
chore: [POC] Include GGJ version in generated library

### DIFF
--- a/rules_java_gapic/java_gapic.bzl
+++ b/rules_java_gapic/java_gapic.bzl
@@ -38,8 +38,12 @@ def _java_gapic_postprocess_srcjar_impl(ctx):
     {formatter} --replace $(find {output_dir_path} -type f -printf "%p ")
     WORKING_DIR=`pwd`
 
-    # Add a file indicating the version of the generator being used
-    echo "{generator_version}" > {output_dir_path}/src/main/java/gapic-generator-java.version
+    # Add a file indicating the version of the generator being used.
+    # Uses the location of gapic_metadata.json as a heuristic to the location of
+    # the version folder (e.g. v1, v1beta1, etc)
+    cd {output_dir_path}/src/main/java
+    ggj_version_location=$(dirname $(find -type f -name 'gapic_metadata.json'))
+    echo "{generator_version}" > $ggj_version_location/gapic-generator-java.version
 
     # Main source files.
     cd {output_dir_path}/src/main/java

--- a/rules_java_gapic/java_gapic.bzl
+++ b/rules_java_gapic/java_gapic.bzl
@@ -24,6 +24,7 @@ def _java_gapic_postprocess_srcjar_impl(ctx):
     output_samples = ctx.outputs.samples
     output_resource_name = ctx.outputs.resource_name
     formatter = ctx.executable.formatter
+    generator_version = bazel.workspace.get_variable('_gapic_generator_java_version')
 
     output_dir_name = ctx.label.name
     output_dir_path = "%s/%s" % (output_main.dirname, output_dir_name)
@@ -35,6 +36,9 @@ def _java_gapic_postprocess_srcjar_impl(ctx):
     # This may fail if there are spaces and/or too many files (exceed max length of command length).
     {formatter} --replace $(find {output_dir_path} -type f -printf "%p ")
     WORKING_DIR=`pwd`
+
+    # Add a file indicating the version of the generator being used
+    echo {generator_version} > $WORKING_DIR/gapic-generator-java.version
 
     # Main source files.
     cd {output_dir_path}/src/main/java

--- a/rules_java_gapic/java_gapic.bzl
+++ b/rules_java_gapic/java_gapic.bzl
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@rules_gapic//:gapic.bzl", "proto_custom_library")
+#load("@//:WORKSPACE", 'gapic_generator_java_version')
 
 NO_GRPC_CONFIG_ALLOWLIST = ["library"]
 
@@ -24,7 +25,7 @@ def _java_gapic_postprocess_srcjar_impl(ctx):
     output_samples = ctx.outputs.samples
     output_resource_name = ctx.outputs.resource_name
     formatter = ctx.executable.formatter
-    generator_version = bazel.workspace.get_variable('_gapic_generator_java_version')
+    generator_version = "2.21.1-SNAPSHOT"  # {x-version-update:gapic-generator-java:current}
 
     output_dir_name = ctx.label.name
     output_dir_path = "%s/%s" % (output_main.dirname, output_dir_name)
@@ -38,7 +39,7 @@ def _java_gapic_postprocess_srcjar_impl(ctx):
     WORKING_DIR=`pwd`
 
     # Add a file indicating the version of the generator being used
-    echo {generator_version} > $WORKING_DIR/gapic-generator-java.version
+    echo "{generator_version}" > {output_dir_path}/src/main/java/gapic-generator-java.version
 
     # Main source files.
     cd {output_dir_path}/src/main/java
@@ -76,6 +77,7 @@ def _java_gapic_postprocess_srcjar_impl(ctx):
     """.format(
         gapic_srcjar = gapic_srcjar.path,
         output_srcjar_name = output_srcjar_name,
+        generator_version = generator_version,
         formatter = formatter,
         output_dir_name = output_dir_name,
         output_dir_path = output_dir_path,

--- a/rules_java_gapic/java_gapic.bzl
+++ b/rules_java_gapic/java_gapic.bzl
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 load("@rules_gapic//:gapic.bzl", "proto_custom_library")
-#load("@//:WORKSPACE", 'gapic_generator_java_version')
 
 NO_GRPC_CONFIG_ALLOWLIST = ["library"]
 

--- a/rules_java_gapic/java_gapic_pkg.bzl
+++ b/rules_java_gapic/java_gapic_pkg.bzl
@@ -273,9 +273,6 @@ def _java_gapic_srcs_pkg_impl(ctx):
         unzip -q -o $src -d {package_dir_path}/src/main/java
         rm -r -f {package_dir_path}/src/main/java/META-INF
 
-        # move ggj version to root level
-        mv {package_dir_path}/src/main/java/gapic-generator-java.version {package_dir_path}
-
         # Remove empty files. If there are no resource names, one such file might have
         # been created. See java_gapic.bzl.
         find {package_dir_path}/src/main/java -type f -size 0 | while read f; do rm -f $f; done

--- a/rules_java_gapic/java_gapic_pkg.bzl
+++ b/rules_java_gapic/java_gapic_pkg.bzl
@@ -273,6 +273,9 @@ def _java_gapic_srcs_pkg_impl(ctx):
         unzip -q -o $src -d {package_dir_path}/src/main/java
         rm -r -f {package_dir_path}/src/main/java/META-INF
 
+        # move ggj version to root level
+        mv {package_dir_path}/src/main/java/gapic-generator-java.version {package_dir_path}
+
         # Remove empty files. If there are no resource names, one such file might have
         # been created. See java_gapic.bzl.
         find {package_dir_path}/src/main/java -type f -size 0 | while read f; do rm -f $f; done


### PR DESCRIPTION
This is a modification to `rules_java_gapic` to add a single-line file containing the version string of the used gapic generator java. This can be used for version matching checks to ensure all the libraries are synced with the same GGJ version.

This POC uses an unorthodox way of obtaining the version string (relying on bot)
**https://github.com/googleapis/sdk-platform-java/blob/81d090f943f4db43db42297cce001c3709fc0010/rules_java_gapic/java_gapic.bzl#L28**

Running the following command in `googleapis`
`bazel build //google/cloud/language/v1:google-cloud-language-v1-java`

Produces the following tar tree
```
google-cloud-language-v1-java
├── build.gradle
├── gapic-google-cloud-language-v1-java
│   ├── build.gradle
│   └── src
│       ├── main
│       │   └── java
│       │       └── com
│       │           └── google
│       │               └── cloud
│       │                   └── language
│       │                       └── v1
│       │                           ├── gapic-generator-java.version   <<<<<<<<<<<<<<< version
│       │                           ├── gapic_metadata.json
│       │                           ├── LanguageServiceClient.java
│       │                           ├── LanguageServiceSettings.java
│       │                           ├── package-info.java
│       │                           └── stub
│       │                               ├── GrpcLanguageServiceCallableFactory.java
│       │                               ├── GrpcLanguageServiceStub.java
│       │                               ├── HttpJsonLanguageServiceCallableFactory.java
│       │                               ├── HttpJsonLanguageServiceStub.java
│       │                               ├── LanguageServiceStub.java
│       │                               └── LanguageServiceStubSettings.java

```

## Improvements
- [ ] Obtain the GGJ version from `WORKSPACE` or custom build file
- [ ] Better method to obtain path to version folder (e.g. `com/google/.../v1`)