### PR TITLE
ci: fix showcase-clirr check on release PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -230,6 +230,8 @@ jobs:
           echo "SHOWCASE_CLIENT_VERSION=$SHOWCASE_CLIENT_VERSION" >> "$GITHUB_ENV"
       - name: Checkout sdk-platform-java @ PR merge commit
         uses: actions/checkout@v3
+      - name: Install sdk-platform-java @ PR merge commit
+        run: mvn install -B -ntp -T 1C -DskipTests
         # Showcase golden test ensures that src changes are already reflected in the PR.
       - name: Clirr check
         working-directory: showcase


### PR DESCRIPTION
Install sdk-platform-java before performing final clirr check, so version changes are available in the local repository

Failure seen in release PR: https://github.com/googleapis/sdk-platform-java/pull/1806