### PR TITLE
wip: OS detection and single-folder output for hermetic build scripts

### DIFF
--- a/.github/workflows/verify_library_generation.yaml
+++ b/.github/workflows/verify_library_generation.yaml
@@ -28,8 +28,7 @@ jobs:
         library_generation/test/generate_library_integration_test.sh \
         -p google/bigtable/v2 \
         -d google-cloud-bigtable-v2-java \
-        --googleapis_gen_url https://cloud-java-bot:${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}@github.com/googleapis/googleapis-gen.git \
-        --os_type ${{ matrix.os }}
+        --googleapis_gen_url https://cloud-java-bot:${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}@github.com/googleapis/googleapis-gen.git
   unit_tests:
     strategy:
       matrix:

--- a/library_generation/generate_library.sh
+++ b/library_generation/generate_library.sh
@@ -79,8 +79,19 @@ if [ -z "${include_samples}" ]; then
 fi
 
 if [ -z "${os_architecture}" ]; then
-  os_architecture="linux-x86_64"
+  if [[ "${OSTYPE}" == "linux-gnu"* ]] || [[ "${OSTYPE}" == "freebsd"* ]]; then
+    os_architecture="linux-x86_64"
+  elif [[ "${OSTYPE}" == "darwin"* ]]; then
+    os_architecture="osx-x86_64"
+  elif [[ "${OSTYPE}" == "cygwin" ]] || [[ "${OSTYPE}" == "msys" ]]; then
+    os_architecture="win32"
+  else
+    echo 'could not detect OS. Please specify it with --os_architecture'
+    exit 1
+  fi
+  echo "Using OS architecture: ${os_architecture}"
 fi
+
 
 mkdir -p "${destination_path}"
 ##################### Section 0 #####################

--- a/library_generation/generate_library.sh
+++ b/library_generation/generate_library.sh
@@ -86,10 +86,11 @@ if [ -z "${os_architecture}" ]; then
   elif [[ "${OSTYPE}" == "cygwin" ]] || [[ "${OSTYPE}" == "msys" ]]; then
     os_architecture="win32"
   else
-    echo 'could not detect OS. Please specify it with --os_architecture'
+    echo 'Could not detect OS. Please specify it with --os_architecture'
+    echo 'Also, see https://github.com/protocolbuffers/protobuf/releases for a list of available OS (e.g. linux-aarch_64)'
     exit 1
   fi
-  echo "Using OS architecture: ${os_architecture}"
+  echo "Detected OS architecture: ${os_architecture}"
 fi
 
 

--- a/library_generation/generate_library.sh
+++ b/library_generation/generate_library.sh
@@ -54,6 +54,7 @@ shift # past argument or value
 done
 
 script_dir=$(dirname "$(readlink -f "$0")")
+output_folder="${script_dir}/output"
 # source utility functions
 source "${script_dir}"/utilities.sh
 
@@ -88,6 +89,7 @@ mkdir -p "${destination_path}"
 # the order of services entries in gapic_metadata.json is relevant to the
 # order of proto file, sort the proto files with respect to their name to
 # get a fixed order.
+pwd
 proto_files=$(find "${proto_path}" -type f  -name "*.proto" | sort)
 folder_name=$(extract_folder_name "${destination_path}")
 # download gapic-generator-java, protobuf and grpc plugin.
@@ -95,6 +97,7 @@ download_tools "${gapic_generator_version}" "${protobuf_version}" "${grpc_versio
 ##################### Section 1 #####################
 # generate grpc-*/
 #####################################################
+pushd "${output_folder}"
 "${protoc_path}"/protoc "--plugin=protoc-gen-rpc-plugin=protoc-gen-grpc-java-${grpc_version}-${os_architecture}.exe" \
 "--rpc-plugin_out=:${destination_path}/java_grpc.jar" \
 ${proto_files} # Do not quote because this variable should not be treated as one long string.
@@ -153,6 +156,7 @@ for proto_src in ${proto_files}; do
   mkdir -p "${destination_path}/proto-${folder_name}/src/main/proto"
   rsync -R "${proto_src}" "${destination_path}/proto-${folder_name}/src/main/proto"
 done
+popd # output_folder
 ##################### Section 4 #####################
 # rm tar files
 #####################################################

--- a/library_generation/generate_library.sh
+++ b/library_generation/generate_library.sh
@@ -79,22 +79,11 @@ if [ -z "${include_samples}" ]; then
 fi
 
 if [ -z "${os_architecture}" ]; then
-  if [[ "${OSTYPE}" == "linux-gnu"* ]] || [[ "${OSTYPE}" == "freebsd"* ]]; then
-    os_architecture="linux-x86_64"
-  elif [[ "${OSTYPE}" == "darwin"* ]]; then
-    os_architecture="osx-x86_64"
-  elif [[ "${OSTYPE}" == "cygwin" ]] || [[ "${OSTYPE}" == "msys" ]]; then
-    os_architecture="win32"
-  else
-    echo 'Could not detect OS. Please specify it with --os_architecture'
-    echo 'Also, see https://github.com/protocolbuffers/protobuf/releases for a list of available OS (e.g. linux-aarch_64)'
-    exit 1
-  fi
-  echo "Detected OS architecture: ${os_architecture}"
+  os_architecture=$(detect_OS)
 fi
 
 
-mkdir -p "${destination_path}"
+mkdir -p "${output_folder}/${destination_path}"
 ##################### Section 0 #####################
 # prepare tooling
 #####################################################
@@ -172,6 +161,6 @@ popd # output_folder
 ##################### Section 4 #####################
 # rm tar files
 #####################################################
-cd "${destination_path}"
+cd "${output_folder}/${destination_path}"
 rm -rf java_gapic_srcjar java_gapic_srcjar_raw.srcjar.zip java_grpc.jar java_proto.jar temp-codegen.srcjar
 set +x

--- a/library_generation/test/generate_library_integration_test.sh
+++ b/library_generation/test/generate_library_integration_test.sh
@@ -100,7 +100,7 @@ sparse_clone "${googleapis_gen_url}" "${proto_path}"
 
 echo "Compare generation result..."
 RESULT=0
-diff -r "googleapis-gen/${proto_path}/${destination_path}" "${destination_path}" -x "*gradle*" || RESULT=$?
+diff -r "googleapis-gen/${proto_path}/${destination_path}" "${output_folder}/${destination_path}" -x "*gradle*" || RESULT=$?
 
 if [ ${RESULT} == 0 ] ; then
   echo "SUCCESS: Comparison finished, no difference is found."

--- a/library_generation/test/generate_library_integration_test.sh
+++ b/library_generation/test/generate_library_integration_test.sh
@@ -45,11 +45,14 @@ done
 script_dir=$(dirname "$(readlink -f "$0")")
 source "${script_dir}/../utilities.sh"
 library_generation_dir="${script_dir}"/..
-cd "${library_generation_dir}"
+output_folder="${library_generation_dir}/output"
+mkdir -p "${output_folder}"
+pushd "${output_folder}"
 # checkout the master branch of googleapis/google (proto files) and WORKSPACE
 echo "Checking out googlapis repository..."
 sparse_clone https://github.com/googleapis/googleapis.git "${proto_path} WORKSPACE google/api google/rpc google/cloud/common_resources.proto google/iam/v1 google/type google/longrunning"
-cd googleapis
+pushd googleapis
+cp -r google "${output_folder}"
 # parse version of gapic-generator-java, protobuf and grpc from WORKSPACE
 gapic_generator_version=$(get_version_from_WORKSPACE "_gapic_generator_java_version" WORKSPACE "=")
 echo "The version of gapic-generator-java is ${gapic_generator_version}."
@@ -82,6 +85,7 @@ os_architecture="linux-x86_64"
 if [[ "$os_type" == *"macos"* ]]; then
   os_architecture="osx-x86_64"
 fi
+popd
 echo "OS Architecture is ${os_architecture}."
 # generate GAPIC client library
 echo "Generating library from ${proto_path}, to ${destination_path}..."

--- a/library_generation/test/generate_library_integration_test.sh
+++ b/library_generation/test/generate_library_integration_test.sh
@@ -81,12 +81,6 @@ include_samples=$(get_config_from_BUILD \
   "false"
 )
 echo "GAPIC options are transport=${transport}, rest_numeric_enums=${rest_numeric_enums}, include_samples=${include_samples}."
-os_architecture="linux-x86_64"
-if [[ "$os_type" == *"macos"* ]]; then
-  os_architecture="osx-x86_64"
-fi
-popd
-echo "OS Architecture is ${os_architecture}."
 # generate GAPIC client library
 echo "Generating library from ${proto_path}, to ${destination_path}..."
 "${library_generation_dir}"/generate_library.sh \
@@ -97,8 +91,7 @@ echo "Generating library from ${proto_path}, to ${destination_path}..."
 --grpc_version "${grpc_version}" \
 --transport "${transport}" \
 --rest_numeric_enums "${rest_numeric_enums}" \
---include_samples "${include_samples}" \
---os_architecture "${os_architecture}"
+--include_samples "${include_samples}"
 
 echo "Generate library finished."
 echo "Checking out googleapis-gen repository..."

--- a/library_generation/test/generate_library_unit_tests.sh
+++ b/library_generation/test/generate_library_unit_tests.sh
@@ -181,15 +181,14 @@ generate_library_failed_with_invalid_generator_version() {
   local destination="google-cloud-alloydb-v1-java"
   local res=0
   cd "${script_dir}/resources"
-  $("${script_dir}"/../generate_library.sh \
+  "${script_dir}"/../generate_library.sh \
     -p google/cloud/alloydb/v1 \
     -d ../"${destination}" \
     --gapic_generator_version 1.99.0 \
     --protobuf_version 23.2 \
     --grpc_version 1.55.1 \
     --transport grpc+rest \
-    --rest_numeric_enums true \
-    --os_architecture "$(__get_os_architecture)") || res=$?
+    --rest_numeric_enums true || res=$?
   assertEquals 1 $((res))
   # still need to clean up potential downloaded tooling.
   cleanup "${destination}"
@@ -199,15 +198,14 @@ generate_library_failed_with_invalid_protobuf_version() {
   local destination="google-cloud-alloydb-v1-java"
   local res=0
   cd "${script_dir}/resources"
-  $("${script_dir}"/../generate_library.sh \
+  "${script_dir}"/../generate_library.sh \
     -p google/cloud/alloydb/v1 \
     -d ../"${destination}" \
     --gapic_generator_version 2.24.0 \
     --protobuf_version 22.99 \
     --grpc_version 1.55.1 \
     --transport grpc+rest \
-    --rest_numeric_enums true \
-    --os_architecture "$(__get_os_architecture)") || res=$?
+    --rest_numeric_enums true || res=$?
   assertEquals 1 $((res))
   # still need to clean up potential downloaded tooling.
   cleanup "${destination}"
@@ -217,14 +215,13 @@ generate_library_failed_with_invalid_grpc_version() {
   local destination="google-cloud-alloydb-v1-java"
   local res=0
   cd "${script_dir}/resources"
-  $("${script_dir}"/../generate_library.sh \
+  "${script_dir}"/../generate_library.sh \
     -p google/cloud/alloydb/v1 \
-    -d ../"${destination}" \
+    -d ../output/"${destination}" \
     --gapic_generator_version 2.24.0 \
     --grpc_version 0.99.0 \
     --transport grpc+rest \
-    --rest_numeric_enums true \
-    --os_architecture "$(__get_os_architecture)") || res=$?
+    --rest_numeric_enums true || res=$?
   assertEquals 1 $((res))
   # still need to clean up potential downloaded tooling.
   cleanup "${destination}"

--- a/library_generation/test/resources/2
+++ b/library_generation/test/resources/2
@@ -1,0 +1,1 @@
+Detected OS architecture: linux-x86_64

--- a/library_generation/test/resources/2
+++ b/library_generation/test/resources/2
@@ -1,1 +1,0 @@
-Detected OS architecture: linux-x86_64

--- a/library_generation/utilities.sh
+++ b/library_generation/utilities.sh
@@ -275,3 +275,19 @@ get_version_from_versions_txt() {
   version=$(grep "$key:" "${versions}" | cut -d: -f3) # 3rd field is snapshot
   echo "${version}"
 }
+
+detect_OS() {
+  if [[ "${OSTYPE}" == "linux-gnu"* ]] || [[ "${OSTYPE}" == "freebsd"* ]]; then
+    os_architecture="linux-x86_64"
+  elif [[ "${OSTYPE}" == "darwin"* ]]; then
+    os_architecture="osx-x86_64"
+  elif [[ "${OSTYPE}" == "cygwin" ]] || [[ "${OSTYPE}" == "msys" ]]; then
+    os_architecture="win32"
+  else
+    >&2 echo 'Could not detect OS. Please specify it with --os_architecture'
+    >&2 echo 'Also, see https://github.com/protocolbuffers/protobuf/releases for a list of available OS (e.g. linux-aarch_64)'
+    exit 1
+  fi
+  >&2 echo "Detected OS architecture: ${os_architecture}" >2
+  echo "${os_architecture}"
+}

--- a/library_generation/utilities.sh
+++ b/library_generation/utilities.sh
@@ -137,6 +137,7 @@ get_protobuf_version() {
 }
 
 download_tools() {
+  pushd "${output_folder}"
   local gapic_generator_version=$1
   local protobuf_version=$2
   local grpc_version=$3
@@ -144,6 +145,7 @@ download_tools() {
   download_generator "${gapic_generator_version}"
   download_protobuf "${protobuf_version}" "${os_architecture}"
   download_grpc_plugin "${grpc_version}" "${os_architecture}"
+  popd
 }
 
 download_generator() {
@@ -177,7 +179,7 @@ download_protobuf() {
     rm "protobuf-${protobuf_version}.zip"
   fi
 
-  protoc_path=protobuf-${protobuf_version}/bin
+  protoc_path="${output_folder}/protobuf-${protobuf_version}/bin"
 }
 
 download_grpc_plugin() {
@@ -257,13 +259,13 @@ sparse_clone() {
   clone_dir=$(basename "${repo_url%.*}")
   rm -rf "${clone_dir}"
   git clone -n --depth=1 --no-single-branch --filter=tree:0 "${repo_url}"
-  cd "${clone_dir}"
+  pushd "${clone_dir}"
   if [ -n "${commitish}" ]; then
     git checkout "${commitish}"
   fi
   git sparse-checkout set --no-cone ${paths}
   git checkout
-  cd ..
+  popd
 }
 
 # takes a versions.txt file and returns its version


### PR DESCRIPTION
* All generated and downloaded files will go to `${script_dir}/output` to make cleanup easier
* OS is now detected and an optional argument