### PR TITLE
ci: add downstream compatibility checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -298,5 +298,9 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: temurin
       - run: mvn -version
+      - name: Install xmllint
+        run: |
+          apt-get update
+          apt-get -y install libxml2-utils
       - name: Perform downstream compatibility testing
         run: ./.kokoro/presubmit/downstream-compatibility.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -301,6 +301,6 @@ jobs:
       - name: Install xmllint
         run: |
           apt-get update
-          apt-get -y install libxml2-utils
+          sudo apt-get -y install libxml2-utils
       - name: Perform downstream compatibility testing
         run: ./.kokoro/presubmit/downstream-compatibility.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -270,7 +270,7 @@ jobs:
           mvn clirr:check -B -ntp -Dclirr.skip=false -DcomparisonVersion=$SHOWCASE_CLIENT_VERSION
 
   gapic-generator-java-bom:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-java@v3
@@ -285,3 +285,18 @@ jobs:
       uses: googleapis/java-cloud-bom/tests/validate-bom@v26.13.0
       with:
         bom-path: gapic-generator-java-bom/pom.xml
+
+  downstream-compatibility:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        java: [ 11, 17 ]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: temurin
+      - run: mvn -version
+      - name: Perform downstream compatibility testing
+        run: ./.kokoro/presubmit/downstream-compatibility.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -300,7 +300,7 @@ jobs:
       - run: mvn -version
       - name: Install xmllint
         run: |
-          apt-get update
+          sudo apt-get update
           sudo apt-get -y install libxml2-utils
       - name: Perform downstream compatibility testing
         run: ./.kokoro/presubmit/downstream-compatibility.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -317,5 +317,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get -y install libxml2-utils
+      - name: Test helper scripts
+        run: ./.kokoro/presubmit/common_test.sh
       - name: Perform downstream compatibility testing
         run: REPOS_UNDER_TEST="${{ matrix.repo }}" ./.kokoro/presubmit/downstream-compatibility.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -290,12 +290,26 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        java: [ 11, 17 ]
+        repo:
+          - google-cloud-java
+          - java-bigtable
+          - java-bigquery
+          - java-bigquerystorage
+          - java-datastore
+          - java-firestore
+          - java-logging
+          - java-logging-logback
+          - java-pubsub
+          - java-pubsublite
+          - java-spanner-jdbc
+          - java-spanner
+          - java-storage
+          - java-storage-nio
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
-          java-version: ${{ matrix.java }}
+          java-version: 17
           distribution: temurin
       - run: mvn -version
       - name: Install xmllint
@@ -303,4 +317,4 @@ jobs:
           sudo apt-get update
           sudo apt-get -y install libxml2-utils
       - name: Perform downstream compatibility testing
-        run: ./.kokoro/presubmit/downstream-compatibility.sh
+        run: REPOS_UNDER_TEST="${{ matrix.repo }}" ./.kokoro/presubmit/downstream-compatibility.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -289,6 +289,7 @@ jobs:
   downstream-compatibility:
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         repo:
           - google-cloud-java

--- a/.kokoro/presubmit/common.sh
+++ b/.kokoro/presubmit/common.sh
@@ -54,3 +54,24 @@ function parse_pom_version {
   fi
   echo "$result"
 }
+
+# ex: find_last_release_version java-bigtable
+# ex: find_last_release_version java-storage 2.22.x
+function find_last_release_version {
+  branch=${2-"main"} # Default to using main branch
+  curl -s -o "versions_$1.txt" "https://raw.githubusercontent.com/googleapis/$1/$branch/versions.txt"
+
+  # First check to see if there's an entry for the overall repo. Used for google-cloud-java.
+  primary_artifact=$(grep -E "^$1" "versions_$1.txt" | head -n 1)
+  if [ -z "$primary_artifact" ]; then
+    # Otherwise, use the first google-cloud-* artifact's version.
+    primary_artifact=$(grep -E "^google-cloud-" "versions_$1.txt" | head -n 1)
+  fi
+  if [ -z "$primary_artifact" ]; then
+    echo "Unable to identify primary artifact for $1"
+    exit 1;
+  fi
+
+  parts=($(echo "$primary_artifact" | tr ":" "\n"))
+  echo "${parts[1]}";
+}

--- a/.kokoro/presubmit/common.sh
+++ b/.kokoro/presubmit/common.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# In the given directory ($1),
+#   update the pom.xml's dependency on the given artifact ($2) to the given version ($3)
+# ex: update_dependency google-cloud-java/google-cloud-jar-parent google-cloud-shared-dependencies 1.2.3
+function update_pom_dependency {
+  pushd "$1" || exit 1
+  xmllint --shell pom.xml <<EOF
+setns x=http://maven.apache.org/POM/4.0.0
+cd .//x:artifactId[text()="$2"]
+cd ../x:version
+set $3
+save pom.xml
+EOF
+  popd || exit 1
+}
+
+# In the given directory ($1),
+#   find and update all pom.xmls' dependencies on the given artifact ($2) to the given version ($3)
+# ex: update_all_poms_dependency google-cloud-java google-cloud-shared-dependencies 1.2.3
+function update_all_poms_dependency {
+  pushd "$1" || exit 1
+  # Recursively find all pom.xmls with a dependency on the given artifact.
+  POMS=$(grep -Rl --include="pom.xml" "<artifactId>$2" .)
+  for pom in $POMS; do
+    update_pom_dependency "$(dirname "$pom")" "$2" "$3"
+  done
+  git diff
+  popd || exit 1
+}
+
+# Parse the version of the pom.xml file in the given directory ($1)
+# ex: VERSION=$(parse_pom_version java-shared-dependencies)
+function parse_pom_version {
+  # Namespace (xmlns) prevents xmllint from specifying tag names in XPath
+  result=$(sed -e 's/xmlns=".*"//' "$1/pom.xml" | xmllint --xpath '/project/version/text()' -)
+
+  if [ -z "${result}" ]; then
+    echo "Version is not found in $1"
+    exit 1
+  fi
+  echo "$result"
+}

--- a/.kokoro/presubmit/common_test.sh
+++ b/.kokoro/presubmit/common_test.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+scriptDir=$(realpath "$(dirname "${BASH_SOURCE[0]}")")
+cd "${scriptDir}/../.." # cd to the root of this repo
+source "$scriptDir/common.sh"
+mkdir -p target
+cd target
+
+function test_find_all_poms_with_versioned_dependency {
+  mkdir -p test_find_all_poms_with_dependency
+  pushd test_find_all_poms_with_dependency
+  cp ../../showcase/gapic-showcase/pom.xml pom.xml
+
+  find_all_poms_with_versioned_dependency 'truth'
+  if [ "${#POMS[@]}" != 1 ]; then
+    echo 'find_all_poms_with_versioned_dependency did not find the expected pom'
+    exit 1
+  elif [ "${POMS[0]}" != './pom.xml' ]; then
+    echo "find_all_poms_with_versioned_dependency found ${POMS[0]} instead of expected ./pom.xml"
+    exit 1
+  fi
+
+  find_all_poms_with_versioned_dependency 'gax-grpc' # Versioned by shared-deps
+  if [ "${#POMS[@]}" != 0 ]; then
+    echo 'find_all_poms_with_versioned_dependency found unexpected pom'
+    exit 1
+  fi
+
+  popd
+}
+
+function test_update_pom_dependency {
+  mkdir -p test_update_pom_dependency
+  pushd test_update_pom_dependency
+  cp ../../showcase/gapic-showcase/pom.xml pom.xml
+
+  update_pom_dependency . truth "99.88.77"
+
+  xmllint --shell pom.xml &>/dev/null <<EOF
+setns x=http://maven.apache.org/POM/4.0.0
+cd .//x:artifactId[text()="truth"]
+cd ../x:version
+write found-version.txt
+EOF
+  if ! grep 99.88.77 found-version.txt &>/dev/null; then
+    echo "update_pom_dependency failed to change version to expected value."
+    exit 1
+  fi
+  rm found-version.txt
+  popd
+}
+
+function test_parse_pom_version {
+  mkdir -p test_parse_pom_version
+  pushd test_parse_pom_version
+  cp ../../showcase/gapic-showcase/pom.xml pom.xml
+
+  VERSION=$(parse_pom_version .)
+  if [ "$VERSION" != "0.0.1-SNAPSHOT" ]; then
+    echo "parse_pom_version failed to read expected version of gapic-showcase."
+  fi
+  popd
+}
+
+test_find_all_poms_with_versioned_dependency
+test_update_pom_dependency
+test_parse_pom_version

--- a/.kokoro/presubmit/downstream-build.sh
+++ b/.kokoro/presubmit/downstream-build.sh
@@ -15,16 +15,12 @@
 
 set -eo pipefail
 
-# Define the google-cloud-java modules to be tested
 if [ -z "${MODULES_UNDER_TEST}" ]; then
   echo "MODULES_UNDER_TEST must be set to run downstream-build.sh"
   exit 1
 fi
-# Define the dedicated client library repos to be tested
-if [ -z "${REPOS_UNDER_TEST}" ]; then
-  echo "REPOS_UNDER_TEST must be set to run downstream-build.sh"
-  exit 1
-fi
+# Use default value for REPOS_UNDER_TEST if unset. If set to empty string, maintain empty string.
+REPOS_UNDER_TEST=${REPOS_UNDER_TEST-"java-storage"}
 
 ## Get the directory of the build script
 scriptDir=$(realpath "$(dirname "${BASH_SOURCE[0]}")")

--- a/.kokoro/presubmit/downstream-build.sh
+++ b/.kokoro/presubmit/downstream-build.sh
@@ -20,6 +20,9 @@ if [ -z "${MODULES_UNDER_TEST}" ]; then
   exit 1
 fi
 # Use default value for REPOS_UNDER_TEST if unset. If set to empty string, maintain empty string.
+#
+# java-storage is currently the only downstream repo that doesn't require cloud resources for its
+#   GraalVM integration tests.
 REPOS_UNDER_TEST=${REPOS_UNDER_TEST-"java-storage"}
 
 ## Get the directory of the build script

--- a/.kokoro/presubmit/downstream-build.sh
+++ b/.kokoro/presubmit/downstream-build.sh
@@ -61,12 +61,11 @@ update_all_poms_dependency google-cloud-java google-cloud-shared-dependencies "$
 
 ### Round 4
 # Run the updated java-shared-dependencies BOM against google-cloud-java integration tests
-pushd google-cloud-java
+cd google-cloud-java
 source ./.kokoro/common.sh
 RETURN_CODE=0
 setup_application_credentials
 setup_cloud "$MODULES_UNDER_TEST"
 run_graalvm_tests "$MODULES_UNDER_TEST"
-popd
-
+# Exit must occur in google-cloud-java directory to correctly destroy IT resources
 exit "$RETURN_CODE"

--- a/.kokoro/presubmit/downstream-compatibility.sh
+++ b/.kokoro/presubmit/downstream-compatibility.sh
@@ -21,21 +21,20 @@ if [ -z "${REPOS_UNDER_TEST}" ]; then
   exit 1
 fi
 
-## Get the directory of the build script
+# Get the directory of the build script
 scriptDir=$(realpath "$(dirname "${BASH_SOURCE[0]}")")
-## cd to the parent directory, i.e. the root of the git repo
-cd "${scriptDir}/../.."
+cd "${scriptDir}/../.." # cd to the root of this repo
 source "$scriptDir/common.sh"
 
-# Use GCP Maven Mirror
+echo "Setup maven mirror"
 mkdir -p "${HOME}/.m2"
 cp settings.xml "${HOME}/.m2"
 
-# Publish this repo's modules to local maven to make them available for downstream libraries
-mvn -B -ntp install --projects '!gapic-generator-java' \
+echo "Installing this repo's modules to local maven."
+mvn -q -B -ntp install --projects '!gapic-generator-java' \
   -Dcheckstyle.skip -Dfmt.skip -DskipTests -T 1C
-
 SHARED_DEPS_VERSION=$(parse_pom_version java-shared-dependencies)
+echo "Install complete. java-shared-dependencies = $SHARED_DEPS_VERSION"
 
 pushd java-shared-dependencies/target
 for repo in ${REPOS_UNDER_TEST//,/ }; do # Split on comma

--- a/.kokoro/presubmit/downstream-compatibility.sh
+++ b/.kokoro/presubmit/downstream-compatibility.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+# Define the dedicated client library repos to be tested in a comma-separated list
+if [ -z "${REPOS_UNDER_TEST}" ]; then
+  REPOS_UNDER_TEST='
+    google-cloud-java
+    java-bigtable
+    java-bigquery
+    java-bigquerystorage
+    java-datastore
+    java-firestore
+    java-logging
+    java-logging-logback
+    java-pubsub
+    java-pubsublite
+    java-spanner-jdbc
+    java-spanner
+    java-storage
+    java-storage-nio
+  '
+fi
+
+## Get the directory of the build script
+scriptDir=$(realpath "$(dirname "${BASH_SOURCE[0]}")")
+## cd to the parent directory, i.e. the root of the git repo
+cd "${scriptDir}/../.."
+source "$scriptDir/common.sh"
+
+# Use GCP Maven Mirror
+mkdir -p "${HOME}/.m2"
+cp settings.xml "${HOME}/.m2"
+
+### Round 1
+# Publish this repo's modules to local maven to make them available for downstream libraries
+mvn -B -ntp install --projects '!gapic-generator-java' \
+  -Dcheckstyle.skip -Dfmt.skip -DskipTests -T 1C
+
+SHARED_DEPS_VERSION=$(parse_pom_version java-shared-dependencies)
+
+pushd java-shared-dependencies/target
+for repo in $REPOS_UNDER_TEST; do
+  git clone "https://github.com/googleapis/$repo.git" --depth=1
+  update_all_poms_dependency "$repo" google-cloud-shared-dependencies "$SHARED_DEPS_VERSION"
+  pushd "$repo"
+  JOB_TYPE="test" ./.kokoro/build.sh
+  popd
+done
+popd

--- a/.kokoro/presubmit/downstream-compatibility.sh
+++ b/.kokoro/presubmit/downstream-compatibility.sh
@@ -38,7 +38,9 @@ echo "Install complete. java-shared-dependencies = $SHARED_DEPS_VERSION"
 
 pushd java-shared-dependencies/target
 for repo in ${REPOS_UNDER_TEST//,/ }; do # Split on comma
-  git clone "https://github.com/googleapis/$repo.git" --depth=1
+  # Perform testing on last release, not HEAD
+  last_release=$(find_last_release_version "$repo")
+  git clone "https://github.com/googleapis/$repo.git" --depth=1 --branch "v$last_release"
   update_all_poms_dependency "$repo" google-cloud-shared-dependencies "$SHARED_DEPS_VERSION"
   pushd "$repo"
   JOB_TYPE="test" ./.kokoro/build.sh

--- a/.kokoro/presubmit/downstream-compatibility.sh
+++ b/.kokoro/presubmit/downstream-compatibility.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2019 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Adds a new GitHub workflow to perform downstream testing on client libraries.

1. Installs sdk-platform-java to local maven.
2. Checks out the downstream repository at the latest release associated with the main branch, not HEAD.
3. Updates all dependencies on java-shared-dependency to the local version.
4. Compiles and invokes unit tests for the given client libraries. 
 
Does not invoke integration tests. Downstream integration testing is limited to google-cloud-java via the existing GraalVM Kokoro presubmits.


