### PR TITLE
ci: add showcase-clirr check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -229,12 +229,12 @@ jobs:
       - name: Checkout sdk-platform-java @ PR merge commit
         uses: actions/checkout@v3
         # Showcase golden test ensures that src changes are already reflected in the PR.
-      - name: Update Showcase version to 0.0.2-SNAPSHOT
+      - name: Clirr check
         working-directory: showcase
-        run: mvn versions:set -B -ntp -DnewVersion=0.0.2-SNAPSHOT
-      - name: Clirr Check
-        working-directory: showcase
-        run: mvn -B -ntp clirr:check -Dclirr.skip=false -DcomparisonVersion=0.0.1-SNAPSHOT
+        run: |
+          SHOWCASE_CLIENT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          mvn versions:set -B -ntp -DnewVersion=local
+          mvn clirr:check -B -ntp -Dclirr.skip=false -DcomparisonVersion=$SHOWCASE_CLIENT_VERSION
 
   gapic-generator-java-bom:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -207,6 +207,35 @@ jobs:
             -P enable-integration-tests \
             --batch-mode \
             --no-transfer-progress
+
+  showcase-clirr:
+    if: ${{ github.base_ref != '' }} # Only execute on pull_request trigger event
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout @ target branch
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.base_ref }}
+      - uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: temurin
+          cache: maven
+      - name: Install sdk-platform-java and showcase to local maven repository
+        run: |
+          mvn install -B -ntp -T 1C -DskipTests
+          cd showcase
+          mvn install -B -ntp -T 1C -DskipTests
+      - name: Checkout sdk-platform-java @ PR merge commit
+        uses: actions/checkout@v3
+        # Showcase golden test ensures that src changes are already reflected in the PR.
+      - name: Update Showcase version to 0.0.2-SNAPSHOT
+        working-directory: showcase
+        run: mvn versions:set -B -ntp -DnewVersion=0.0.2-SNAPSHOT
+      - name: Clirr Check
+        working-directory: showcase
+        run: mvn -B -ntp clirr:check -Dclirr.skip=false -DcomparisonVersion=0.0.1-SNAPSHOT
+
   gapic-generator-java-bom:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -226,13 +226,14 @@ jobs:
           mvn install -B -ntp -T 1C -DskipTests
           cd showcase
           mvn install -B -ntp -T 1C -DskipTests
+          SHOWCASE_CLIENT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "SHOWCASE_CLIENT_VERSION=$SHOWCASE_CLIENT_VERSION" >> "$GITHUB_ENV"
       - name: Checkout sdk-platform-java @ PR merge commit
         uses: actions/checkout@v3
         # Showcase golden test ensures that src changes are already reflected in the PR.
       - name: Clirr check
         working-directory: showcase
         run: |
-          SHOWCASE_CLIENT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           mvn versions:set -B -ntp -DnewVersion=local
           mvn clirr:check -B -ntp -Dclirr.skip=false -DcomparisonVersion=$SHOWCASE_CLIENT_VERSION
 


### PR DESCRIPTION
This check compares the Showcase client against the **target branch** for binary incompatible changes.

Previous binary incompatibilities have been caught with the java-iam client, but:
* Showcase covers proto, grpc, and gapic artifacts. The java-iam client covers only proto and grpc.
* Showcase is intended to provide broad feature coverage, thus it will be a more robust binary compatibility check.
* Since this check compares against the target branch, it works with LTS branches.

See https://github.com/googleapis/sdk-platform-java/pull/1804 for an example of this check catching a binary incompatible change.