### PR TITLE
fix: generate native image configurations for Gapics

### DIFF
--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/protoparser/Parser.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/protoparser/Parser.java
@@ -202,15 +202,6 @@ public class Parser {
       }
     }
 
-    // Before we convert to GapicContext, we want to print th service info in a .txt file.
-//    System.out.println("****** MY SERVICE INFO");
-//    System.out.println(services.get(0).name());
-//    for (Method serviceMethod : services.get(0).methods()) {
-//      System.out.println(serviceMethod.name());
-//      System.out.println(serviceMethod.methodSignatures().get(0));
-//    }
-
-
     return GapicContext.builder()
         .setServices(services)
         .setMixinServices(
@@ -751,11 +742,6 @@ public class Parser {
               .setIsDeprecated(isDeprecated)
               .setOperationPollingMethod(operationPollingMethod)
               .build());
-
-//      if (protoMethod.getName().contains("Builder")) {
-//        System.out.println("HELLLOOOOOOOO");
-//        System.out.println(protoMethod.getName());
-//      }
 
       // Any input type that has a resource reference will need a resource name helper class.
       for (Field field : inputMessage.fields()) {

--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/protoparser/Parser.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/protoparser/Parser.java
@@ -202,6 +202,15 @@ public class Parser {
       }
     }
 
+    // Before we convert to GapicContext, we want to print th service info in a .txt file.
+//    System.out.println("****** MY SERVICE INFO");
+//    System.out.println(services.get(0).name());
+//    for (Method serviceMethod : services.get(0).methods()) {
+//      System.out.println(serviceMethod.name());
+//      System.out.println(serviceMethod.methodSignatures().get(0));
+//    }
+
+
     return GapicContext.builder()
         .setServices(services)
         .setMixinServices(
@@ -742,6 +751,11 @@ public class Parser {
               .setIsDeprecated(isDeprecated)
               .setOperationPollingMethod(operationPollingMethod)
               .build());
+
+//      if (protoMethod.getName().contains("Builder")) {
+//        System.out.println("HELLLOOOOOOOO");
+//        System.out.println(protoMethod.getName());
+//      }
 
       // Any input type that has a resource reference will need a resource name helper class.
       for (Field field : inputMessage.fields()) {

--- a/scripts/update_golden.sh
+++ b/scripts/update_golden.sh
@@ -19,6 +19,10 @@ find . -name '*.java' -delete
 find . -name 'gapic_metadata.json' -delete
 
 mkdir -p ./src
+echo "Hello"
+#ls ${UNPACK_DIR}/src/main/java/*
+#ls ${UNPACK_DIR}/src/main/java/google/
+ls ./src
 cp -r ${UNPACK_DIR}/src/main/java/* ./src
 cp -r ${UNPACK_DIR}/src/test/java/* ./src
 [ -d ${UNPACK_DIR}/proto ] && cp -r ${UNPACK_DIR}/proto/src/main/java/* ./src

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/reflect-config.json
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/reflect-config.json
@@ -1,82 +1,155 @@
 [
   {
-    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
-    "allDeclaredFields": true
+    "name": "com.google.cloud.asset.v1.stub.AssetServiceStub",
+    "queryAllDeclaredConstructors": true,
+    "queryAllPublicConstructors": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllPublicMethods": true,
+    "allDeclaredClasses": true,
+    "allPublicClasses": true
   },
   {
-    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
-    "allDeclaredFields": true
+    "name": "com.google.cloud.asset.v1.stub.AssetServiceStubSettings",
+    "queryAllDeclaredConstructors": true,
+    "queryAllPublicConstructors": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllPublicMethods": true,
+    "allDeclaredClasses": true,
+    "allPublicClasses": true
   },
   {
-    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
-    "allDeclaredFields": true
+    "name": "com.google.cloud.asset.v1.stub.GrpcAssetServiceCallableFactory",
+    "queryAllDeclaredConstructors": true,
+    "queryAllPublicConstructors": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllPublicMethods": true,
+    "allDeclaredClasses": true,
+    "allPublicClasses": true
   },
   {
-    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
-    "allDeclaredFields": true
+    "name": "com.google.cloud.asset.v1.stub.GrpcAssetServiceStub",
+    "queryAllDeclaredConstructors": true,
+    "queryAllPublicConstructors": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllPublicMethods": true,
+    "allDeclaredClasses": true,
+    "allPublicClasses": true
   },
   {
-    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
-    "allDeclaredFields": true
+    "name": "com.google.cloud.asset.v1.stub.HttpJsonAssetServiceCallableFactory",
+    "queryAllDeclaredConstructors": true,
+    "queryAllPublicConstructors": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllPublicMethods": true,
+    "allDeclaredClasses": true,
+    "allPublicClasses": true
   },
   {
-    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
-    "allDeclaredFields": true
+    "name": "com.google.cloud.asset.v1.stub.HttpJsonAssetServiceStub",
+    "queryAllDeclaredConstructors": true,
+    "queryAllPublicConstructors": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllPublicMethods": true,
+    "allDeclaredClasses": true,
+    "allPublicClasses": true
   },
   {
-    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
-    "allDeclaredFields": true
+    "name": "com.google.cloud.asset.v1.AssetServiceClient",
+    "queryAllDeclaredConstructors": true,
+    "queryAllPublicConstructors": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllPublicMethods": true,
+    "allDeclaredClasses": true,
+    "allPublicClasses": true
   },
   {
-    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
-    "allDeclaredFields": true
+    "name": "com.google.cloud.asset.v1.AssetServiceSettings",
+    "queryAllDeclaredConstructors": true,
+    "queryAllPublicConstructors": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllPublicMethods": true,
+    "allDeclaredClasses": true,
+    "allPublicClasses": true
   },
   {
-    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
-    "allDeclaredFields": true
+    "name": "com.google.cloud.asset.v1.MockAssetService",
+    "queryAllDeclaredConstructors": true,
+    "queryAllPublicConstructors": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllPublicMethods": true,
+    "allDeclaredClasses": true,
+    "allPublicClasses": true
   },
   {
-    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
-    "allDeclaredFields": true
+    "name": "com.google.cloud.asset.v1.MockAssetServiceImpl",
+    "queryAllDeclaredConstructors": true,
+    "queryAllPublicConstructors": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllPublicMethods": true,
+    "allDeclaredClasses": true,
+    "allPublicClasses": true
   },
   {
-    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
-    "allDeclaredFields": true
+    "name": "com.google.cloud.asset.v1.AssetServiceClientTest",
+    "queryAllDeclaredConstructors": true,
+    "queryAllPublicConstructors": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllPublicMethods": true,
+    "allDeclaredClasses": true,
+    "allPublicClasses": true
   },
   {
-    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
-    "allDeclaredFields": true
+    "name": "com.google.cloud.asset.v1.AssetServiceClientHttpJsonTest",
+    "queryAllDeclaredConstructors": true,
+    "queryAllPublicConstructors": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllPublicMethods": true,
+    "allDeclaredClasses": true,
+    "allPublicClasses": true
   },
   {
-    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
-    "allDeclaredFields": true
+    "name": "com.google.cloud.asset.v1.FeedName",
+    "queryAllDeclaredConstructors": true,
+    "queryAllPublicConstructors": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllPublicMethods": true,
+    "allDeclaredClasses": true,
+    "allPublicClasses": true
   },
   {
-    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
-    "allDeclaredFields": true
+    "name": "com.google.cloud.asset.v1.SavedQueryName",
+    "queryAllDeclaredConstructors": true,
+    "queryAllPublicConstructors": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllPublicMethods": true,
+    "allDeclaredClasses": true,
+    "allPublicClasses": true
   },
   {
-    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
-    "allDeclaredFields": true
+    "name": "com.google.cloud.asset.v1.FolderName",
+    "queryAllDeclaredConstructors": true,
+    "queryAllPublicConstructors": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllPublicMethods": true,
+    "allDeclaredClasses": true,
+    "allPublicClasses": true
   },
   {
-    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
-    "allDeclaredFields": true
+    "name": "com.google.cloud.asset.v1.OrganizationName",
+    "queryAllDeclaredConstructors": true,
+    "queryAllPublicConstructors": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllPublicMethods": true,
+    "allDeclaredClasses": true,
+    "allPublicClasses": true
   },
   {
-    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
-    "allDeclaredFields": true
-  },
-  {
-    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
-    "allDeclaredFields": true
-  },
-  {
-    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
-    "allDeclaredFields": true
-  },
-  {
-    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
-    "allDeclaredFields": true
+    "name": "com.google.cloud.asset.v1.ProjectName",
+    "queryAllDeclaredConstructors": true,
+    "queryAllPublicConstructors": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllPublicMethods": true,
+    "allDeclaredClasses": true,
+    "allPublicClasses": true
   }
 ]

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/reflect-config.json
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/reflect-config.json
@@ -1,0 +1,82 @@
+[
+  {
+    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
+    "allDeclaredFields": true
+  },
+  {
+    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
+    "allDeclaredFields": true
+  },
+  {
+    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
+    "allDeclaredFields": true
+  },
+  {
+    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
+    "allDeclaredFields": true
+  },
+  {
+    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
+    "allDeclaredFields": true
+  },
+  {
+    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
+    "allDeclaredFields": true
+  },
+  {
+    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
+    "allDeclaredFields": true
+  },
+  {
+    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
+    "allDeclaredFields": true
+  },
+  {
+    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
+    "allDeclaredFields": true
+  },
+  {
+    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
+    "allDeclaredFields": true
+  },
+  {
+    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
+    "allDeclaredFields": true
+  },
+  {
+    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
+    "allDeclaredFields": true
+  },
+  {
+    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
+    "allDeclaredFields": true
+  },
+  {
+    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
+    "allDeclaredFields": true
+  },
+  {
+    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
+    "allDeclaredFields": true
+  },
+  {
+    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
+    "allDeclaredFields": true
+  },
+  {
+    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
+    "allDeclaredFields": true
+  },
+  {
+    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
+    "allDeclaredFields": true
+  },
+  {
+    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
+    "allDeclaredFields": true
+  },
+  {
+    "name": "com.google.cloud.asset.v1.BatchGetEffectiveIamPolicies",
+    "allDeclaredFields": true
+  }
+]


### PR DESCRIPTION
Notable Changes:

- This PR leverages the Writer class to parse necessary information such as package name and class name from the collection of GapicClass objects that are returned by the Composer. It then uses that information to generated a `reflect-config.json` file. 
- The drawback of this change is that it only includes a subset of classes, particularly, the ones generated by the gapic generator. We need to also include the classes that are generated by the standard `java_proto_library` bazel rule. 