### PR TITLE
chore: add exceptions to search in `proto_path`, but not in its subdirectories

### DIFF
--- a/library_generation/generate_library.sh
+++ b/library_generation/generate_library.sh
@@ -107,7 +107,13 @@ mkdir -p "${output_folder}/${destination_path}"
 # get a fixed order.
 folder_name=$(extract_folder_name "${destination_path}")
 pushd "${output_folder}"
-proto_files=$(find "${proto_path}" -type f  -name "*.proto" | sort)
+depth=""
+case "${proto_path}" in
+  "google/api")
+    depth="-maxdepth 1"
+    ;;
+esac
+proto_files=$(find "${proto_path}" ${depth} -type f  -name "*.proto" | sort)
 # include or exclude certain protos in grpc plugin and gapic generator java.
 case "${proto_path}" in
   "google/cloud/aiplatform/v1beta1"*)


### PR DESCRIPTION
In this PR, add special cases in which only search protos in `proto_path`, but not in its subdirectories. The cases are:
- google/api