### PR TITLE
ci: showcase now uses shared-dependencies

### DIFF
--- a/gapic-generator-java-bom/pom.xml
+++ b/gapic-generator-java-bom/pom.xml
@@ -30,6 +30,14 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>com.google.auth</groupId>
+        <artifactId>google-auth-library-oauth2-http</artifactId>
+        <version>${google.auth.version}</version>
+        <type>test-jar</type>
+        <classifier>testlib</classifier>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-bom</artifactId>
         <version>${google.http-client.version}</version>

--- a/showcase/gapic-showcase/pom.xml
+++ b/showcase/gapic-showcase/pom.xml
@@ -232,7 +232,6 @@
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
-      <version>${google.auth.version}</version>
       <type>test-jar</type>
       <classifier>testlib</classifier>
       <scope>test</scope>

--- a/showcase/pom.xml
+++ b/showcase/pom.xml
@@ -13,10 +13,10 @@
   </description>
 
   <parent>
-    <groupId>com.google.api</groupId>
-    <artifactId>gapic-generator-java-bom</artifactId>
-    <version>2.24.1-SNAPSHOT</version><!-- {x-version-update:gapic-generator-java:current} -->
-    <relativePath>../gapic-generator-java-bom</relativePath>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>google-cloud-shared-config</artifactId>
+    <version>1.5.7</version>
+    <relativePath/>
   </parent>
 
   <properties>
@@ -31,6 +31,13 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-shared-dependencies</artifactId>
+        <version>3.14.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-shared-dependencies:current} -->
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-gapic-showcase-v1beta1</artifactId>


### PR DESCRIPTION
Primary change:
Showcase now uses shared-config as its parent, and imports shared-deps in its dependency management. This makes showcase more consistent with production client libraries which is useful for testing.

Secondary change:
Shared dependencies (via gapic-generator-java-bom) now includes a declaration for the google-auth-library-oauth2-http testlib.