### PR TITLE
fix: [POC] point to documentation on LRO CancelledException

### DIFF
--- a/gax-java/gax/src/main/java/com/google/api/gax/longrunning/OperationTimedPollAlgorithm.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/longrunning/OperationTimedPollAlgorithm.java
@@ -77,7 +77,9 @@ public class OperationTimedPollAlgorithm extends ExponentialRetryAlgorithm {
     if (super.shouldRetry(nextAttemptSettings)) {
       return true;
     }
-    throw new CancellationException();
+    throw new CancellationException(
+        "The task has been cancelled. Please refer to "
+            + "https://github.com/googleapis/google-cloud-java#lro-timeouts for more information");
   }
 
   // Note: if the potential time spent is exactly equal to the totalTimeout,

--- a/gax-java/gax/src/main/java/com/google/api/gax/longrunning/OperationTimedPollAlgorithm.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/longrunning/OperationTimedPollAlgorithm.java
@@ -43,6 +43,10 @@ import java.util.concurrent.CancellationException;
  * algorithm cancels polling.
  */
 public class OperationTimedPollAlgorithm extends ExponentialRetryAlgorithm {
+
+  public static final String LRO_TROUBLESHOOTING_LINK =
+      "https://github.com/googleapis/google-cloud-java#lro-timeouts";
+
   /**
    * Creates the polling algorithm, using the default {@code NanoClock} for time computations.
    *
@@ -79,7 +83,7 @@ public class OperationTimedPollAlgorithm extends ExponentialRetryAlgorithm {
     }
     throw new CancellationException(
         "The task has been cancelled. Please refer to "
-            + "https://github.com/googleapis/google-cloud-java#lro-timeouts for more information");
+            + LRO_TROUBLESHOOTING_LINK + " for more information");
   }
 
   // Note: if the potential time spent is exactly equal to the totalTimeout,

--- a/gax-java/gax/src/main/java/com/google/api/gax/retrying/BasicRetryingFuture.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/retrying/BasicRetryingFuture.java
@@ -67,6 +67,8 @@ class BasicRetryingFuture<ResponseT> extends AbstractFuture<ResponseT>
   private volatile ApiFuture<ResponseT> latestCompletedAttemptResult;
   private volatile ApiFuture<ResponseT> attemptResult;
 
+  private volatile CancellationException customCancellationException = null;
+
   private static final Logger LOG = Logger.getLogger(BasicRetryingFuture.class.getName());
 
   BasicRetryingFuture(
@@ -205,6 +207,9 @@ class BasicRetryingFuture<ResponseT> extends AbstractFuture<ResponseT>
       } catch (CancellationException e) {
         // A retry algorithm triggered cancellation.
         tracer.attemptFailedRetriesExhausted(e);
+        // The exception caught here is coming from gax code. We save it in order to throw
+        // this exception as the main one, while keeping guava's `Task was cancelled.` as a cause
+        customCancellationException = e;
         super.cancel(false);
       } catch (Exception e) {
         // Should never happen, but still possible in case of buggy retry algorithm implementation.
@@ -261,6 +266,18 @@ class BasicRetryingFuture<ResponseT> extends AbstractFuture<ResponseT>
       // execution. In case if a callback is executed in a separate thread executor (the recommended
       // way) the exception will be thrown in a separate thread and will not be swallowed by this
       // catch block anyways.
+    }
+  }
+
+  public ResponseT get() throws InterruptedException, ExecutionException{
+    try {
+      return super.get();
+    } catch (CancellationException ex) {
+      if (customCancellationException instanceof CancellationException) {
+        customCancellationException.initCause(ex);
+        throw customCancellationException;
+      }
+      throw ex;
     }
   }
 

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITLongRunningOperation.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITLongRunningOperation.java
@@ -147,10 +147,10 @@ public class ITLongRunningOperation {
       OperationFuture<WaitResponse, WaitMetadata> operationFuture =
           grpcClient.waitOperationCallable().futureCall(waitRequest);
       CancellationException cancellationException =
-              assertThrows(CancellationException.class, operationFuture::get);
+          assertThrows(CancellationException.class, operationFuture::get);
       assertThat(cancellationException)
-              .hasMessageThat()
-              .contains("https://github.com/googleapis/google-cloud-java#lro-timeouts");
+          .hasMessageThat()
+          .contains("https://github.com/googleapis/google-cloud-java#lro-timeouts");
       int attemptCount = operationFuture.getPollingFuture().getAttemptSettings().getAttemptCount();
       assertThat(attemptCount).isGreaterThan(1);
     } finally {

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITLongRunningOperation.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITLongRunningOperation.java
@@ -15,6 +15,7 @@
  */
 package com.google.showcase.v1beta1.it;
 
+import static com.google.api.gax.longrunning.OperationTimedPollAlgorithm.LRO_TROUBLESHOOTING_LINK;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
@@ -150,7 +151,7 @@ public class ITLongRunningOperation {
           assertThrows(CancellationException.class, operationFuture::get);
       assertThat(cancellationException)
           .hasMessageThat()
-          .contains("https://github.com/googleapis/google-cloud-java#lro-timeouts");
+          .contains(LRO_TROUBLESHOOTING_LINK);
       int attemptCount = operationFuture.getPollingFuture().getAttemptSettings().getAttemptCount();
       assertThat(attemptCount).isGreaterThan(1);
     } finally {
@@ -193,7 +194,7 @@ public class ITLongRunningOperation {
           assertThrows(CancellationException.class, operationFuture::get);
       assertThat(cancellationException)
           .hasMessageThat()
-          .contains("https://github.com/googleapis/google-cloud-java#lro-timeouts");
+          .contains(LRO_TROUBLESHOOTING_LINK);
       int attemptCount = operationFuture.getPollingFuture().getAttemptSettings().getAttemptCount();
       assertThat(attemptCount).isGreaterThan(1);
     } finally {

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITLongRunningOperation.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITLongRunningOperation.java
@@ -146,7 +146,11 @@ public class ITLongRunningOperation {
               .build();
       OperationFuture<WaitResponse, WaitMetadata> operationFuture =
           grpcClient.waitOperationCallable().futureCall(waitRequest);
-      assertThrows(CancellationException.class, operationFuture::get);
+      CancellationException cancellationException =
+              assertThrows(CancellationException.class, operationFuture::get);
+      assertThat(cancellationException)
+              .hasMessageThat()
+              .contains("https://github.com/googleapis/google-cloud-java#lro-timeouts");
       int attemptCount = operationFuture.getPollingFuture().getAttemptSettings().getAttemptCount();
       assertThat(attemptCount).isGreaterThan(1);
     } finally {

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITLongRunningOperation.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITLongRunningOperation.java
@@ -185,7 +185,8 @@ public class ITLongRunningOperation {
               .build();
       OperationFuture<WaitResponse, WaitMetadata> operationFuture =
           httpjsonClient.waitOperationCallable().futureCall(waitRequest);
-      assertThrows(CancellationException.class, operationFuture::get);
+      CancellationException cancellationException = assertThrows(CancellationException.class, operationFuture::get);
+      assertThat(cancellationException).hasMessageThat().contains("https://github.com/googleapis/google-cloud-java#lro-timeouts");
       int attemptCount = operationFuture.getPollingFuture().getAttemptSettings().getAttemptCount();
       assertThat(attemptCount).isGreaterThan(1);
     } finally {

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITLongRunningOperation.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITLongRunningOperation.java
@@ -185,8 +185,11 @@ public class ITLongRunningOperation {
               .build();
       OperationFuture<WaitResponse, WaitMetadata> operationFuture =
           httpjsonClient.waitOperationCallable().futureCall(waitRequest);
-      CancellationException cancellationException = assertThrows(CancellationException.class, operationFuture::get);
-      assertThat(cancellationException).hasMessageThat().contains("https://github.com/googleapis/google-cloud-java#lro-timeouts");
+      CancellationException cancellationException =
+          assertThrows(CancellationException.class, operationFuture::get);
+      assertThat(cancellationException)
+          .hasMessageThat()
+          .contains("https://github.com/googleapis/google-cloud-java#lro-timeouts");
       int attemptCount = operationFuture.getPollingFuture().getAttemptSettings().getAttemptCount();
       assertThat(attemptCount).isGreaterThan(1);
     } finally {


### PR DESCRIPTION
This PR modifies the `CancellationException` a `LongRunningOperation` throws when a timeout deadline is met. The exception now points to the [timeouts in LRO documentation in google-cloud-java](https://github.com/googleapis/google-cloud-java#lro-timeouts)