### PR TITLE
build: use errorprone's GuardedBy rather than javax's

### DIFF
--- a/gax-java/gax-httpjson/BUILD.bazel
+++ b/gax-java/gax-httpjson/BUILD.bazel
@@ -11,6 +11,7 @@ _COMPILE_DEPS = [
     "@com_google_code_gson_gson//jar",
     "@com_google_guava_guava//jar",
     "@com_google_code_findbugs_jsr305//jar",
+    "@com_google_errorprone_error_prone_annotations//jar",
     "@org_threeten_threetenbp//jar",
     "@com_google_http_client_google_http_client//jar",
     "@com_google_auth_google_auth_library_oauth2_http//jar",

--- a/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonClientCallImpl.java
+++ b/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonClientCallImpl.java
@@ -47,7 +47,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
-import javax.annotation.concurrent.GuardedBy;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
 
 /**
  * This class serves as main implementation of {@link HttpJsonClientCall} for REST transport and is

--- a/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonClientCallImpl.java
+++ b/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonClientCallImpl.java
@@ -35,6 +35,7 @@ import com.google.api.gax.httpjson.HttpRequestRunnable.ResultListener;
 import com.google.api.gax.httpjson.HttpRequestRunnable.RunnableResult;
 import com.google.api.gax.rpc.StatusCode;
 import com.google.common.base.Preconditions;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
@@ -47,7 +48,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
-import com.google.errorprone.annotations.concurrent.GuardedBy;
 
 /**
  * This class serves as main implementation of {@link HttpJsonClientCall} for REST transport and is

--- a/gax-java/gax/BUILD.bazel
+++ b/gax-java/gax/BUILD.bazel
@@ -16,6 +16,7 @@ _COMPILE_DEPS = [
     "@com_google_auto_value_auto_value//jar",
     "@com_google_auto_value_auto_value_annotations//jar",
     "@com_google_code_findbugs_jsr305//jar",
+    "@com_google_errorprone_error_prone_annotations//jar",
     "@com_google_guava_guava//jar",
     "@io_opencensus_opencensus_api//jar",
     "@io_opencensus_opencensus_contrib_http_util//jar",

--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingAttemptCallable.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingAttemptCallable.java
@@ -34,9 +34,9 @@ import com.google.api.gax.retrying.RetryingFuture;
 import com.google.api.gax.retrying.ServerStreamingAttemptException;
 import com.google.api.gax.retrying.StreamResumptionStrategy;
 import com.google.common.base.Preconditions;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
-import com.google.errorprone.annotations.concurrent.GuardedBy;
 
 /**
  * A callable that generates Server Streaming attempts. At any one time, it is responsible for at

--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingAttemptCallable.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingAttemptCallable.java
@@ -36,7 +36,7 @@ import com.google.api.gax.retrying.StreamResumptionStrategy;
 import com.google.common.base.Preconditions;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
-import javax.annotation.concurrent.GuardedBy;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
 
 /**
  * A callable that generates Server Streaming attempts. At any one time, it is responsible for at

--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/Watchdog.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/Watchdog.java
@@ -44,7 +44,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
-import javax.annotation.concurrent.GuardedBy;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
 import org.threeten.bp.Duration;
 
 /**

--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/Watchdog.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/Watchdog.java
@@ -32,6 +32,7 @@ package com.google.api.gax.rpc;
 import com.google.api.core.ApiClock;
 import com.google.api.gax.core.BackgroundResource;
 import com.google.common.base.Preconditions;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
 import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.concurrent.CancellationException;
@@ -44,7 +45,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
-import com.google.errorprone.annotations.concurrent.GuardedBy;
 import org.threeten.bp.Duration;
 
 /**


### PR DESCRIPTION
Towards #1938 . This pull request replaces `javax.annotation.concurrent.GuardedBy` with errorprone's annotation. The official documentation https://github.com/google/error-prone/blob/master/docs/bugpattern/GuardedBy.md uses `com.google.errorprone.annotations.concurrent.GuardedBy`.


To reviewers, if you wonder whether the GuardedBy annotation has any effect, see the Bazel build caught a bug I intentionally introduced in https://github.com/googleapis/sdk-platform-java/pull/2060.

