### PR TITLE
fix(hermetic-build): obtain gapic-generator-java locally on release branch

### DIFF
--- a/library_generation/README.md
+++ b/library_generation/README.md
@@ -72,9 +72,8 @@ You can find the released version of gapic-generator-java in [maven central](htt
 
 Use `--gapic_generator_version` to specify the value.
 
-Note that you can specify a `SNAPSHOT` version as long as you have build the SNAPSHOT of gapic-generator-java in your maven
-local repository. If this is a release branch (i.e.
-`release-please--branches--main`) it will also be obtained locally.
+Note that you can specify any non-published version (e.g. a SNAPSHOT) as long as you have installed it in your maven
+local repository. The script will search locally first.
 
 ### protobuf_version (optional)
 You can find the released version of protobuf in [GitHub](https://github.com/protocolbuffers/protobuf/releases/).

--- a/library_generation/README.md
+++ b/library_generation/README.md
@@ -73,7 +73,8 @@ You can find the released version of gapic-generator-java in [maven central](htt
 Use `--gapic_generator_version` to specify the value.
 
 Note that you can specify a `SNAPSHOT` version as long as you have build the SNAPSHOT of gapic-generator-java in your maven
-local repository.
+local repository. If this is a release branch (i.e.
+`release-please--branches--main`) it will also be obtained locally.
 
 ### protobuf_version (optional)
 You can find the released version of protobuf in [GitHub](https://github.com/protocolbuffers/protobuf/releases/).

--- a/library_generation/test/generate_library_unit_tests.sh
+++ b/library_generation/test/generate_library_unit_tests.sh
@@ -78,9 +78,11 @@ remove_grpc_version_test() {
 }
 
 download_generator_success_with_valid_version_test() {
-  download_generator "2.24.0"
-  assertFileOrDirectoryExists "gapic-generator-java-2.24.0.jar"
-  rm "gapic-generator-java-2.24.0.jar"
+  local version="2.24.0"
+  local artifact="gapic-generator-java-${version}.jar"
+  download_generator_artifact "${version}" "${artifact}"
+  assertFileOrDirectoryExists "${artifact}"
+  rm "${artifact}"
 }
 
 download_generator_failed_with_invalid_version_test() {
@@ -91,7 +93,9 @@ download_generator_failed_with_invalid_version_test() {
   # the other tests can continue executing in the current
   # shell.
   local res=0
-  $(download_generator "1.99.0") || res=$?
+  local version="1.99.0"
+  local artifact="gapic-generator-java-${version}.jar"
+  $(download_generator_artifact "${version}" "${artifact}") || res=$?
   assertEquals 1 $((res))
 }
 

--- a/library_generation/utilities.sh
+++ b/library_generation/utilities.sh
@@ -171,7 +171,8 @@ download_from() {
 copy_from() {
   local local_repo=$1
   local save_as=$2
-  cp "${local_repo}" "${save_as}" && echo "false" || echo "true"
+  not_found_locally=$(cp "${local_repo}" "${save_as}" && echo "false" || echo "true")
+  echo "${not_found_locally}"
 }
 
 download_fail() {

--- a/library_generation/utilities.sh
+++ b/library_generation/utilities.sh
@@ -114,9 +114,9 @@ download_generator_artifact() {
   local project=${3:-"gapic-generator-java"}
   if [ ! -f "gapic-generator-java-${gapic_generator_version}.jar" ]; then
     # first, try to fetch the generator locally
-    local not_found_locally=$(copy_from "$HOME/.m2/repository/com/google/api/${project}/${gapic_generator_version}/${artifact}" \
+    local local_fetch_successful=$(copy_from "$HOME/.m2/repository/com/google/api/${project}/${gapic_generator_version}/${artifact}" \
       "${artifact}")
-    if [[ "${not_found_locally}" == "true" ]];then 
+    if [[ "${local_fetch_successful}" == "false" ]];then 
       # download gapic-generator-java artifact from Google maven central mirror if not
       # found locally
       >&2 echo "${artifact} not found locally. Attempting a download from Maven Central"
@@ -166,13 +166,12 @@ download_from() {
 }
 
 # copies the specified file in $1 to $2
-# will return "false" if the copy was successful, otherwise true (to indicate
-# that there is a failure)
+# will return "true" if the copy was successful
 copy_from() {
   local local_repo=$1
   local save_as=$2
-  not_found_locally=$(cp "${local_repo}" "${save_as}" && echo "false" || echo "true")
-  echo "${not_found_locally}"
+  copy_successful=$(cp "${local_repo}" "${save_as}" && echo "true" || echo "false")
+  echo "${copy_successful}"
 }
 
 download_fail() {

--- a/library_generation/utilities.sh
+++ b/library_generation/utilities.sh
@@ -170,8 +170,7 @@ download_from() {
 copy_from() {
   local local_repo=$1
   local save_as=$2
-  local not_found_locally=$(cp "${local_repo}" "${save_as}" && echo "false" || echo "true")
-  echo "${not_found_locally}"
+  cp "${local_repo}" "${save_as}" && echo "false" || echo "true"
 }
 
 download_fail() {

--- a/library_generation/utilities.sh
+++ b/library_generation/utilities.sh
@@ -166,7 +166,8 @@ download_from() {
 }
 
 # copies the specified file in $1 to $2
-# will print "true" if $1 (local_repo) points to a non-existent file
+# will return "false" if the copy was successful, otherwise true (to indicate
+# that there is a failure)
 copy_from() {
   local local_repo=$1
   local save_as=$2

--- a/library_generation/utilities.sh
+++ b/library_generation/utilities.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 set -xeo pipefail
-util_script_dir=$(dirname "${BASH_SOURCE}")
 
 # Utility functions used in `generate_library.sh` and showcase generation.
 extract_folder_name() {
@@ -76,18 +75,7 @@ remove_grpc_version() {
 
 download_gapic_generator_pom_parent() {
   local gapic_generator_version=$1
-  if [ ! -f "gapic-generator-java-pom-parent-${gapic_generator_version}.pom" ]; then
-    # first, try to fetch the generator pom locally
-    bash -c "source ${util_script_dir}/utilities.sh && copy_from \"$HOME/.m2/repository/com/google/api/gapic-generator-java-pom-parent/${gapic_generator_version}/gapic-generator-java-pom-parent-${gapic_generator_version}.pom\" \
-    \"gapic-generator-java-pom-parent-${gapic_generator_version}.pom\"" || not_found_locally="true"
-    if [[ "${not_found_locally}" == "true" ]];then 
-      # download gapic-generator-java-pom-parent from Google maven central mirror.
-      download_from \
-      "https://maven-central.storage-download.googleapis.com/maven2/com/google/api/gapic-generator-java-pom-parent/${gapic_generator_version}/gapic-generator-java-pom-parent-${gapic_generator_version}.pom" \
-      "gapic-generator-java-pom-parent-${gapic_generator_version}.pom"
-    fi
-  fi
-  # file exists, do not need to download again.
+  download_generator_artifact "${gapic_generator_version}" "gapic-generator-java-pom-parent-${gapic_generator_version}.pom" "gapic-generator-java-pom-parent"
 }
 
 get_grpc_version() {
@@ -114,24 +102,27 @@ download_tools() {
   local protobuf_version=$2
   local grpc_version=$3
   local os_architecture=$4
-  download_generator "${gapic_generator_version}"
+  download_generator_artifact "${gapic_generator_version}" "gapic-generator-java-${gapic_generator_version}.jar"
   download_protobuf "${protobuf_version}" "${os_architecture}"
   download_grpc_plugin "${grpc_version}" "${os_architecture}"
   popd
 }
 
-download_generator() {
+download_generator_artifact() {
   local gapic_generator_version=$1
+  local artifact=$2
+  local project=${3:-"gapic-generator-java"}
   if [ ! -f "gapic-generator-java-${gapic_generator_version}.jar" ]; then
     # first, try to fetch the generator locally
-    bash -c "source ${util_script_dir}/utilities.sh && copy_from \"$HOME/.m2/repository/com/google/api/gapic-generator-java/${gapic_generator_version}/gapic-generator-java-${gapic_generator_version}.jar\" \
-    \"gapic-generator-java-${gapic_generator_version}.jar\"" || not_found_locally="true"
+    local not_found_locally=$(copy_from "$HOME/.m2/repository/com/google/api/${project}/${gapic_generator_version}/${artifact}" \
+      "${artifact}")
     if [[ "${not_found_locally}" == "true" ]];then 
-      # download gapic-generator-java from Google maven central mirror if not
+      # download gapic-generator-java artifact from Google maven central mirror if not
       # found locally
+      echo "${artifact} not found locally. Attempting a download from Maven Central"
       download_from \
-      "https://maven-central.storage-download.googleapis.com/maven2/com/google/api/gapic-generator-java/${gapic_generator_version}/gapic-generator-java-${gapic_generator_version}.jar" \
-      "gapic-generator-java-${gapic_generator_version}.jar"
+      "https://maven-central.storage-download.googleapis.com/maven2/com/google/api/${project}/${gapic_generator_version}/${artifact}" \
+      "${artifact}"
     fi
   fi
 }
@@ -174,17 +165,19 @@ download_from() {
   curl -LJ -o "${save_as}" --fail -m 30 --retry 2 "$url" || download_fail "${save_as}" "${repo}"
 }
 
+# copies the specified file in $1 to $2
+# will print "true" if $1 (local_repo) points to a non-existent file
 copy_from() {
   local local_repo=$1
   local save_as=$2
-  cp "${local_repo}" "${save_as}" || \
-    download_fail "${save_as}" "maven local"
+  local not_found_locally=$(cp "${local_repo}" "${save_as}" && echo "false" || echo "true")
+  echo "${not_found_locally}"
 }
 
 download_fail() {
   local artifact=$1
   local repo=${2:-"maven central mirror"}
-  >&2 echo "Fail to download ${artifact} from ${repo} repository. Please install ${artifact} first if you want to download a SNAPSHOT."
+  >&2 echo "Fail to download ${artifact} from ${repo} repository. Please install ${artifact} first if you want to use a non-published artifact."
   exit 1
 }
 

--- a/library_generation/utilities.sh
+++ b/library_generation/utilities.sh
@@ -76,7 +76,9 @@ remove_grpc_version() {
 download_gapic_generator_pom_parent() {
   local gapic_generator_version=$1
   if [ ! -f "gapic-generator-java-pom-parent-${gapic_generator_version}.pom" ]; then
-    if [[ "${gapic_generator_version}" == *"-SNAPSHOT" ]]; then
+    # release please branches will point to a non-snapshot that hasn't been
+    # published. We want to get the generator pom locally in this case
+    if [[ "${gapic_generator_version}" == *"-SNAPSHOT" ]] || [[ "$(is_release_branch)" == "true" ]]; then
       # copy a SNAPSHOT version from maven local repository.
       copy_from "$HOME/.m2/repository/com/google/api/gapic-generator-java-pom-parent/${gapic_generator_version}/gapic-generator-java-pom-parent-${gapic_generator_version}.pom" \
       "gapic-generator-java-pom-parent-${gapic_generator_version}.pom"
@@ -123,7 +125,9 @@ download_tools() {
 download_generator() {
   local gapic_generator_version=$1
   if [ ! -f "gapic-generator-java-${gapic_generator_version}.jar" ]; then
-    if [[ "${gapic_generator_version}" == *"-SNAPSHOT" ]]; then
+    # release please branches will point to a non-snapshot that hasn't been
+    # published. We want to get the generator locally in this case
+    if [[ "${gapic_generator_version}" == *"-SNAPSHOT" ]] || [[ "$(is_release_branch)" == "true" ]]; then
       # copy a SNAPSHOT version from maven local repository.
       copy_from "$HOME/.m2/repository/com/google/api/gapic-generator-java/${gapic_generator_version}/gapic-generator-java-${gapic_generator_version}.jar" \
       "gapic-generator-java-${gapic_generator_version}.jar"
@@ -211,4 +215,13 @@ detect_os_architecture() {
       ;;
   esac
   echo "${os_architecture}"
+}
+
+# returns true if we are on a release branch
+is_release_branch() {
+  if [ $(git rev-parse --abbrev-ref HEAD) == "release-please--branches--main" ]; then
+    echo "true"
+    return
+  fi
+  echo "false"
 }

--- a/library_generation/utilities.sh
+++ b/library_generation/utilities.sh
@@ -123,6 +123,9 @@ download_generator_artifact() {
       download_from \
       "https://maven-central.storage-download.googleapis.com/maven2/com/google/api/${project}/${gapic_generator_version}/${artifact}" \
       "${artifact}"
+      >&2 echo "${artifact} found and downloaded from Maven Central"
+    else
+      >&2 echo "${artifact} found copied from local repository (~/.m2)"
     fi
   fi
 }

--- a/library_generation/utilities.sh
+++ b/library_generation/utilities.sh
@@ -119,7 +119,7 @@ download_generator_artifact() {
     if [[ "${not_found_locally}" == "true" ]];then 
       # download gapic-generator-java artifact from Google maven central mirror if not
       # found locally
-      echo "${artifact} not found locally. Attempting a download from Maven Central"
+      >&2 echo "${artifact} not found locally. Attempting a download from Maven Central"
       download_from \
       "https://maven-central.storage-download.googleapis.com/maven2/com/google/api/${project}/${gapic_generator_version}/${artifact}" \
       "${artifact}"


### PR DESCRIPTION
This prevents the [failures](https://github.com/googleapis/sdk-platform-java/actions/runs/6263228150/job/17007141447?pr=1978) from showcase tests on the release-please branch since it tries to fetch a non-published version (`2.26.0`). The fix is to check whether we are on a release please branch as an additional condition to fetch the generator jar and pom locally.