### PR TITLE
fix: confirm owlbot-copy succeeeded to transfer java files

### DIFF
--- a/library_generation/test/generate_library_integration_test.sh
+++ b/library_generation/test/generate_library_integration_test.sh
@@ -85,7 +85,7 @@ fi
 grep -v '^ *#' < "${proto_path_list}" | while IFS= read -r line; do
   proto_path=$(echo "$line" | cut -d " " -f 1)
   repository_path=$(echo "$line" | cut -d " " -f 2)
-  is_handwritten=$(echo "$line" | cut -d " " -f 3)
+  skip_postprocessing=$(echo "$line" | cut -d " " -f 3)
   # parse destination_path
   pushd "${output_folder}"
   echo "Checking out googleapis-gen repository..."
@@ -110,8 +110,8 @@ grep -v '^ *#' < "${proto_path_list}" | while IFS= read -r line; do
     service_yaml=${service_yaml},
     include_samples=${include_samples}."
   pushd "${output_folder}"
-  if [ "${is_handwritten}" == "true" ]; then
-    echo 'this is a handwritten library'
+  if [ "${skip_postprocessing}" == "true" ]; then
+    echo 'this library is not intended for postprocessing test'
     popd # output folder
     continue
   else

--- a/library_generation/test/generate_library_integration_test.sh
+++ b/library_generation/test/generate_library_integration_test.sh
@@ -173,6 +173,11 @@ grep -v '^ *#' < "${proto_path_list}" | while IFS= read -r line; do
   echo "Generate library finished."
   echo "Compare generation result..."
   if [ $enable_postprocessing == "true" ]; then
+    if [ $(find "${output_folder}/workspace" -name '*.java' | wc -l) -eq 0 ];
+    then
+      echo 'no java files found in workspace. This probably means that owlbot copy failed'
+      exit 1
+    fi
     echo "Checking out repository..."
     pushd "${target_folder}"
     SOURCE_DIFF_RESULT=0

--- a/library_generation/test/generate_library_integration_test.sh
+++ b/library_generation/test/generate_library_integration_test.sh
@@ -126,7 +126,7 @@ grep -v '^ *#' < "${proto_path_list}" | while IFS= read -r line; do
   # generate GAPIC client library
   echo "Generating library from ${proto_path}, to ${destination_path}..."
   generation_start=$(date "+%s")
-  if [ $enable_postprocessing == "true" ]; then
+  if [ "${enable_postprocessing}" == "true" ]; then
     if [[ "${repository_path}" == "null" ]]; then
       # we need a repository to compare the generated results with. Skip this
       # library
@@ -180,7 +180,7 @@ grep -v '^ *#' < "${proto_path_list}" | while IFS= read -r line; do
     fi
     echo "Checking out repository..."
     pushd "${target_folder}"
-    SOURCE_DIFF_RESULT=0
+    source_diff_result=0
     git diff \
       --ignore-space-at-eol \
       -r \
@@ -189,34 +189,34 @@ grep -v '^ *#' < "${proto_path_list}" | while IFS= read -r line; do
       ':!*pom.xml' \
       ':!*README.md' \
       ':!*package-info.java' \
-      || SOURCE_DIFF_RESULT=$?
+      || source_diff_result=$?
 
-    POM_DIFF_RESULT=$(compare_poms "${target_folder}")
+    pom_diff_result=$(compare_poms "${target_folder}")
     popd # target_folder
-    if [[ ${SOURCE_DIFF_RESULT} == 0 ]] && [[ ${POM_DIFF_RESULT} == 0 ]] ; then
+    if [[ ${source_diff_result} == 0 ]] && [[ ${pom_diff_result} == 0 ]] ; then
       echo "SUCCESS: Comparison finished, no difference is found."
       # Delete google-cloud-java to allow a sparse clone of the next library
       rm -rdf google-cloud-java
-    elif [ ${SOURCE_DIFF_RESULT} != 0 ]; then
+    elif [ ${source_diff_result} != 0 ]; then
       echo "FAILURE: Differences found in proto path: ${proto_path}."
       exit "${SOURCE_DIFF_RESULT}"
-    elif [ ${POM_DIFF_RESULT} != 0 ]; then
+    elif [ ${pom_diff_result} != 0 ]; then
       echo "FAILURE: Differences found in generated poms"
-      exit "${POM_DIFF_RESULT}"
+      exit "${pom_diff_result}"
     fi
-  elif [ $enable_postprocessing == "false" ]; then
+  elif [ "${enable_postprocessing}" == "false" ]; then
     # include gapic_metadata.json and package-info.java after
     # resolving https://github.com/googleapis/sdk-platform-java/issues/1986
-    SOURCE_DIFF_RESULT=0
+    source_diff_result=0
     diff --strip-trailing-cr -r "googleapis-gen/${proto_path}/${destination_path}" "${output_folder}/${destination_path}" \
       -x "*gradle*" \
       -x "gapic_metadata.json" \
-      -x "package-info.java" || SOURCE_DIFF_RESULT=$?
-    if [ ${SOURCE_DIFF_RESULT} == 0 ] ; then
+      -x "package-info.java" || source_diff_result=$?
+    if [ ${source_diff_result} == 0 ] ; then
       echo "SUCCESS: Comparison finished, no difference is found."
     else
       echo "FAILURE: Differences found in proto path: ${proto_path}." 
-      exit "${SOURCE_DIFF_RESULT}"
+      exit "${source_diff_result}"
     fi
   fi
 

--- a/library_generation/test/resources/proto_path_list.txt
+++ b/library_generation/test/resources/proto_path_list.txt
@@ -1,6 +1,6 @@
 # This file is used in integration test against `generate_library.sh`.
 # Format:
-# proto_path repository_path is_handwritten
+# proto_path repository_path skip_postprocessing_test
 # google/bigtable/admin/v2 java-bigtable true
 # google/bigtable/v2 java-bigtable true
 google/cloud/apigeeconnect/v1 java-apigee-connect false
@@ -17,6 +17,7 @@ google/cloud/redis/v1 java-redis false
 google/cloud/redis/v1beta1 java-redis false
 # google/example/library/v1 google-cloud-example-library-v1-java null false
 google/devtools/containeranalysis/v1 java-containeranalysis false
+google/iam/v1 java-iam true
 google/iam/v2 java-iam false
 google/iam/credentials/v1 java-iamcredentials false
 google/logging/v2 java-logging true

--- a/library_generation/test/resources/proto_path_list.txt
+++ b/library_generation/test/resources/proto_path_list.txt
@@ -17,7 +17,7 @@ google/cloud/redis/v1 java-redis false
 google/cloud/redis/v1beta1 java-redis false
 # google/example/library/v1 google-cloud-example-library-v1-java null false
 google/devtools/containeranalysis/v1 java-containeranalysis false
-google/iam/v1 java-iam false
+google/iam/v2 java-iam false
 google/iam/credentials/v1 java-iamcredentials false
 google/logging/v2 java-logging true
 google/pubsub/v1 java-pubsub true


### PR DESCRIPTION
Follow up of https://github.com/googleapis/google-cloud-java/pull/10050
* Confirms java files have been transferred by owl-bot-copy
* Adds `google/iam/v2` in the integration test list. 
* `google/iam/v1` is blacklisted from postprocessing list because it is not listed in its [owlbot yaml ](https://github.com/googleapis/google-cloud-java/blob/18020600f38e9cf966d3b4c12035954a7124344a/java-iam/.OwlBot.yaml#L25-L28)

