### PR TITLE
fix: ensure that channel pool ref count never goes negative (take2)

### DIFF
--- a/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/ChannelPool.java
+++ b/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/ChannelPool.java
@@ -68,8 +68,7 @@ import org.threeten.bp.Duration;
  * <p>Package-private for internal use.
  */
 class ChannelPool extends ManagedChannel {
-  @VisibleForTesting
-  static final Logger LOG = Logger.getLogger(ChannelPool.class.getName());
+  @VisibleForTesting static final Logger LOG = Logger.getLogger(ChannelPool.class.getName());
   private static final Duration REFRESH_PERIOD = Duration.ofMinutes(50);
 
   private final ChannelPoolSettings settings;
@@ -427,7 +426,7 @@ class ChannelPool extends ManagedChannel {
 
     void release() {
       if (!wasReleased.compareAndSet(false, true)) {
-        Exception e =  new IllegalStateException("Entry was already released");
+        Exception e = new IllegalStateException("Entry was already released");
         LOG.log(Level.WARNING, e.getMessage(), e);
         return;
       }
@@ -537,7 +536,8 @@ class ChannelPool extends ManagedChannel {
 
       RetainedEntry entry = getRetainedEntry(affinity);
 
-      return new ReleasingClientCall<>(entry.getChannel().newCall(methodDescriptor, callOptions), entry);
+      return new ReleasingClientCall<>(
+          entry.getChannel().newCall(methodDescriptor, callOptions), entry);
     }
   }
 

--- a/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/ChannelPool.java
+++ b/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/ChannelPool.java
@@ -415,6 +415,10 @@ class ChannelPool extends ManagedChannel {
     return localEntries.get(index);
   }
 
+  /**
+   * This represents the reserved refcount of a single RPC using a channel. It the responsibility of
+   * that RPC to call release exactly once when it completes to release the Channel.
+   */
   private static class RetainedEntry {
     private final Entry entry;
     private final AtomicBoolean wasReleased;

--- a/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/ChannelPool.java
+++ b/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/ChannelPool.java
@@ -417,7 +417,7 @@ class ChannelPool extends ManagedChannel {
 
   private static class RetainedEntry {
     private final Entry entry;
-    private AtomicBoolean wasReleased;
+    private final AtomicBoolean wasReleased;
 
     public RetainedEntry(Entry entry) {
       this.entry = entry;

--- a/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/ChannelPool.java
+++ b/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/ChannelPool.java
@@ -68,7 +68,8 @@ import org.threeten.bp.Duration;
  * <p>Package-private for internal use.
  */
 class ChannelPool extends ManagedChannel {
-  private static final Logger LOG = Logger.getLogger(ChannelPool.class.getName());
+  @VisibleForTesting
+  static final Logger LOG = Logger.getLogger(ChannelPool.class.getName());
   private static final Duration REFRESH_PERIOD = Duration.ofMinutes(50);
 
   private final ChannelPoolSettings settings;
@@ -439,9 +440,9 @@ class ChannelPool extends ManagedChannel {
   }
 
   /** Bundles a gRPC {@link ManagedChannel} with some usage accounting. */
-  private static class Entry {
+  static class Entry {
     private final ManagedChannel channel;
-    private final AtomicInteger outstandingRpcs = new AtomicInteger(0);
+    final AtomicInteger outstandingRpcs = new AtomicInteger(0);
     private final AtomicInteger maxOutstanding = new AtomicInteger();
 
     // Flag that the channel should be closed once all of the outstanding RPC complete.

--- a/gax-java/gax-grpc/src/test/java/com/google/api/gax/grpc/ChannelPoolTest.java
+++ b/gax-java/gax-grpc/src/test/java/com/google/api/gax/grpc/ChannelPoolTest.java
@@ -67,13 +67,9 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.logging.Filter;
 import java.util.logging.Handler;
-import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.stream.Collectors;
-
-import org.graalvm.nativeimage.LogHandler;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
@@ -692,21 +688,24 @@ public class ChannelPoolTest {
 
       // Construct a fake callable to use the channel pool
       ClientContext context =
-              ClientContext.newBuilder()
-                      .setTransportChannel(GrpcTransportChannel.create(pool))
-                      .setDefaultCallContext(GrpcCallContext.of(pool, CallOptions.DEFAULT))
-                      .build();
+          ClientContext.newBuilder()
+              .setTransportChannel(GrpcTransportChannel.create(pool))
+              .setDefaultCallContext(GrpcCallContext.of(pool, CallOptions.DEFAULT))
+              .build();
 
-      UnaryCallSettings<Color, Money> settings = UnaryCallSettings.<Color, Money>newUnaryCallSettingsBuilder().build();
+      UnaryCallSettings<Color, Money> settings =
+          UnaryCallSettings.<Color, Money>newUnaryCallSettingsBuilder().build();
       UnaryCallable<Color, Money> callable =
-              GrpcCallableFactory.createUnaryCallable(
-                      GrpcCallSettings.create(METHOD_RECOGNIZE), settings, context);
+          GrpcCallableFactory.createUnaryCallable(
+              GrpcCallSettings.create(METHOD_RECOGNIZE), settings, context);
 
       // Start the RPC
-      ApiFuture<Money> rpcFuture = callable.futureCall(Color.getDefaultInstance(), context.getDefaultCallContext());
+      ApiFuture<Money> rpcFuture =
+          callable.futureCall(Color.getDefaultInstance(), context.getDefaultCallContext());
 
       // Get the server side listener and intentionally close it twice
-      ArgumentCaptor<ClientCall.Listener<?>> clientCallListenerCaptor = ArgumentCaptor.forClass(ClientCall.Listener.class);
+      ArgumentCaptor<ClientCall.Listener<?>> clientCallListenerCaptor =
+          ArgumentCaptor.forClass(ClientCall.Listener.class);
       Mockito.verify(mockClientCall).start(clientCallListenerCaptor.capture(), Mockito.any());
       clientCallListenerCaptor.getValue().onClose(Status.INTERNAL, new Metadata());
       clientCallListenerCaptor.getValue().onClose(Status.UNKNOWN, new Metadata());
@@ -719,7 +718,6 @@ public class ChannelPoolTest {
     } finally {
       ChannelPool.LOG.removeHandler(logHandler);
     }
-
   }
 
   private static class FakeLogHandler extends Handler {
@@ -731,14 +729,10 @@ public class ChannelPoolTest {
     }
 
     @Override
-    public void flush() {
-
-    }
+    public void flush() {}
 
     @Override
-    public void close() throws SecurityException {
-
-    }
+    public void close() throws SecurityException {}
 
     List<String> getAllMessages() {
       return records.stream().map(LogRecord::getMessage).collect(Collectors.toList());


### PR DESCRIPTION
I'm not sure the root cause that might cause this, but this guard should tone down the noise that is created and help us identify the root cause

Thank you for opening a Pull Request! For general contributing guidelines, please refer to [contributing guide](https://github.com/googleapis/gapic-generator-java/blob/main/CONTRIBUTING.md)

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/gapic-generator-java/issues/new/choose) before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️