### PR TITLE
chore: Enabling Dependency Dashboard for renovate-bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "extends": [
     "config:base"
   ],
+  "dependencyDashboard": true,
   "ignoreDeps": ["rules_pkg"],
   "regexManagers": [
     {


### PR DESCRIPTION
As described in https://docs.renovatebot.com/key-concepts/dashboard/, we can enable the dependency dashboard using this configuration.