### PR TITLE
fix: Add Geo common protos to Bazel test dependencies.

### DIFF
--- a/rules_java_gapic/java_gapic.bzl
+++ b/rules_java_gapic/java_gapic.bzl
@@ -333,6 +333,7 @@ def java_gapic_library(
     # Test deps.
     actual_test_deps = [
         "@com_google_googleapis//google/type:type_java_proto",  # Commonly used.
+        "@com_google_googleapis//google/geo/type:viewport_java_proto",  # Used by Geo.
         "@com_google_api_gax_java//gax:gax_testlib",
         "@com_google_code_gson_gson//jar",
         "@junit_junit//jar",


### PR DESCRIPTION
The generated unit tests for google/maps/places is not compilable, this is due to a Geo common proto is not added to Bazel test dependencies. See cl/567435528 and yaqs/8970072045605879808 for details.

In long term, the Bazel Java test should be replaced with Maven/Gradle tests, so all the dependencies are managed through the gapic-generator-java jar instead of Bazel. This should be done as part of the Hermetic build project, cc: @JoeWang1127 