### PR TITLE
chore: revert exclusion for `j2objc-annotations`

### DIFF
--- a/gapic-generator-java/pom.xml
+++ b/gapic-generator-java/pom.xml
@@ -424,12 +424,6 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java-util</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.j2objc</groupId>
-          <artifactId>j2objc-annotations</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>

--- a/gax-java/dependencies.properties
+++ b/gax-java/dependencies.properties
@@ -26,9 +26,6 @@ version.gax_httpjson=2.34.1-SNAPSHOT
 # The protobuf version is only used for generating gradle files for showcase module,
 # not for self-service clients (from googleapis project).
 
-# On next protobuf upgrade (to 3.23.3 or higher),
-# remove temporarily j2objc-annotations exclusions from protobuf-java-util dependencies.
-# For context: https://github.com/googleapis/sdk-platform-java/pull/1791
 version.com_google_protobuf=3.24.3
 version.google_java_format=1.15.0
 version.io_grpc=1.58.0

--- a/gax-java/gax-httpjson/pom.xml
+++ b/gax-java/gax-httpjson/pom.xml
@@ -67,12 +67,6 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java-util</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.j2objc</groupId>
-          <artifactId>j2objc-annotations</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>

--- a/java-core/google-cloud-core/pom.xml
+++ b/java-core/google-cloud-core/pom.xml
@@ -33,12 +33,6 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java-util</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.j2objc</groupId>
-          <artifactId>j2objc-annotations</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>


### PR DESCRIPTION
Reverts a temporary solution from https://github.com/googleapis/sdk-platform-java/pull/1791#issuecomment-1601587713 that excludes `j2objc-annotations` brought by `protobuf-java-util` which has a differing version. 

With protobuf `24.3`, this should not be necessary anymore