### PR TITLE
chore: skip cache for download-maven-plugin

### DIFF
--- a/gapic-generator-java/pom.xml
+++ b/gapic-generator-java/pom.xml
@@ -142,6 +142,10 @@
                 https://raw.githubusercontent.com/googleapis/googleapis/${googleapis.commit}/gapic/metadata/gapic_metadata.proto
               </url>
               <outputDirectory>target/generated-sources/proto</outputDirectory>
+              <!-- Set this to always download the latest version and overwrite the existing file -->
+              <overwrite>true</overwrite>
+              <!-- Don't use the local maven download plugin cache -->
+              <skipCache>true</skipCache>
             </configuration>
           </execution>
           <execution>


### PR DESCRIPTION
For https://github.com/googleapis/sdk-platform-java/pull/2228 which is running into the following error for the showcase/ clirr check:
```
Error:  /home/runner/work/sdk-platform-java/sdk-platform-java/gapic-generator-java/target/generated-sources/proto/gapic_metadata.proto [0:0]: gapic_metadata.proto:1:1: Invalid control characters encountered in text.
...
Error:  Failed to execute goal org.xolstice.maven.plugins:protobuf-maven-plugin:0.6.1:compile (compile-downloaded-protos) on project gapic-generator-java: protoc did not exit cleanly. Review output for more information. -> [Help 1]
```

Following workaround in https://github.com/googleapis/sdk-platform-java/pull/2151 to verify if skipping caching will result in a successful build. 