### PR TITLE
docs: add release level to gax metadata

### DIFF
--- a/gax-java/.repo-metadata.json
+++ b/gax-java/.repo-metadata.json
@@ -5,6 +5,7 @@
   "api_description": "Google API Extensions for Java (GAX Java) is a library which aids in the development of client libraries for server APIs, based on GRPC and Google API conventions.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/gax/latest/overview",
   "language": "java",
+  "release_level": "stable",
   "repo": "googleapis/sdk-platform-java",
   "repo_short": "gax-java",
   "library_type": "OTHER",


### PR DESCRIPTION
Fixes: https://github.com/googleapis/sdk-platform-java/issues/2021