### PR TITLE
chore: include/exclude certain protos when generating libraries

### DIFF
--- a/library_generation/generate_library.sh
+++ b/library_generation/generate_library.sh
@@ -108,6 +108,9 @@ mkdir -p "${output_folder}/${destination_path}"
 folder_name=$(extract_folder_name "${destination_path}")
 pushd "${output_folder}"
 proto_files=$(find "${proto_path}" -type f  -name "*.proto" | sort)
+if [[ "${proto_path}" == "google/cloud/filestore"* ]]; then
+  proto_files="${proto_files} google/cloud/common/operation_metadata.proto"
+fi
 # download gapic-generator-java, protobuf and grpc plugin.
 download_tools "${gapic_generator_version}" "${protobuf_version}" "${grpc_version}" "${os_architecture}"
 ##################### Section 1 #####################

--- a/library_generation/generate_library.sh
+++ b/library_generation/generate_library.sh
@@ -108,6 +108,7 @@ mkdir -p "${output_folder}/${destination_path}"
 folder_name=$(extract_folder_name "${destination_path}")
 pushd "${output_folder}"
 proto_files=$(find "${proto_path}" -type f  -name "*.proto" | sort)
+# include or exclude certain protos in grpc plugin and gapic generator java.
 case "${proto_path}" in
   "google/cloud/aiplatform/v1beta1"*)
     removed_proto="google/cloud/aiplatform/v1beta1/schema/io_format.proto"
@@ -174,6 +175,7 @@ fi
 ##################### Section 3 #####################
 # generate proto-*/
 #####################################################
+# exclude certain protos to java compiler.
 case "${proto_path}" in
   "google/cloud/aiplatform/v1beta1"*)
     prefix="google/cloud/aiplatform/v1beta1/schema"
@@ -197,7 +199,7 @@ fi
 unzip_src_files "proto"
 # remove empty files in proto-*/src/main/java
 remove_empty_files "proto"
-# copy proto files to proto-*/src/main/proto
+# include certain protos in generated library.
 case "${proto_path}" in
   "google/cloud/aiplatform/v1beta1"*)
     prefix="google/cloud/aiplatform/v1beta1/schema"
@@ -210,6 +212,7 @@ case "${proto_path}" in
     proto_files="${proto_files} google/devtools/containeranalysis/v1beta1/cvss/cvss.proto"
     ;;
 esac
+# copy proto files to proto-*/src/main/proto
 for proto_src in ${proto_files}; do
   if [[ "${proto_src}" == "google/cloud/common/operation_metadata.proto" ]]; then
     continue

--- a/library_generation/generate_library.sh
+++ b/library_generation/generate_library.sh
@@ -177,6 +177,9 @@ unzip_src_files "proto"
 remove_empty_files "proto"
 # copy proto files to proto-*/src/main/proto
 for proto_src in ${proto_files}; do
+  if [[ "${proto_src}" == "google/cloud/common/operation_metadata.proto" ]]; then
+    continue
+  fi
   mkdir -p "${destination_path}/proto-${folder_name}/src/main/proto"
   rsync -R "${proto_src}" "${destination_path}/proto-${folder_name}/src/main/proto"
 done

--- a/library_generation/generate_library.sh
+++ b/library_generation/generate_library.sh
@@ -109,15 +109,15 @@ folder_name=$(extract_folder_name "${destination_path}")
 pushd "${output_folder}"
 proto_files=$(find "${proto_path}" -type f  -name "*.proto" | sort)
 case "${proto_path}" in
+  "google/cloud/aiplatform/v1beta1"*)
+    removed_proto="google/cloud/aiplatform/v1beta1/schema/io_format.proto"
+    proto_files="${proto_files//${removed_proto}/}"
+    ;;
   "google/cloud/filestore"*)
     proto_files="${proto_files} google/cloud/common/operation_metadata.proto"
     ;;
   "google/cloud/oslogin"*)
     proto_files="${proto_files} google/cloud/oslogin/common/common.proto"
-    ;;
-  "google/devtools/containeranalysis/v1beta1"*)
-    removed_proto="google/devtools/containeranalysis/v1beta1/cvss/cvss.proto"
-    proto_files="${proto_files//${removed_proto}/}"
     ;;
 esac
 # download gapic-generator-java, protobuf and grpc plugin.
@@ -174,6 +174,19 @@ fi
 ##################### Section 3 #####################
 # generate proto-*/
 #####################################################
+case "${proto_path}" in
+  "google/cloud/aiplatform/v1beta1"*)
+    prefix="google/cloud/aiplatform/v1beta1/schema"
+    protos="${prefix}/annotation_payload.proto ${prefix}/annotation_spec_color.proto ${prefix}/data_item_payload.proto ${prefix}/dataset_metadata.proto ${prefix}/geometry.proto"
+    for removed_proto in ${protos}; do
+      proto_files="${proto_files//${removed_proto}/}"
+    done
+    ;;
+  "google/devtools/containeranalysis/v1beta1"*)
+    removed_proto="google/devtools/containeranalysis/v1beta1/cvss/cvss.proto"
+    proto_files="${proto_files//${removed_proto}/}"
+    ;;
+esac
 "$protoc_path"/protoc "--java_out=${destination_path}/java_proto.jar" ${proto_files}
 if [[ "${proto_only}" == "false" ]]; then
   # move java_gapic_srcjar/proto/src/main/java (generated resource name helper class)
@@ -185,6 +198,18 @@ unzip_src_files "proto"
 # remove empty files in proto-*/src/main/java
 remove_empty_files "proto"
 # copy proto files to proto-*/src/main/proto
+case "${proto_path}" in
+  "google/cloud/aiplatform/v1beta1"*)
+    prefix="google/cloud/aiplatform/v1beta1/schema"
+    protos="${prefix}/annotation_payload.proto ${prefix}/annotation_spec_color.proto ${prefix}/data_item_payload.proto ${prefix}/dataset_metadata.proto ${prefix}/geometry.proto"
+    for added_proto in ${protos}; do
+      proto_files="${proto_files} ${added_proto}"
+    done
+    ;;
+  "google/devtools/containeranalysis/v1beta1"*)
+    proto_files="${proto_files} google/devtools/containeranalysis/v1beta1/cvss/cvss.proto"
+    ;;
+esac
 for proto_src in ${proto_files}; do
   if [[ "${proto_src}" == "google/cloud/common/operation_metadata.proto" ]]; then
     continue

--- a/library_generation/generate_library.sh
+++ b/library_generation/generate_library.sh
@@ -108,9 +108,14 @@ mkdir -p "${output_folder}/${destination_path}"
 folder_name=$(extract_folder_name "${destination_path}")
 pushd "${output_folder}"
 proto_files=$(find "${proto_path}" -type f  -name "*.proto" | sort)
-if [[ "${proto_path}" == "google/cloud/filestore"* ]]; then
-  proto_files="${proto_files} google/cloud/common/operation_metadata.proto"
-fi
+case "${proto_path}" in
+  "google/cloud/filestore"*)
+    proto_files="${proto_files} google/cloud/common/operation_metadata.proto"
+    ;;
+  "google/cloud/oslogin"*)
+    proto_files="${proto_files} google/cloud/oslogin/common/common.proto"
+    ;;
+esac
 # download gapic-generator-java, protobuf and grpc plugin.
 download_tools "${gapic_generator_version}" "${protobuf_version}" "${grpc_version}" "${os_architecture}"
 ##################### Section 1 #####################

--- a/library_generation/generate_library.sh
+++ b/library_generation/generate_library.sh
@@ -115,6 +115,10 @@ case "${proto_path}" in
   "google/cloud/oslogin"*)
     proto_files="${proto_files} google/cloud/oslogin/common/common.proto"
     ;;
+  "google/devtools/containeranalysis/v1beta1"*)
+    removed_proto="google/devtools/containeranalysis/v1beta1/cvss/cvss.proto"
+    proto_files="${proto_files//${removed_proto}/}"
+    ;;
 esac
 # download gapic-generator-java, protobuf and grpc plugin.
 download_tools "${gapic_generator_version}" "${protobuf_version}" "${grpc_version}" "${os_architecture}"

--- a/library_generation/generate_library.sh
+++ b/library_generation/generate_library.sh
@@ -111,13 +111,18 @@ proto_files=$(find "${proto_path}" -type f  -name "*.proto" | sort)
 # include or exclude certain protos in grpc plugin and gapic generator java.
 case "${proto_path}" in
   "google/cloud/aiplatform/v1beta1"*)
+    # this proto is excluded from //google/cloud/aiplatform/v1beta1/schema:schema_proto
     removed_proto="google/cloud/aiplatform/v1beta1/schema/io_format.proto"
     proto_files="${proto_files//${removed_proto}/}"
     ;;
   "google/cloud/filestore"*)
+    # this proto is included in //google/cloud/filestore/v1:google-cloud-filestore-v1-java
+    # and //google/cloud/filestore/v1beta1:google-cloud-filestore-v1-java
     proto_files="${proto_files} google/cloud/common/operation_metadata.proto"
     ;;
   "google/cloud/oslogin"*)
+    # this proto is included in //google/cloud/oslogin/v1:google-cloud-oslogin-v1-java
+    # and //google/cloud/oslogin/v1beta1:google-cloud-oslogin-v1-java
     proto_files="${proto_files} google/cloud/oslogin/common/common.proto"
     ;;
 esac
@@ -178,6 +183,7 @@ fi
 # exclude certain protos to java compiler.
 case "${proto_path}" in
   "google/cloud/aiplatform/v1beta1"*)
+    # these protos are excluded from //google/cloud/aiplatform/v1beta1:google-cloud-aiplatform-v1beta1-java
     prefix="google/cloud/aiplatform/v1beta1/schema"
     protos="${prefix}/annotation_payload.proto ${prefix}/annotation_spec_color.proto ${prefix}/data_item_payload.proto ${prefix}/dataset_metadata.proto ${prefix}/geometry.proto"
     for removed_proto in ${protos}; do
@@ -185,6 +191,7 @@ case "${proto_path}" in
     done
     ;;
   "google/devtools/containeranalysis/v1beta1"*)
+    # this proto is excluded from //google/devtools/containeranalysis/v1beta1:google-cloud-devtools-containeranalysis-v1beta1-java
     removed_proto="google/devtools/containeranalysis/v1beta1/cvss/cvss.proto"
     proto_files="${proto_files//${removed_proto}/}"
     ;;


### PR DESCRIPTION
In this PR: add exceptions to include/exclude certain protos from `proto_path`.
- google/cloud/filestore: include `google/cloud/common/operation_metadata.proto`
- google/cloud/oslogin: include `google/cloud/oslogin/common/common.proto`
- google/devtools/containeranalysis/v1beta1: exclude `google/devtools/containeranalysis/v1beta1/cvss/cvss.proto` in java compiler
- google/cloud/aiplatform/v1beta1: 
  - exclude `google/cloud/aiplatform/v1beta1/schema/io_format.proto`
  - exclude `google/cloud/aiplatform/v1beta1/schema/*.proto` in java compiler

Follow up PR will add exceptions to exclude subdirectories within `proto_path`.