### PR TITLE
deps: update graal-sdk to 22.3.3 in bazel dependencies file

### DIFF
--- a/gax-java/dependencies.properties
+++ b/gax-java/dependencies.properties
@@ -74,7 +74,7 @@ maven.com_google_http_client_google_http_client=com.google.http-client:google-ht
 maven.com_google_http_client_google_http_client_gson=com.google.http-client:google-http-client-gson:1.43.3
 maven.org_codehaus_mojo_animal_sniffer_annotations=org.codehaus.mojo:animal-sniffer-annotations:1.23
 maven.javax_annotation_javax_annotation_api=javax.annotation:javax.annotation-api:1.3.2
-maven.org_graalvm_sdk=org.graalvm.sdk:graal-sdk:22.3.1
+maven.org_graalvm_sdk=org.graalvm.sdk:graal-sdk:22.3.3
 
 # Testing maven artifacts
 maven.junit_junit=junit:junit:4.13.2


### PR DESCRIPTION
Currently we need to make an additional update to the dependencies.properties file for bazel.  Created an issue to investigate this further: https://github.com/googleapis/sdk-platform-java/issues/2210