### PR TITLE
chore: remove gson version duplication

### DIFF
--- a/java-shared-dependencies/first-party-dependencies/pom.xml
+++ b/java-shared-dependencies/first-party-dependencies/pom.xml
@@ -23,7 +23,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <site.installationModule>${project.artifactId}</site.installationModule>
     <grpc-gcp.version>1.4.1</grpc-gcp.version>
-    <gson.version>2.10.1</gson.version>
     <google.oauth-client.version>1.34.1</google.oauth-client.version>
     <google.api-client.version>2.2.0</google.api-client.version>
   </properties>
@@ -42,11 +41,6 @@
         <groupId>com.google.cloud</groupId>
         <artifactId>grpc-gcp</artifactId>
         <version>${grpc-gcp.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.code.gson</groupId>
-        <artifactId>gson</artifactId>
-        <version>${gson.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>


### PR DESCRIPTION
Dependency management for gson is already provided via the [gapic-generator-java-bom import](https://github.com/googleapis/sdk-platform-java/blob/main/java-shared-dependencies/first-party-dependencies/pom.xml#L33-L40) which has a [gson entry](https://github.com/googleapis/sdk-platform-java/blob/main/gapic-generator-java-bom/pom.xml#L39-L43) with the [version defined in the gapic-generator-pom-parent](https://github.com/googleapis/sdk-platform-java/blob/main/gapic-generator-java-pom-parent/pom.xml#L33).