### PR TITLE
fix: improve information on CancellationException for LROs

### DIFF
--- a/gax-java/gax-grpc/src/test/java/com/google/api/gax/grpc/ChannelPoolTest.java
+++ b/gax-java/gax-grpc/src/test/java/com/google/api/gax/grpc/ChannelPoolTest.java
@@ -43,6 +43,7 @@ import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.StreamController;
 import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
+import com.google.api.gax.util.FakeLogHandler;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -718,22 +719,4 @@ public class ChannelPoolTest {
     }
   }
 
-  private static class FakeLogHandler extends Handler {
-    List<LogRecord> records = new ArrayList<>();
-
-    @Override
-    public void publish(LogRecord record) {
-      records.add(record);
-    }
-
-    @Override
-    public void flush() {}
-
-    @Override
-    public void close() throws SecurityException {}
-
-    List<String> getAllMessages() {
-      return records.stream().map(LogRecord::getMessage).collect(Collectors.toList());
-    }
-  }
 }

--- a/gax-java/gax/pom.xml
+++ b/gax-java/gax/pom.xml
@@ -76,6 +76,7 @@
                 <include>com/google/api/gax/core/**</include>
                 <include>com/google/api/gax/rpc/testing/**</include>
                 <include>com/google/api/gax/rpc/mtls/**</include>
+                <include>com/google/api/gax/util/**</include>
               </includes>
             </configuration>
           </execution>

--- a/gax-java/gax/src/main/java/com/google/api/gax/longrunning/OperationTimedPollAlgorithm.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/longrunning/OperationTimedPollAlgorithm.java
@@ -77,7 +77,9 @@ public class OperationTimedPollAlgorithm extends ExponentialRetryAlgorithm {
     if (super.shouldRetry(nextAttemptSettings)) {
       return true;
     }
-    throw new CancellationException();
+    throw new CancellationException(
+        "The task has been cancelled. Please refer to "
+            + "https://github.com/googleapis/google-cloud-java#lro-timeouts for more information");
   }
 
   // Note: if the potential time spent is exactly equal to the totalTimeout,

--- a/gax-java/gax/src/main/java/com/google/api/gax/longrunning/OperationTimedPollAlgorithm.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/longrunning/OperationTimedPollAlgorithm.java
@@ -35,7 +35,10 @@ import com.google.api.core.NanoClock;
 import com.google.api.gax.retrying.ExponentialRetryAlgorithm;
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.api.gax.retrying.TimedAttemptSettings;
+import com.google.common.annotations.VisibleForTesting;
 import java.util.concurrent.CancellationException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Operation timed polling algorithm, which uses exponential backoff factor for determining when the
@@ -44,6 +47,8 @@ import java.util.concurrent.CancellationException;
  */
 public class OperationTimedPollAlgorithm extends ExponentialRetryAlgorithm {
 
+  @VisibleForTesting
+  public static Logger LOGGER = Logger.getLogger(OperationTimedPollAlgorithm.class.getName());
   public static final String LRO_TROUBLESHOOTING_LINK =
       "https://github.com/googleapis/google-cloud-java#lro-timeouts";
 
@@ -81,9 +86,11 @@ public class OperationTimedPollAlgorithm extends ExponentialRetryAlgorithm {
     if (super.shouldRetry(nextAttemptSettings)) {
       return true;
     }
-    throw new CancellationException(
-        "The task has been cancelled. Please refer to "
-            + LRO_TROUBLESHOOTING_LINK + " for more information");
+    if (LOGGER.isLoggable(Level.SEVERE)) {
+      LOGGER.log(Level.SEVERE, "The task has been cancelled. Please refer to "
+          + LRO_TROUBLESHOOTING_LINK + " for more information");
+    }
+    throw new CancellationException();
   }
 
   // Note: if the potential time spent is exactly equal to the totalTimeout,

--- a/gax-java/gax/src/main/java/com/google/api/gax/longrunning/OperationTimedPollAlgorithm.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/longrunning/OperationTimedPollAlgorithm.java
@@ -43,6 +43,10 @@ import java.util.concurrent.CancellationException;
  * algorithm cancels polling.
  */
 public class OperationTimedPollAlgorithm extends ExponentialRetryAlgorithm {
+
+  public static final String LRO_TROUBLESHOOTING_LINK =
+      "https://github.com/googleapis/google-cloud-java#lro-timeouts";
+
   /**
    * Creates the polling algorithm, using the default {@code NanoClock} for time computations.
    *
@@ -79,7 +83,7 @@ public class OperationTimedPollAlgorithm extends ExponentialRetryAlgorithm {
     }
     throw new CancellationException(
         "The task has been cancelled. Please refer to "
-            + "https://github.com/googleapis/google-cloud-java#lro-timeouts for more information");
+            + LRO_TROUBLESHOOTING_LINK + " for more information");
   }
 
   // Note: if the potential time spent is exactly equal to the totalTimeout,

--- a/gax-java/gax/src/main/java/com/google/api/gax/retrying/BasicRetryingFuture.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/retrying/BasicRetryingFuture.java
@@ -67,6 +67,8 @@ class BasicRetryingFuture<ResponseT> extends AbstractFuture<ResponseT>
   private volatile ApiFuture<ResponseT> latestCompletedAttemptResult;
   private volatile ApiFuture<ResponseT> attemptResult;
 
+  private volatile CancellationException customCancellationException = null;
+
   private static final Logger LOG = Logger.getLogger(BasicRetryingFuture.class.getName());
 
   BasicRetryingFuture(
@@ -205,6 +207,9 @@ class BasicRetryingFuture<ResponseT> extends AbstractFuture<ResponseT>
       } catch (CancellationException e) {
         // A retry algorithm triggered cancellation.
         tracer.attemptFailedRetriesExhausted(e);
+        // The exception caught here is coming from gax code. We save it in order to throw
+        // this exception as the main one, while keeping guava's `Task was cancelled.` as a cause
+        customCancellationException = e;
         super.cancel(false);
       } catch (Exception e) {
         // Should never happen, but still possible in case of buggy retry algorithm implementation.
@@ -261,6 +266,18 @@ class BasicRetryingFuture<ResponseT> extends AbstractFuture<ResponseT>
       // execution. In case if a callback is executed in a separate thread executor (the recommended
       // way) the exception will be thrown in a separate thread and will not be swallowed by this
       // catch block anyways.
+    }
+  }
+
+  public ResponseT get() throws InterruptedException, ExecutionException{
+    try {
+      return super.get();
+    } catch (CancellationException ex) {
+      if (customCancellationException instanceof CancellationException) {
+        customCancellationException.initCause(ex);
+        throw customCancellationException;
+      }
+      throw ex;
     }
   }
 

--- a/gax-java/gax/src/test/java/com/google/api/gax/util/FakeLogHandler.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/util/FakeLogHandler.java
@@ -1,0 +1,26 @@
+package com.google.api.gax.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+import java.util.stream.Collectors;
+
+public class FakeLogHandler extends Handler {
+  List<LogRecord> records = new ArrayList<>();
+
+  @Override
+  public void publish(LogRecord record) {
+    records.add(record);
+  }
+
+  @Override
+  public void flush() {}
+
+  @Override
+  public void close() throws SecurityException {}
+
+  public List<String> getAllMessages() {
+    return records.stream().map(LogRecord::getMessage).collect(Collectors.toList());
+  }
+}

--- a/gax-java/gax/src/test/java/com/google/api/gax/util/FakeLogHandler.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/util/FakeLogHandler.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.api.gax.util;
 
 import java.util.ArrayList;
@@ -6,6 +21,10 @@ import java.util.logging.Handler;
 import java.util.logging.LogRecord;
 import java.util.stream.Collectors;
 
+/*
+ * Convenience class that stores the log entries produced by any logger
+ * It can then be inspected - its entries are a list log records
+ */
 public class FakeLogHandler extends Handler {
   List<LogRecord> records = new ArrayList<>();
 

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITLongRunningOperation.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITLongRunningOperation.java
@@ -147,10 +147,10 @@ public class ITLongRunningOperation {
       OperationFuture<WaitResponse, WaitMetadata> operationFuture =
           grpcClient.waitOperationCallable().futureCall(waitRequest);
       CancellationException cancellationException =
-              assertThrows(CancellationException.class, operationFuture::get);
+          assertThrows(CancellationException.class, operationFuture::get);
       assertThat(cancellationException)
-              .hasMessageThat()
-              .contains("https://github.com/googleapis/google-cloud-java#lro-timeouts");
+          .hasMessageThat()
+          .contains("https://github.com/googleapis/google-cloud-java#lro-timeouts");
       int attemptCount = operationFuture.getPollingFuture().getAttemptSettings().getAttemptCount();
       assertThat(attemptCount).isGreaterThan(1);
     } finally {

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITLongRunningOperation.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITLongRunningOperation.java
@@ -15,6 +15,7 @@
  */
 package com.google.showcase.v1beta1.it;
 
+import static com.google.api.gax.longrunning.OperationTimedPollAlgorithm.LRO_TROUBLESHOOTING_LINK;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
@@ -150,7 +151,7 @@ public class ITLongRunningOperation {
           assertThrows(CancellationException.class, operationFuture::get);
       assertThat(cancellationException)
           .hasMessageThat()
-          .contains("https://github.com/googleapis/google-cloud-java#lro-timeouts");
+          .contains(LRO_TROUBLESHOOTING_LINK);
       int attemptCount = operationFuture.getPollingFuture().getAttemptSettings().getAttemptCount();
       assertThat(attemptCount).isGreaterThan(1);
     } finally {
@@ -193,7 +194,7 @@ public class ITLongRunningOperation {
           assertThrows(CancellationException.class, operationFuture::get);
       assertThat(cancellationException)
           .hasMessageThat()
-          .contains("https://github.com/googleapis/google-cloud-java#lro-timeouts");
+          .contains(LRO_TROUBLESHOOTING_LINK);
       int attemptCount = operationFuture.getPollingFuture().getAttemptSettings().getAttemptCount();
       assertThat(attemptCount).isGreaterThan(1);
     } finally {

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITLongRunningOperation.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITLongRunningOperation.java
@@ -15,7 +15,6 @@
  */
 package com.google.showcase.v1beta1.it;
 
-import static com.google.api.gax.longrunning.OperationTimedPollAlgorithm.LRO_TROUBLESHOOTING_LINK;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
@@ -147,11 +146,7 @@ public class ITLongRunningOperation {
               .build();
       OperationFuture<WaitResponse, WaitMetadata> operationFuture =
           grpcClient.waitOperationCallable().futureCall(waitRequest);
-      CancellationException cancellationException =
-          assertThrows(CancellationException.class, operationFuture::get);
-      assertThat(cancellationException)
-          .hasMessageThat()
-          .contains(LRO_TROUBLESHOOTING_LINK);
+      assertThrows(CancellationException.class, operationFuture::get);
       int attemptCount = operationFuture.getPollingFuture().getAttemptSettings().getAttemptCount();
       assertThat(attemptCount).isGreaterThan(1);
     } finally {
@@ -190,11 +185,7 @@ public class ITLongRunningOperation {
               .build();
       OperationFuture<WaitResponse, WaitMetadata> operationFuture =
           httpjsonClient.waitOperationCallable().futureCall(waitRequest);
-      CancellationException cancellationException =
-          assertThrows(CancellationException.class, operationFuture::get);
-      assertThat(cancellationException)
-          .hasMessageThat()
-          .contains(LRO_TROUBLESHOOTING_LINK);
+      assertThrows(CancellationException.class, operationFuture::get);
       int attemptCount = operationFuture.getPollingFuture().getAttemptSettings().getAttemptCount();
       assertThat(attemptCount).isGreaterThan(1);
     } finally {

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITLongRunningOperation.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITLongRunningOperation.java
@@ -146,7 +146,11 @@ public class ITLongRunningOperation {
               .build();
       OperationFuture<WaitResponse, WaitMetadata> operationFuture =
           grpcClient.waitOperationCallable().futureCall(waitRequest);
-      assertThrows(CancellationException.class, operationFuture::get);
+      CancellationException cancellationException =
+              assertThrows(CancellationException.class, operationFuture::get);
+      assertThat(cancellationException)
+              .hasMessageThat()
+              .contains("https://github.com/googleapis/google-cloud-java#lro-timeouts");
       int attemptCount = operationFuture.getPollingFuture().getAttemptSettings().getAttemptCount();
       assertThat(attemptCount).isGreaterThan(1);
     } finally {

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITLongRunningOperation.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITLongRunningOperation.java
@@ -185,7 +185,8 @@ public class ITLongRunningOperation {
               .build();
       OperationFuture<WaitResponse, WaitMetadata> operationFuture =
           httpjsonClient.waitOperationCallable().futureCall(waitRequest);
-      assertThrows(CancellationException.class, operationFuture::get);
+      CancellationException cancellationException = assertThrows(CancellationException.class, operationFuture::get);
+      assertThat(cancellationException).hasMessageThat().contains("https://github.com/googleapis/google-cloud-java#lro-timeouts");
       int attemptCount = operationFuture.getPollingFuture().getAttemptSettings().getAttemptCount();
       assertThat(attemptCount).isGreaterThan(1);
     } finally {

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITLongRunningOperation.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITLongRunningOperation.java
@@ -16,16 +16,20 @@
 package com.google.showcase.v1beta1.it;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 import com.google.api.gax.longrunning.OperationFuture;
+import com.google.api.gax.longrunning.OperationTimedPollAlgorithm;
 import com.google.api.gax.retrying.RetrySettings;
+import com.google.api.gax.util.FakeLogHandler;
 import com.google.protobuf.Timestamp;
 import com.google.showcase.v1beta1.EchoClient;
 import com.google.showcase.v1beta1.WaitMetadata;
 import com.google.showcase.v1beta1.WaitRequest;
 import com.google.showcase.v1beta1.WaitResponse;
 import com.google.showcase.v1beta1.it.util.TestClientInitializer;
+import com.google.showcase.v1beta1.stub.EchoStubSettings;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.TimeUnit;
 import org.junit.Test;
@@ -121,6 +125,8 @@ public class ITLongRunningOperation {
   @Test
   public void testGRPC_LROUnsuccessfulResponse_exceedsTotalTimeout_throwsDeadlineExceededException()
       throws Exception {
+    FakeLogHandler logHandler = new FakeLogHandler();
+    OperationTimedPollAlgorithm.LOGGER.addHandler(logHandler);
     RetrySettings initialUnaryRetrySettings =
         RetrySettings.newBuilder()
             .setInitialRpcTimeout(Duration.ofMillis(5000L))
@@ -149,6 +155,9 @@ public class ITLongRunningOperation {
       assertThrows(CancellationException.class, operationFuture::get);
       int attemptCount = operationFuture.getPollingFuture().getAttemptSettings().getAttemptCount();
       assertThat(attemptCount).isGreaterThan(1);
+      assertEquals(1, logHandler.getAllMessages().size());
+      assertThat(logHandler.getAllMessages().get(0))
+          .contains(OperationTimedPollAlgorithm.LRO_TROUBLESHOOTING_LINK);
     } finally {
       grpcClient.close();
       grpcClient.awaitTermination(
@@ -160,6 +169,8 @@ public class ITLongRunningOperation {
   public void
       testHttpJson_LROUnsuccessfulResponse_exceedsTotalTimeout_throwsDeadlineExceededException()
           throws Exception {
+    FakeLogHandler logHandler = new FakeLogHandler();
+    OperationTimedPollAlgorithm.LOGGER.addHandler(logHandler);
     RetrySettings initialUnaryRetrySettings =
         RetrySettings.newBuilder()
             .setInitialRpcTimeout(Duration.ofMillis(5000L))
@@ -188,6 +199,9 @@ public class ITLongRunningOperation {
       assertThrows(CancellationException.class, operationFuture::get);
       int attemptCount = operationFuture.getPollingFuture().getAttemptSettings().getAttemptCount();
       assertThat(attemptCount).isGreaterThan(1);
+      assertEquals(1, logHandler.getAllMessages().size());
+      assertThat(logHandler.getAllMessages().get(0))
+          .contains(OperationTimedPollAlgorithm.LRO_TROUBLESHOOTING_LINK);
     } finally {
       httpjsonClient.close();
       httpjsonClient.awaitTermination(

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITLongRunningOperation.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITLongRunningOperation.java
@@ -185,8 +185,11 @@ public class ITLongRunningOperation {
               .build();
       OperationFuture<WaitResponse, WaitMetadata> operationFuture =
           httpjsonClient.waitOperationCallable().futureCall(waitRequest);
-      CancellationException cancellationException = assertThrows(CancellationException.class, operationFuture::get);
-      assertThat(cancellationException).hasMessageThat().contains("https://github.com/googleapis/google-cloud-java#lro-timeouts");
+      CancellationException cancellationException =
+          assertThrows(CancellationException.class, operationFuture::get);
+      assertThat(cancellationException)
+          .hasMessageThat()
+          .contains("https://github.com/googleapis/google-cloud-java#lro-timeouts");
       int attemptCount = operationFuture.getPollingFuture().getAttemptSettings().getAttemptCount();
       assertThat(attemptCount).isGreaterThan(1);
     } finally {


### PR DESCRIPTION
Fixes https://github.com/googleapis/sdk-platform-java/issues/1858
When a LRO runs out of retries/time, it throws a `CancellationException` that is then swallowed by guava's `AbstractFuture`, meaning there is no simple way to bubble up a custom exception with message.

This approach uses a logger with a message that points to LRO documentation to ensure the user is informed on what they can do about this.