### PR TITLE
ci: use java 17 with sonar

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -13,10 +13,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
       - name: Cache SonarCloud packages
         uses: actions/cache@v3


### PR DESCRIPTION
From recent PRs' sonar scan results:

![image](https://github.com/googleapis/sdk-platform-java/assets/40617934/9c9dae26-cc16-40bf-a7b9-121bbd663eb1) The version of Java (11.0.19) you have used to run this [Sonar] analysis is deprecated and we will stop accepting it soon. Please update to at least Java 17.
Read more [here](https://docs.sonarcloud.io/appendices/scanner-environment/)