### PR TITLE
feat: Adding vendor and vendor information in header

### DIFF
--- a/gax-java/gax/src/main/java/com/google/api/gax/core/GaxProperties.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/core/GaxProperties.java
@@ -29,10 +29,8 @@
  */
 package com.google.api.gax.core;
 
-import static org.graalvm.nativeimage.ImageInfo.PROPERTY_IMAGE_CODE_KEY;
-import static org.graalvm.nativeimage.ImageInfo.PROPERTY_IMAGE_CODE_VALUE_RUNTIME;
-
 import com.google.api.core.InternalApi;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import java.io.IOException;
 import java.io.InputStream;
@@ -85,12 +83,6 @@ public class GaxProperties {
 
   /** Returns the version of the running JVM */
   public static String getJavaVersion() {
-    // When running the application as a native image, append `-graalvm` to the
-    // version.
-    String imageCode = System.getProperty(PROPERTY_IMAGE_CODE_KEY);
-    if (imageCode != null && imageCode.equals(PROPERTY_IMAGE_CODE_VALUE_RUNTIME)) {
-      return System.getProperty("java.version") + "-graalvm";
-    }
     return JAVA_VERSION;
   }
 
@@ -99,8 +91,12 @@ public class GaxProperties {
     return GAX_VERSION;
   }
 
-  /** Returns the current runtime version */
-  private static String getRuntimeVersion() {
+  /**
+   * Returns the current runtime version. For GraalVM the values in this method will be fetched at
+   * build time and the values should not differ from runtime (executable)
+   */
+  @VisibleForTesting
+  static String getRuntimeVersion() {
     String javaRuntimeInformation = System.getProperty("java.version");
 
     // append the vendor information to the java-version if vendor is present.

--- a/gax-java/gax/src/main/java/com/google/api/gax/core/GaxProperties.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/core/GaxProperties.java
@@ -33,6 +33,7 @@ import static org.graalvm.nativeimage.ImageInfo.PROPERTY_IMAGE_CODE_KEY;
 import static org.graalvm.nativeimage.ImageInfo.PROPERTY_IMAGE_CODE_VALUE_RUNTIME;
 
 import com.google.api.core.InternalApi;
+import com.google.common.base.Strings;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
@@ -100,23 +101,22 @@ public class GaxProperties {
 
   /** Returns the current runtime version */
   private static String getRuntimeVersion() {
-    String javaVersion = System.getProperty("java.version");
-    String combined = javaVersion;
+    String javaRuntimeInformation = System.getProperty("java.version");
 
     // append the vendor information to the java-version if vendor is present.
     String vendor = System.getProperty("java.vendor");
-    if (vendor != null && !vendor.isEmpty()) {
-      combined = String.format("%s__%s", combined, vendor);
+    if (!Strings.isNullOrEmpty(vendor)) {
+      javaRuntimeInformation = String.format("%s__%s", javaRuntimeInformation, vendor);
     }
 
     // appends the vendor version information to the java-version if vendor version is present.
     String vendorVersion = System.getProperty("java.vendor.version");
-    if (vendorVersion != null && !vendorVersion.isEmpty()) {
-      combined = String.format("%s__%s", combined, vendorVersion);
+    if (!Strings.isNullOrEmpty(vendorVersion)) {
+      javaRuntimeInformation = String.format("%s__%s", javaRuntimeInformation, vendorVersion);
     }
 
     // replacing all characters that are not numbers, letters, underscores, periods, or backslashes
     // with hyphens.
-    return combined.replaceAll("[^0-9a-zA-Z_\\\\.]", "-");
+    return javaRuntimeInformation.replaceAll("[^0-9a-zA-Z_\\\\.]", "-");
   }
 }

--- a/gax-java/gax/src/main/java/com/google/api/gax/core/GaxProperties.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/core/GaxProperties.java
@@ -93,24 +93,22 @@ public class GaxProperties {
 
   /**
    * Returns the current runtime version. For GraalVM the values in this method will be fetched at
-   * build time and the values should not differ from runtime (executable)
+   * build time and the values should not differ from the runtime (executable)
    */
   @VisibleForTesting
   static String getRuntimeVersion() {
-    String javaRuntimeInformation = System.getProperty("java.version");
+    String javaRuntimeInformation = System.getProperty("java.version", "null");
 
     // append the vendor information to the java-version if vendor is present.
     String vendor = System.getProperty("java.vendor");
     if (!Strings.isNullOrEmpty(vendor)) {
       javaRuntimeInformation = String.format("%s__%s", javaRuntimeInformation, vendor);
+      // appends the vendor version information to the java-version if vendor version is present.
+      String vendorVersion = System.getProperty("java.vendor.version");
+      if (!Strings.isNullOrEmpty(vendorVersion)) {
+        javaRuntimeInformation = String.format("%s__%s", javaRuntimeInformation, vendorVersion);
+      }
     }
-
-    // appends the vendor version information to the java-version if vendor version is present.
-    String vendorVersion = System.getProperty("java.vendor.version");
-    if (!Strings.isNullOrEmpty(vendorVersion)) {
-      javaRuntimeInformation = String.format("%s__%s", javaRuntimeInformation, vendorVersion);
-    }
-
     // replacing all characters that are not numbers, letters, underscores, periods, or backslashes
     // with hyphens.
     return javaRuntimeInformation.replaceAll("[^0-9a-zA-Z_\\\\.]", "-");

--- a/gax-java/gax/src/main/java/com/google/api/gax/core/GaxProperties.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/core/GaxProperties.java
@@ -100,6 +100,23 @@ public class GaxProperties {
 
   /** Returns the current runtime version */
   private static String getRuntimeVersion() {
-    return System.getProperty("java.version");
+    String javaVersion = System.getProperty("java.version");
+    String combined = javaVersion;
+
+    // append the vendor information to the java-version if vendor is present.
+    String vendor = System.getProperty("java.vendor");
+    if (vendor != null && !vendor.isEmpty()) {
+      combined = String.format("%s__%s", combined, vendor);
+    }
+
+    // appends the vendor version information to the java-version if vendor version is present.
+    String vendorVersion = System.getProperty("java.vendor.version");
+    if (vendorVersion != null && !vendorVersion.isEmpty()) {
+      combined = String.format("%s__%s", combined, vendorVersion);
+    }
+
+    // replacing all characters that are not numbers, letters, underscores, periods, or backslashes
+    // with hyphens.
+    return combined.replaceAll("[^0-9a-zA-Z_\\\\.]", "-");
   }
 }

--- a/gax-java/gax/src/test/java/com/google/api/gax/core/GaxPropertiesTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/core/GaxPropertiesTest.java
@@ -84,7 +84,7 @@ public class GaxPropertiesTest {
   }
 
   @Test
-  public void testGetJavaRuntimeInfoCaseGraalVM() {
+  public void testGetJavaRuntimeInfo_graalVM() {
 
     System.setProperty("java.version", "17.0.3");
     System.setProperty("java.vendor", "GraalVM Community");
@@ -95,7 +95,7 @@ public class GaxPropertiesTest {
   }
 
   @Test
-  public void testGetJavaRuntimeInfoCaseTemurin() {
+  public void testGetJavaRuntimeInfo_temurin() {
     System.setProperty("java.version", "11.0.19");
     System.setProperty("java.vendor", "Eclipse Adoptium");
     System.setProperty("java.vendor.version", "Temurin-11.0.19+7");
@@ -105,7 +105,7 @@ public class GaxPropertiesTest {
   }
 
   @Test
-  public void testGetJavaRuntimeInfoCaseCoretto() {
+  public void testGetJavaRuntimeInfo_coretto() {
     System.setProperty("java.version", "11.0.19");
     System.setProperty("java.vendor", "Amazon.com Inc.");
     System.setProperty("java.vendor.version", "Corretto-11.0.19.7.1");
@@ -115,7 +115,7 @@ public class GaxPropertiesTest {
   }
 
   @Test
-  public void testGetJavaRuntimeInfoCaseOracle() {
+  public void testGetJavaRuntimeInfo_oracle() {
     System.setProperty("java.version", "20.0.1");
     System.setProperty("java.vendor", "Oracle Corporation");
     // case where java.vendor.version is null
@@ -126,7 +126,7 @@ public class GaxPropertiesTest {
   }
 
   @Test
-  public void testGetJavaRuntimeInfoCaseNullValues() {
+  public void testGetJavaRuntimeInfo_nullVendorVersion() {
     System.setProperty("java.version", "20.0.1");
     // case where java.vendor and java.vendor.version is null
     System.clearProperty("java.vendor");
@@ -134,5 +134,18 @@ public class GaxPropertiesTest {
 
     String runtimeInfo = GaxProperties.getRuntimeVersion();
     assertEquals("20.0.1", runtimeInfo);
+  }
+
+  @Test
+  public void testGetJavaRuntimeInfo_nullJavaVersion() {
+    // We don't expect this case to happen, however we don't want the method to fail when it really
+    // happens.
+    System.clearProperty("java.version");
+    // case where java.vendor and java.vendor.version is null
+    System.setProperty("java.vendor", "oracle");
+    System.setProperty("java.vendor.version", "20.0.1");
+
+    String runtimeInfo = GaxProperties.getRuntimeVersion();
+    assertEquals("null__oracle__20.0.1", runtimeInfo);
   }
 }

--- a/gax-java/gax/src/test/java/com/google/api/gax/core/GaxPropertiesTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/core/GaxPropertiesTest.java
@@ -84,8 +84,9 @@ public class GaxPropertiesTest {
   }
 
   @Test
-  public void testGetJavaRuntimeInfo_graalVM_withSpaces() {
+  public void testGetJavaRuntimeInfo_graalVM() {
     // This case is one of major Java vendors
+    // testing if spaces are handled properly [ replaced with hyphen ("-") ]
     System.setProperty("java.version", "17.0.3");
     System.setProperty("java.vendor", "GraalVM Community");
     System.setProperty("java.vendor.version", "GraalVM CE 22.1.0");
@@ -95,8 +96,9 @@ public class GaxPropertiesTest {
   }
 
   @Test
-  public void testGetJavaRuntimeInfo_temurin_withSpacesAndSpecialCharacters() {
+  public void testGetJavaRuntimeInfo_temurin() {
     // This case is one of major Java vendors
+    // testing if spaces and special characters are handled properly [ replaced with hyphen ("-") ]
     System.setProperty("java.version", "11.0.19");
     System.setProperty("java.vendor", "Eclipse Adoptium");
     System.setProperty("java.vendor.version", "Temurin-11.0.19+7");
@@ -117,7 +119,7 @@ public class GaxPropertiesTest {
   }
 
   @Test
-  public void testGetJavaRuntimeInfo_oracle_nullVendorVersion() {
+  public void testGetJavaRuntimeInfo_nullVendorVersion() {
     System.setProperty("java.version", "20.0.1");
     System.setProperty("java.vendor", "Oracle Corporation");
     // case where java.vendor.version is null

--- a/gax-java/gax/src/test/java/com/google/api/gax/core/GaxPropertiesTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/core/GaxPropertiesTest.java
@@ -29,8 +29,6 @@
  */
 package com.google.api.gax.core;
 
-import static org.graalvm.nativeimage.ImageInfo.PROPERTY_IMAGE_CODE_KEY;
-import static org.graalvm.nativeimage.ImageInfo.PROPERTY_IMAGE_CODE_VALUE_RUNTIME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 

--- a/gax-java/gax/src/test/java/com/google/api/gax/core/GaxPropertiesTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/core/GaxPropertiesTest.java
@@ -31,9 +31,12 @@ package com.google.api.gax.core;
 
 import static org.graalvm.nativeimage.ImageInfo.PROPERTY_IMAGE_CODE_KEY;
 import static org.graalvm.nativeimage.ImageInfo.PROPERTY_IMAGE_CODE_VALUE_RUNTIME;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.regex.Pattern;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -62,5 +65,30 @@ public class GaxPropertiesTest {
     System.setProperty(PROPERTY_IMAGE_CODE_KEY, PROPERTY_IMAGE_CODE_VALUE_RUNTIME);
     String javaVersion = GaxProperties.getJavaVersion();
     assertTrue(javaVersion.endsWith("-graalvm"));
+  }
+
+  private static String originalJavaVersion = System.getProperty("java.version");
+  private static String originalJavaVendor = System.getProperty("java.vendor");
+  private static String originalJavaVendorVersion = System.getProperty("java.vendor.version");
+
+  @BeforeClass
+  public static void setup() {
+    System.setProperty("java.version", "11.1.2");
+    System.setProperty("java.vendor", "GraalVM Community");
+    System.setProperty("java.vendor.version", "GraalVM CE 22.3.0");
+  }
+
+  @AfterClass
+  public static void cleanup() {
+    System.setProperty("java.version", originalJavaVersion);
+    System.setProperty("java.vendor", originalJavaVendor);
+    System.setProperty("java.vendor.version", originalJavaVendorVersion);
+  }
+
+  @Test
+  public void testGetJavaRuntimeInfo() {
+    String runtimeInfo = GaxProperties.getJavaVersion();
+    System.out.println(runtimeInfo);
+    assertEquals("11.1.2__GraalVM-Community__GraalVM-CE-22.3.0", runtimeInfo);
   }
 }

--- a/gax-java/gax/src/test/java/com/google/api/gax/core/GaxPropertiesTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/core/GaxPropertiesTest.java
@@ -34,9 +34,8 @@ import static org.graalvm.nativeimage.ImageInfo.PROPERTY_IMAGE_CODE_VALUE_RUNTIM
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.base.Strings;
 import java.util.regex.Pattern;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -60,34 +59,73 @@ public class GaxPropertiesTest {
     }
   }
 
-  @Test
-  public void testGetVersion_nativeImage() {
-    System.setProperty(PROPERTY_IMAGE_CODE_KEY, PROPERTY_IMAGE_CODE_VALUE_RUNTIME);
-    String javaVersion = GaxProperties.getJavaVersion();
-    assertTrue(javaVersion.endsWith("-graalvm"));
-  }
-
   private static String originalJavaVersion = System.getProperty("java.version");
   private static String originalJavaVendor = System.getProperty("java.vendor");
   private static String originalJavaVendorVersion = System.getProperty("java.vendor.version");
 
-  @BeforeClass
-  public static void setup() {
-    System.setProperty("java.version", "11.1.2");
-    System.setProperty("java.vendor", "GraalVM Community");
-    System.setProperty("java.vendor.version", "GraalVM CE 22.3.0");
-  }
-
-  @AfterClass
   public static void cleanup() {
-    System.setProperty("java.version", originalJavaVersion);
-    System.setProperty("java.vendor", originalJavaVendor);
-    System.setProperty("java.vendor.version", originalJavaVendorVersion);
+    if (Strings.isNullOrEmpty(originalJavaVersion)) {
+      System.clearProperty("java.version");
+    } else {
+      System.setProperty("java.version", originalJavaVersion);
+    }
+
+    if (Strings.isNullOrEmpty(originalJavaVendor)) {
+      System.clearProperty("java.vendor");
+    } else {
+      System.setProperty("java.vendor", originalJavaVendor);
+    }
+
+    if (Strings.isNullOrEmpty(originalJavaVendorVersion)) {
+      System.clearProperty("java.vendor.version");
+    } else {
+      System.setProperty("java.vendor.version", originalJavaVendorVersion);
+    }
   }
 
   @Test
-  public void testGetJavaRuntimeInfo() {
-    String runtimeInfo = GaxProperties.getJavaVersion();
-    assertEquals("11.1.2__GraalVM-Community__GraalVM-CE-22.3.0", runtimeInfo);
+  public void testGetJavaRuntimeInfoCaseGraalVM() {
+
+    System.setProperty("java.version", "17.0.3");
+    System.setProperty("java.vendor", "GraalVM Community");
+    System.setProperty("java.vendor.version", "GraalVM CE 22.1.0");
+
+    String runtimeInfo = GaxProperties.getRuntimeVersion();
+    assertEquals("17.0.3__GraalVM-Community__GraalVM-CE-22.1.0", runtimeInfo);
+    cleanup();
+  }
+
+  @Test
+  public void testGetJavaRuntimeInfoCaseOne() {
+    System.setProperty("java.version", "11.0.19");
+    System.setProperty("java.vendor", "Eclipse Adoptium");
+    System.setProperty("java.vendor.version", "Temurin-11.0.19+7");
+
+    String runtimeInfo = GaxProperties.getRuntimeVersion();
+    assertEquals("11.0.19__Eclipse-Adoptium__Temurin-11.0.19-7", runtimeInfo);
+    cleanup();
+  }
+
+  @Test
+  public void testGetJavaRuntimeInfoCaseTwo() {
+    System.setProperty("java.version", "11.0.19");
+    System.setProperty("java.vendor", "Amazon.com Inc.");
+    System.setProperty("java.vendor.version", "Corretto-11.0.19.7.1");
+
+    String runtimeInfo = GaxProperties.getRuntimeVersion();
+    assertEquals("11.0.19__Amazon.com-Inc.__Corretto-11.0.19.7.1", runtimeInfo);
+    cleanup();
+  }
+
+  @Test
+  public void testGetJavaRuntimeInfoCaseThree() {
+    System.setProperty("java.version", "20.0.1");
+    System.setProperty("java.vendor", "Oracle Corporation");
+    // case where java.vendor.version is null
+    System.clearProperty("java.vendor.version");
+
+    String runtimeInfo = GaxProperties.getRuntimeVersion();
+    assertEquals("20.0.1__Oracle-Corporation", runtimeInfo);
+    cleanup();
   }
 }

--- a/gax-java/gax/src/test/java/com/google/api/gax/core/GaxPropertiesTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/core/GaxPropertiesTest.java
@@ -126,4 +126,16 @@ public class GaxPropertiesTest {
     assertEquals("20.0.1__Oracle-Corporation", runtimeInfo);
     cleanup();
   }
+
+  @Test
+  public void testGetJavaRuntimeInfoCaseFour() {
+    System.setProperty("java.version", "20.0.1");
+    // case where java.vendor and java.vendor.version is null
+    System.clearProperty("java.vendor");
+    System.clearProperty("java.vendor.version");
+
+    String runtimeInfo = GaxProperties.getRuntimeVersion();
+    assertEquals("20.0.1", runtimeInfo);
+    cleanup();
+  }
 }

--- a/gax-java/gax/src/test/java/com/google/api/gax/core/GaxPropertiesTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/core/GaxPropertiesTest.java
@@ -86,7 +86,6 @@ public class GaxPropertiesTest {
   @Test
   public void testGetJavaRuntimeInfo_graalVM() {
     // This case is one of major Java vendors
-    // testing if spaces are handled properly [ replaced with hyphen ("-") ]
     System.setProperty("java.version", "17.0.3");
     System.setProperty("java.vendor", "GraalVM Community");
     System.setProperty("java.vendor.version", "GraalVM CE 22.1.0");
@@ -98,7 +97,6 @@ public class GaxPropertiesTest {
   @Test
   public void testGetJavaRuntimeInfo_temurin() {
     // This case is one of major Java vendors
-    // testing if spaces and special characters are handled properly [ replaced with hyphen ("-") ]
     System.setProperty("java.version", "11.0.19");
     System.setProperty("java.vendor", "Eclipse Adoptium");
     System.setProperty("java.vendor.version", "Temurin-11.0.19+7");
@@ -119,20 +117,31 @@ public class GaxPropertiesTest {
   }
 
   @Test
+  public void testGetJavaRuntimeInfo_specialCharacters() {
+    // testing for unsupported characters and spaces
+    System.setProperty("java.version", "20%^.&0~.1#45`*");
+    System.setProperty("java.vendor", "A^!@#$*B()[]{} C ~%& D-E ?");
+    System.setProperty("java.vendor.version", "1!@%$@#.AB!346.9^");
+
+    String runtimeInfo = GaxProperties.getRuntimeVersion();
+    assertEquals("20--.-0-.1-45--__A------B-------C-----D-E--__1------.AB-346.9-", runtimeInfo);
+  }
+
+  @Test
   public void testGetJavaRuntimeInfo_nullVendorVersion() {
+    // testing for null java.vendor.version
     System.setProperty("java.version", "20.0.1");
-    System.setProperty("java.vendor", "Oracle Corporation");
-    // case where java.vendor.version is null
+    System.setProperty("java.vendor", "Oracle");
     System.clearProperty("java.vendor.version");
 
     String runtimeInfo = GaxProperties.getRuntimeVersion();
-    assertEquals("20.0.1__Oracle-Corporation", runtimeInfo);
+    assertEquals("20.0.1__Oracle", runtimeInfo);
   }
 
   @Test
   public void testGetJavaRuntimeInfo_nullVendorAndVendorVersion() {
+    // testing for null java.vendor and java.vendor.version
     System.setProperty("java.version", "20.0.1");
-    // case where java.vendor and java.vendor.version is null
     System.clearProperty("java.vendor");
     System.clearProperty("java.vendor.version");
 
@@ -142,10 +151,11 @@ public class GaxPropertiesTest {
 
   @Test
   public void testGetJavaRuntimeInfo_nullJavaVersion() {
+    // testing for null java.version
     // We don't expect this case to happen, however we don't want the method to fail when it really
     // happens.
+
     System.clearProperty("java.version");
-    // case where java.vendor and java.vendor.version is null
     System.setProperty("java.vendor", "oracle");
     System.setProperty("java.vendor.version", "20.0.1");
 

--- a/gax-java/gax/src/test/java/com/google/api/gax/core/GaxPropertiesTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/core/GaxPropertiesTest.java
@@ -88,7 +88,6 @@ public class GaxPropertiesTest {
   @Test
   public void testGetJavaRuntimeInfo() {
     String runtimeInfo = GaxProperties.getJavaVersion();
-    System.out.println(runtimeInfo);
     assertEquals("11.1.2__GraalVM-Community__GraalVM-CE-22.3.0", runtimeInfo);
   }
 }

--- a/gax-java/gax/src/test/java/com/google/api/gax/core/GaxPropertiesTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/core/GaxPropertiesTest.java
@@ -84,7 +84,7 @@ public class GaxPropertiesTest {
   }
 
   @Test
-  public void testGetJavaRuntimeInfo_spaces() {
+  public void testGetJavaRuntimeInfo_graalVM_withSpaces() {
     // This case is one of major Java vendors
     System.setProperty("java.version", "17.0.3");
     System.setProperty("java.vendor", "GraalVM Community");
@@ -95,7 +95,7 @@ public class GaxPropertiesTest {
   }
 
   @Test
-  public void testGetJavaRuntimeInfo_spacesAndSpecialCharacters() {
+  public void testGetJavaRuntimeInfo_temurin_withSpacesAndSpecialCharacters() {
     // This case is one of major Java vendors
     System.setProperty("java.version", "11.0.19");
     System.setProperty("java.vendor", "Eclipse Adoptium");
@@ -106,7 +106,7 @@ public class GaxPropertiesTest {
   }
 
   @Test
-  public void testGetJavaRuntimeInfo_nullVendorVersion() {
+  public void testGetJavaRuntimeInfo_oracle_nullVendorVersion() {
     System.setProperty("java.version", "20.0.1");
     System.setProperty("java.vendor", "Oracle Corporation");
     // case where java.vendor.version is null

--- a/gax-java/gax/src/test/java/com/google/api/gax/core/GaxPropertiesTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/core/GaxPropertiesTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.common.base.Strings;
 import java.util.regex.Pattern;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -61,7 +62,8 @@ public class GaxPropertiesTest {
   private static String originalJavaVendor = System.getProperty("java.vendor");
   private static String originalJavaVendorVersion = System.getProperty("java.vendor.version");
 
-  public static void cleanup() {
+  @After
+  public void cleanup() {
     if (Strings.isNullOrEmpty(originalJavaVersion)) {
       System.clearProperty("java.version");
     } else {
@@ -90,33 +92,30 @@ public class GaxPropertiesTest {
 
     String runtimeInfo = GaxProperties.getRuntimeVersion();
     assertEquals("17.0.3__GraalVM-Community__GraalVM-CE-22.1.0", runtimeInfo);
-    cleanup();
   }
 
   @Test
-  public void testGetJavaRuntimeInfoCaseOne() {
+  public void testGetJavaRuntimeInfoCaseTemurin() {
     System.setProperty("java.version", "11.0.19");
     System.setProperty("java.vendor", "Eclipse Adoptium");
     System.setProperty("java.vendor.version", "Temurin-11.0.19+7");
 
     String runtimeInfo = GaxProperties.getRuntimeVersion();
     assertEquals("11.0.19__Eclipse-Adoptium__Temurin-11.0.19-7", runtimeInfo);
-    cleanup();
   }
 
   @Test
-  public void testGetJavaRuntimeInfoCaseTwo() {
+  public void testGetJavaRuntimeInfoCaseCoretto() {
     System.setProperty("java.version", "11.0.19");
     System.setProperty("java.vendor", "Amazon.com Inc.");
     System.setProperty("java.vendor.version", "Corretto-11.0.19.7.1");
 
     String runtimeInfo = GaxProperties.getRuntimeVersion();
     assertEquals("11.0.19__Amazon.com-Inc.__Corretto-11.0.19.7.1", runtimeInfo);
-    cleanup();
   }
 
   @Test
-  public void testGetJavaRuntimeInfoCaseThree() {
+  public void testGetJavaRuntimeInfoCaseOracle() {
     System.setProperty("java.version", "20.0.1");
     System.setProperty("java.vendor", "Oracle Corporation");
     // case where java.vendor.version is null
@@ -124,11 +123,10 @@ public class GaxPropertiesTest {
 
     String runtimeInfo = GaxProperties.getRuntimeVersion();
     assertEquals("20.0.1__Oracle-Corporation", runtimeInfo);
-    cleanup();
   }
 
   @Test
-  public void testGetJavaRuntimeInfoCaseFour() {
+  public void testGetJavaRuntimeInfoCaseNullValues() {
     System.setProperty("java.version", "20.0.1");
     // case where java.vendor and java.vendor.version is null
     System.clearProperty("java.vendor");
@@ -136,6 +134,5 @@ public class GaxPropertiesTest {
 
     String runtimeInfo = GaxProperties.getRuntimeVersion();
     assertEquals("20.0.1", runtimeInfo);
-    cleanup();
   }
 }

--- a/gax-java/gax/src/test/java/com/google/api/gax/core/GaxPropertiesTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/core/GaxPropertiesTest.java
@@ -106,6 +106,17 @@ public class GaxPropertiesTest {
   }
 
   @Test
+  public void testGetJavaRuntimeInfo_coretto() {
+    // This case is one of major Java vendors
+    System.setProperty("java.version", "11.0.19");
+    System.setProperty("java.vendor", "Amazon.com Inc.");
+    System.setProperty("java.vendor.version", "Corretto-11.0.19.7.1");
+
+    String runtimeInfo = GaxProperties.getRuntimeVersion();
+    assertEquals("11.0.19__Amazon.com-Inc.__Corretto-11.0.19.7.1", runtimeInfo);
+  }
+
+  @Test
   public void testGetJavaRuntimeInfo_oracle_nullVendorVersion() {
     System.setProperty("java.version", "20.0.1");
     System.setProperty("java.vendor", "Oracle Corporation");

--- a/gax-java/gax/src/test/java/com/google/api/gax/core/GaxPropertiesTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/core/GaxPropertiesTest.java
@@ -84,8 +84,8 @@ public class GaxPropertiesTest {
   }
 
   @Test
-  public void testGetJavaRuntimeInfo_graalVM() {
-
+  public void testGetJavaRuntimeInfo_spaces() {
+    // This case is one of major Java vendors
     System.setProperty("java.version", "17.0.3");
     System.setProperty("java.vendor", "GraalVM Community");
     System.setProperty("java.vendor.version", "GraalVM CE 22.1.0");
@@ -95,7 +95,8 @@ public class GaxPropertiesTest {
   }
 
   @Test
-  public void testGetJavaRuntimeInfo_temurin() {
+  public void testGetJavaRuntimeInfo_spacesAndSpecialCharacters() {
+    // This case is one of major Java vendors
     System.setProperty("java.version", "11.0.19");
     System.setProperty("java.vendor", "Eclipse Adoptium");
     System.setProperty("java.vendor.version", "Temurin-11.0.19+7");
@@ -105,17 +106,7 @@ public class GaxPropertiesTest {
   }
 
   @Test
-  public void testGetJavaRuntimeInfo_coretto() {
-    System.setProperty("java.version", "11.0.19");
-    System.setProperty("java.vendor", "Amazon.com Inc.");
-    System.setProperty("java.vendor.version", "Corretto-11.0.19.7.1");
-
-    String runtimeInfo = GaxProperties.getRuntimeVersion();
-    assertEquals("11.0.19__Amazon.com-Inc.__Corretto-11.0.19.7.1", runtimeInfo);
-  }
-
-  @Test
-  public void testGetJavaRuntimeInfo_oracle() {
+  public void testGetJavaRuntimeInfo_nullVendorVersion() {
     System.setProperty("java.version", "20.0.1");
     System.setProperty("java.vendor", "Oracle Corporation");
     // case where java.vendor.version is null
@@ -126,7 +117,7 @@ public class GaxPropertiesTest {
   }
 
   @Test
-  public void testGetJavaRuntimeInfo_nullVendorVersion() {
+  public void testGetJavaRuntimeInfo_nullVendorAndVendorVersion() {
     System.setProperty("java.version", "20.0.1");
     // case where java.vendor and java.vendor.version is null
     System.clearProperty("java.vendor");


### PR DESCRIPTION
This PR adds java vendor information to the "gl-java" header value. Only when the information is present, add it to `javaRuntimeInformation`.

Local testing results for various combinations- 

(1)
the vendor is -> Eclipse Adoptium
the vendor version is -> Temurin-11.0.19+7
**the javaRuntimeInformation is -> 11.0.19__Eclipse-Adoptium__Temurin-11.0.19-7**

(2)
the vendor is ->Amazon.com Inc.
the vendor version is ->Corretto-11.0.19.7.1
**the javaRuntimeInformation is ->11.0.19__Amazon.com-Inc.__Corretto-11.0.19.7.1**


(3)
the vendor is ->Eclipse Adoptium
the vendor version is ->Temurin-11.0.20.1+1
**the javaRuntimeInformation is ->11.0.20.1__Eclipse-Adoptium__Temurin-11.0.20.1-1**


(4) [Case when vendor version is not available]
the vendor is ->Oracle Corporation
the vendor version is ->null
**the javaRuntimeInformation is ->20.0.1__Oracle-Corporation**
