### PR TITLE
deps: Bumping java-shared-config to 1.5.8

### DIFF
--- a/gapic-generator-java-pom-parent/pom.xml
+++ b/gapic-generator-java-pom-parent/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-shared-config</artifactId>
-    <version>1.5.7</version>
+    <version>1.5.8</version>
     <relativePath/>
   </parent>
 
@@ -26,7 +26,6 @@
     <!-- External dependencies, especially gRPC and Protobuf version, should be
         consistent across modules in this repository -->
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
-    <auto-value.version>1.10.2</auto-value.version>
     <grpc.version>1.58.0</grpc.version>
     <google.auth.version>1.19.0</google.auth.version>
     <google.http-client.version>1.43.3</google.http-client.version>

--- a/gax-java/gax-bom/pom.xml
+++ b/gax-java/gax-bom/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-shared-config</artifactId>
-    <version>1.5.7</version>
+    <version>1.5.8</version>
     <relativePath/>
   </parent>
 

--- a/java-shared-dependencies/first-party-dependencies/pom.xml
+++ b/java-shared-dependencies/first-party-dependencies/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-shared-config</artifactId>
-    <version>1.5.7</version>
+    <version>1.5.8</version>
     <relativePath />
   </parent>
 

--- a/java-shared-dependencies/third-party-dependencies/pom.xml
+++ b/java-shared-dependencies/third-party-dependencies/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-shared-config</artifactId>
-    <version>1.5.7</version>
+    <version>1.5.8</version>
     <relativePath />
   </parent>
 

--- a/java-shared-dependencies/upper-bound-check/pom.xml
+++ b/java-shared-dependencies/upper-bound-check/pom.xml
@@ -16,7 +16,7 @@
     <groupId>com.google.cloud</groupId>
     <!-- The shared config has RequireUpperBoundDeps enforcer rule -->
     <artifactId>google-cloud-shared-config</artifactId>
-    <version>1.5.7</version>
+    <version>1.5.8</version>
     <relativePath/>
   </parent>
 

--- a/showcase/pom.xml
+++ b/showcase/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-shared-config</artifactId>
-    <version>1.5.7</version>
+    <version>1.5.8</version>
     <relativePath/>
   </parent>
 


### PR DESCRIPTION
This PR bumps java-shared-config to `1.5.8` and removes `<auto-value.version>` property declaration from the gapic-pom-parent. This version will be inherited from java-shared-config from now on. Current latest version for `<auto-value>` is `1.10.4` 