### PR TITLE
fix: format proto comments in Client Overview

### DIFF
--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/comment/ServiceClientCommentComposer.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/comment/ServiceClientCommentComposer.java
@@ -242,7 +242,7 @@ public class ServiceClientCommentComposer {
           .append(method.method)
           .append("</td>\n")
           .append("     <td>")
-          .append("<p>" + method.description + "</p>")
+          .append(CommentFormatter.formatAsJavaDocComment(method.description, null))
           .append("</td>\n")
           .append("     <td>\n");
       generateUnorderedListMethodVariants(

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/writer/JavaWriterVisitorTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/writer/JavaWriterVisitorTest.java
@@ -71,6 +71,7 @@ import com.google.api.generator.engine.ast.VaporReference;
 import com.google.api.generator.engine.ast.Variable;
 import com.google.api.generator.engine.ast.VariableExpr;
 import com.google.api.generator.engine.ast.WhileStatement;
+import com.google.api.generator.engine.writer.JavaFormatter.FormatException;
 import com.google.api.generator.gapic.composer.grpc.ServiceClientClassComposer;
 import com.google.api.generator.gapic.model.GapicClass;
 import com.google.api.generator.gapic.model.GapicContext;
@@ -958,6 +959,25 @@ public class JavaWriterVisitorTest {
             "*/\n");
     javaDocComment.accept(writerVisitor);
     assertEquals(expected, writerVisitor.write());
+  }
+
+  @Test
+  public void writeFailingComment_specialChar() {
+    JavaDocComment javaDocComment =
+        JavaDocComment.builder()
+            .addUnescapedComment(
+                "This resource reference needs to be CommentFormatted or it will fail: `bookShelves/*/`")
+            .build();
+
+    FormatException exceptionForIncorrectlyFormattedComment =
+        assertThrows(
+            FormatException.class,
+            () -> {
+              javaDocComment.accept(writerVisitor);
+            });
+    assertThat(exceptionForIncorrectlyFormattedComment)
+        .hasMessageThat()
+        .contains("The input resource can not be parsed");
   }
 
   @Test

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/writer/goldens/GrpcServiceClientWithNestedClassImport.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/writer/goldens/GrpcServiceClientWithNestedClassImport.golden
@@ -38,7 +38,7 @@ import javax.annotation.Generated;
  *      <th>Method Variants</th>
  *    <tr>
  *      <td>NestedMessageMethod</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/BookshopClient.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/BookshopClient.golden
@@ -38,7 +38,7 @@ import javax.annotation.Generated;
  *      <th>Method Variants</th>
  *    <tr>
  *      <td>GetBook</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/DeprecatedServiceClient.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/DeprecatedServiceClient.golden
@@ -37,7 +37,7 @@ import javax.annotation.Generated;
  *      <th>Method Variants</th>
  *    <tr>
  *      <td>FastFibonacci</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -51,7 +51,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>SlowFibonacci</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/EchoClient.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/EchoClient.golden
@@ -59,7 +59,7 @@ import javax.annotation.Generated;
  *      <th>Method Variants</th>
  *    <tr>
  *      <td>Echo</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -84,7 +84,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>Expand</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Callable method variants take no parameters and return an immutable API callable object, which can be used to initiate calls to the service.</p>
  *      <ul>
@@ -94,7 +94,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>Collect</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Callable method variants take no parameters and return an immutable API callable object, which can be used to initiate calls to the service.</p>
  *      <ul>
@@ -104,7 +104,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>Chat</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Callable method variants take no parameters and return an immutable API callable object, which can be used to initiate calls to the service.</p>
  *      <ul>
@@ -114,7 +114,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ChatAgain</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Callable method variants take no parameters and return an immutable API callable object, which can be used to initiate calls to the service.</p>
  *      <ul>
@@ -124,7 +124,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>PagedExpand</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -139,7 +139,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>SimplePagedExpand</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -158,7 +158,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>Wait</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -178,7 +178,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>Block</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -192,7 +192,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>CollideName</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/IdentityClient.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/IdentityClient.golden
@@ -47,7 +47,7 @@ import javax.annotation.Generated;
  *      <th>Method Variants</th>
  *    <tr>
  *      <td>CreateUser</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -67,7 +67,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetUser</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -86,7 +86,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>UpdateUser</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -100,7 +100,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>DeleteUser</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -119,7 +119,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListUsers</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/MessagingClient.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/MessagingClient.golden
@@ -54,7 +54,7 @@ import javax.annotation.Generated;
  *      <th>Method Variants</th>
  *    <tr>
  *      <td>CreateRoom</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -72,7 +72,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetRoom</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -91,7 +91,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>UpdateRoom</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -105,7 +105,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>DeleteRoom</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -124,7 +124,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListRooms</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -139,7 +139,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>CreateBlurb</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -162,7 +162,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetBlurb</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -181,7 +181,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>UpdateBlurb</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -195,7 +195,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>DeleteBlurb</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -214,7 +214,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListBlurbs</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -235,7 +235,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>SearchBlurbs</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -254,7 +254,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>StreamBlurbs</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Callable method variants take no parameters and return an immutable API callable object, which can be used to initiate calls to the service.</p>
  *      <ul>
@@ -264,7 +264,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>SendBlurbs</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Callable method variants take no parameters and return an immutable API callable object, which can be used to initiate calls to the service.</p>
  *      <ul>
@@ -274,7 +274,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>Connect</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Callable method variants take no parameters and return an immutable API callable object, which can be used to initiate calls to the service.</p>
  *      <ul>

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoClient.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoClient.golden
@@ -54,7 +54,7 @@ import javax.annotation.Generated;
  *      <th>Method Variants</th>
  *    <tr>
  *      <td>Echo</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -79,7 +79,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>Expand</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Callable method variants take no parameters and return an immutable API callable object, which can be used to initiate calls to the service.</p>
  *      <ul>
@@ -89,7 +89,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>PagedExpand</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -104,7 +104,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>SimplePagedExpand</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -123,7 +123,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>Wait</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -143,7 +143,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>Block</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -157,7 +157,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>CollideName</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -171,7 +171,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>NestedBinding</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -185,7 +185,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>Chat</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Callable method variants take no parameters and return an immutable API callable object, which can be used to initiate calls to the service.</p>
  *      <ul>
@@ -195,7 +195,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>NoBinding</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -209,7 +209,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>UpdateCase</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/WickedClient.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/WickedClient.golden
@@ -39,7 +39,7 @@ import javax.annotation.Generated;
  *      <th>Method Variants</th>
  *    <tr>
  *      <td>CraftEvilPlan</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -53,7 +53,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>BrainstormEvilPlans</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Callable method variants take no parameters and return an immutable API callable object, which can be used to initiate calls to the service.</p>
  *      <ul>
@@ -63,7 +63,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>PersuadeEvilPlan</td>
- *      <td><p></p></td>
+ *      <td><p> </td>
  *      <td>
  *      <p>Callable method variants take no parameters and return an immutable API callable object, which can be used to initiate calls to the service.</p>
  *      <ul>

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/ComplianceClient.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/ComplianceClient.java
@@ -86,8 +86,7 @@ import javax.annotation.Generated;
  *      <th>Method Variants</th>
  *    <tr>
  *      <td>RepeatDataBody</td>
- *      <td><p>This method echoes the ComplianceData request. This method exercises
- *  sending the entire request object in the REST body.</p></td>
+ *      <td><p> This method echoes the ComplianceData request. This method exercises sending the entire request object in the REST body.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -101,9 +100,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>RepeatDataBodyInfo</td>
- *      <td><p>This method echoes the ComplianceData request. This method exercises
- *  sending the a message-type field in the REST body. Per AIP-127, only
- *  top-level, non-repeated fields can be sent this way.</p></td>
+ *      <td><p> This method echoes the ComplianceData request. This method exercises sending the a message-type field in the REST body. Per AIP-127, only top-level, non-repeated fields can be sent this way.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -117,8 +114,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>RepeatDataQuery</td>
- *      <td><p>This method echoes the ComplianceData request. This method exercises
- *  sending all request fields as query parameters.</p></td>
+ *      <td><p> This method echoes the ComplianceData request. This method exercises sending all request fields as query parameters.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -132,9 +128,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>RepeatDataSimplePath</td>
- *      <td><p>This method echoes the ComplianceData request. This method exercises
- *  sending some parameters as "simple" path variables (i.e., of the form
- *  "/bar/{foo}" rather than "/{foo=bar/*}"), and the rest as query parameters.</p></td>
+ *      <td><p> This method echoes the ComplianceData request. This method exercises sending some parameters as "simple" path variables (i.e., of the form "/bar/{foo}" rather than "/{foo=bar/&#42;}"), and the rest as query parameters.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -148,7 +142,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>RepeatDataPathResource</td>
- *      <td><p>Same as RepeatDataSimplePath, but with a path resource.</p></td>
+ *      <td><p> Same as RepeatDataSimplePath, but with a path resource.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -162,7 +156,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>RepeatDataPathTrailingResource</td>
- *      <td><p>Same as RepeatDataSimplePath, but with a trailing resource.</p></td>
+ *      <td><p> Same as RepeatDataSimplePath, but with a trailing resource.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -176,7 +170,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>RepeatDataBodyPut</td>
- *      <td><p>This method echoes the ComplianceData request, using the HTTP PUT method.</p></td>
+ *      <td><p> This method echoes the ComplianceData request, using the HTTP PUT method.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -190,7 +184,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>RepeatDataBodyPatch</td>
- *      <td><p>This method echoes the ComplianceData request, using the HTTP PATCH method.</p></td>
+ *      <td><p> This method echoes the ComplianceData request, using the HTTP PATCH method.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -204,12 +198,8 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetEnum</td>
- *      <td><p>This method requests an enum value from the server. Depending on the contents of EnumRequest, the enum value returned will be a known enum declared in the
- *  .proto file, or a made-up enum value the is unknown to the client. To verify that clients can round-trip unknown enum vaues they receive, use the
- *  response from this RPC as the request to VerifyEnum()
- *
- *  The values of enums sent by the server when a known or unknown value is requested will be the same within a single Showcase server run (this is needed for
- *  VerifyEnum() to work) but are not guaranteed to be the same across separate Showcase server runs.</p></td>
+ *      <td><p> This method requests an enum value from the server. Depending on the contents of EnumRequest, the enum value returned will be a known enum declared in the .proto file, or a made-up enum value the is unknown to the client. To verify that clients can round-trip unknown enum vaues they receive, use the response from this RPC as the request to VerifyEnum()
+ * <p>  The values of enums sent by the server when a known or unknown value is requested will be the same within a single Showcase server run (this is needed for VerifyEnum() to work) but are not guaranteed to be the same across separate Showcase server runs.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -223,12 +213,8 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>VerifyEnum</td>
- *      <td><p>This method is used to verify that clients can round-trip enum values, which is particularly important for unknown enum values over REST. VerifyEnum()
- *  verifies that its request, which is presumably the response that the client previously got to a GetEnum(), contains the correct data. If so, it responds
- *  with the same EnumResponse; otherwise, the RPC errors.
- *
- *  This works because the values of enums sent by the server when a known or unknown value is requested will be the same within a single Showcase server run,
- *  although they are not guaranteed to be the same across separate Showcase server runs.</p></td>
+ *      <td><p> This method is used to verify that clients can round-trip enum values, which is particularly important for unknown enum values over REST. VerifyEnum() verifies that its request, which is presumably the response that the client previously got to a GetEnum(), contains the correct data. If so, it responds with the same EnumResponse; otherwise, the RPC errors.
+ * <p>  This works because the values of enums sent by the server when a known or unknown value is requested will be the same within a single Showcase server run, although they are not guaranteed to be the same across separate Showcase server runs.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -242,7 +228,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListLocations</td>
- *      <td><p>Lists information about the supported locations for this service.</p></td>
+ *      <td><p> Lists information about the supported locations for this service.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -257,7 +243,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetLocation</td>
- *      <td><p>Gets information about a location.</p></td>
+ *      <td><p> Gets information about a location.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -271,10 +257,8 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>SetIamPolicy</td>
- *      <td><p>Sets the access control policy on the specified resource. Replaces any
- *  existing policy.
- *
- *  Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.</p></td>
+ *      <td><p> Sets the access control policy on the specified resource. Replaces any existing policy.
+ * <p>  Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -288,9 +272,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetIamPolicy</td>
- *      <td><p>Gets the access control policy for a resource.
- *  Returns an empty policy if the resource exists and does not have a policy
- *  set.</p></td>
+ *      <td><p> Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -304,13 +286,8 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>TestIamPermissions</td>
- *      <td><p>Returns permissions that a caller has on the specified resource.
- *  If the resource does not exist, this will return an empty set of
- *  permissions, not a `NOT_FOUND` error.
- *
- *  Note: This operation is designed to be used for building permission-aware
- *  UIs and command-line tools, not for authorization checking. This operation
- *  may "fail open" without warning.</p></td>
+ *      <td><p> Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error.
+ * <p>  Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may "fail open" without warning.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/EchoClient.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/EchoClient.java
@@ -89,7 +89,7 @@ import javax.annotation.Generated;
  *      <th>Method Variants</th>
  *    <tr>
  *      <td>Echo</td>
- *      <td><p>This method simply echoes the request. This method showcases unary RPCs.</p></td>
+ *      <td><p> This method simply echoes the request. This method showcases unary RPCs.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -103,12 +103,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>EchoErrorDetails</td>
- *      <td><p>This method returns error details in a repeated "google.protobuf.Any"
- *  field. This method showcases handling errors thus encoded, particularly
- *  over REST transport. Note that GAPICs only allow the type
- *  "google.protobuf.Any" for field paths ending in "error.details", and, at
- *  run-time, the actual types for these fields must be one of the types in
- *  google/rpc/error_details.proto.</p></td>
+ *      <td><p> This method returns error details in a repeated "google.protobuf.Any" field. This method showcases handling errors thus encoded, particularly over REST transport. Note that GAPICs only allow the type "google.protobuf.Any" for field paths ending in "error.details", and, at run-time, the actual types for these fields must be one of the types in google/rpc/error_details.proto.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -122,8 +117,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>Expand</td>
- *      <td><p>This method splits the given content into words and will pass each word back
- *  through the stream. This method showcases server-side streaming RPCs.</p></td>
+ *      <td><p> This method splits the given content into words and will pass each word back through the stream. This method showcases server-side streaming RPCs.</td>
  *      <td>
  *      <p>Callable method variants take no parameters and return an immutable API callable object, which can be used to initiate calls to the service.</p>
  *      <ul>
@@ -133,9 +127,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>Collect</td>
- *      <td><p>This method will collect the words given to it. When the stream is closed
- *  by the client, this method will return the a concatenation of the strings
- *  passed to it. This method showcases client-side streaming RPCs.</p></td>
+ *      <td><p> This method will collect the words given to it. When the stream is closed by the client, this method will return the a concatenation of the strings passed to it. This method showcases client-side streaming RPCs.</td>
  *      <td>
  *      <p>Callable method variants take no parameters and return an immutable API callable object, which can be used to initiate calls to the service.</p>
  *      <ul>
@@ -145,9 +137,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>Chat</td>
- *      <td><p>This method, upon receiving a request on the stream, will pass the same
- *  content back on the stream. This method showcases bidirectional
- *  streaming RPCs.</p></td>
+ *      <td><p> This method, upon receiving a request on the stream, will pass the same content back on the stream. This method showcases bidirectional streaming RPCs.</td>
  *      <td>
  *      <p>Callable method variants take no parameters and return an immutable API callable object, which can be used to initiate calls to the service.</p>
  *      <ul>
@@ -157,8 +147,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>PagedExpand</td>
- *      <td><p>This is similar to the Expand method but instead of returning a stream of
- *  expanded words, this method returns a paged list of expanded words.</p></td>
+ *      <td><p> This is similar to the Expand method but instead of returning a stream of expanded words, this method returns a paged list of expanded words.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -173,9 +162,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>PagedExpandLegacy</td>
- *      <td><p>This is similar to the PagedExpand except that it uses
- *  max_results instead of page_size, as some legacy APIs still
- *  do. New APIs should NOT use this pattern.</p></td>
+ *      <td><p> This is similar to the PagedExpand except that it uses max_results instead of page_size, as some legacy APIs still do. New APIs should NOT use this pattern.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -189,11 +176,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>PagedExpandLegacyMapped</td>
- *      <td><p>This method returns a map containing lists of words that appear in the input, keyed by their
- *  initial character. The only words returned are the ones included in the current page,
- *  as determined by page_token and page_size, which both refer to the word indices in the
- *  input. This paging result consisting of a map of lists is a pattern used by some legacy
- *  APIs. New APIs should NOT use this pattern.</p></td>
+ *      <td><p> This method returns a map containing lists of words that appear in the input, keyed by their initial character. The only words returned are the ones included in the current page, as determined by page_token and page_size, which both refer to the word indices in the input. This paging result consisting of a map of lists is a pattern used by some legacy APIs. New APIs should NOT use this pattern.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -208,8 +191,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>Wait</td>
- *      <td><p>This method will wait for the requested amount of time and then return.
- *  This method showcases how a client handles a request timeout.</p></td>
+ *      <td><p> This method will wait for the requested amount of time and then return. This method showcases how a client handles a request timeout.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -224,9 +206,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>Block</td>
- *      <td><p>This method will block (wait) for the requested amount of time
- *  and then return the response or error.
- *  This method showcases how a client handles delays or retries.</p></td>
+ *      <td><p> This method will block (wait) for the requested amount of time and then return the response or error. This method showcases how a client handles delays or retries.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -240,7 +220,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListLocations</td>
- *      <td><p>Lists information about the supported locations for this service.</p></td>
+ *      <td><p> Lists information about the supported locations for this service.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -255,7 +235,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetLocation</td>
- *      <td><p>Gets information about a location.</p></td>
+ *      <td><p> Gets information about a location.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -269,10 +249,8 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>SetIamPolicy</td>
- *      <td><p>Sets the access control policy on the specified resource. Replaces any
- *  existing policy.
- *
- *  Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.</p></td>
+ *      <td><p> Sets the access control policy on the specified resource. Replaces any existing policy.
+ * <p>  Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -286,9 +264,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetIamPolicy</td>
- *      <td><p>Gets the access control policy for a resource.
- *  Returns an empty policy if the resource exists and does not have a policy
- *  set.</p></td>
+ *      <td><p> Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -302,13 +278,8 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>TestIamPermissions</td>
- *      <td><p>Returns permissions that a caller has on the specified resource.
- *  If the resource does not exist, this will return an empty set of
- *  permissions, not a `NOT_FOUND` error.
- *
- *  Note: This operation is designed to be used for building permission-aware
- *  UIs and command-line tools, not for authorization checking. This operation
- *  may "fail open" without warning.</p></td>
+ *      <td><p> Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error.
+ * <p>  Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may "fail open" without warning.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/IdentityClient.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/IdentityClient.java
@@ -73,7 +73,7 @@ import javax.annotation.Generated;
  *      <th>Method Variants</th>
  *    <tr>
  *      <td>CreateUser</td>
- *      <td><p>Creates a user.</p></td>
+ *      <td><p> Creates a user.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -92,7 +92,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetUser</td>
- *      <td><p>Retrieves the User with the given uri.</p></td>
+ *      <td><p> Retrieves the User with the given uri.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -111,7 +111,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>UpdateUser</td>
- *      <td><p>Updates a user.</p></td>
+ *      <td><p> Updates a user.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -125,7 +125,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>DeleteUser</td>
- *      <td><p>Deletes a user, their profile, and all of their authored messages.</p></td>
+ *      <td><p> Deletes a user, their profile, and all of their authored messages.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -144,7 +144,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListUsers</td>
- *      <td><p>Lists all users.</p></td>
+ *      <td><p> Lists all users.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -159,7 +159,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListLocations</td>
- *      <td><p>Lists information about the supported locations for this service.</p></td>
+ *      <td><p> Lists information about the supported locations for this service.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -174,7 +174,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetLocation</td>
- *      <td><p>Gets information about a location.</p></td>
+ *      <td><p> Gets information about a location.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -188,10 +188,8 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>SetIamPolicy</td>
- *      <td><p>Sets the access control policy on the specified resource. Replaces any
- *  existing policy.
- *
- *  Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.</p></td>
+ *      <td><p> Sets the access control policy on the specified resource. Replaces any existing policy.
+ * <p>  Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -205,9 +203,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetIamPolicy</td>
- *      <td><p>Gets the access control policy for a resource.
- *  Returns an empty policy if the resource exists and does not have a policy
- *  set.</p></td>
+ *      <td><p> Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -221,13 +217,8 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>TestIamPermissions</td>
- *      <td><p>Returns permissions that a caller has on the specified resource.
- *  If the resource does not exist, this will return an empty set of
- *  permissions, not a `NOT_FOUND` error.
- *
- *  Note: This operation is designed to be used for building permission-aware
- *  UIs and command-line tools, not for authorization checking. This operation
- *  may "fail open" without warning.</p></td>
+ *      <td><p> Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error.
+ * <p>  Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may "fail open" without warning.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/MessagingClient.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/MessagingClient.java
@@ -84,7 +84,7 @@ import javax.annotation.Generated;
  *      <th>Method Variants</th>
  *    <tr>
  *      <td>CreateRoom</td>
- *      <td><p>Creates a room.</p></td>
+ *      <td><p> Creates a room.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -102,7 +102,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetRoom</td>
- *      <td><p>Retrieves the Room with the given resource name.</p></td>
+ *      <td><p> Retrieves the Room with the given resource name.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -121,7 +121,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>UpdateRoom</td>
- *      <td><p>Updates a room.</p></td>
+ *      <td><p> Updates a room.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -135,7 +135,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>DeleteRoom</td>
- *      <td><p>Deletes a room and all of its blurbs.</p></td>
+ *      <td><p> Deletes a room and all of its blurbs.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -154,7 +154,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListRooms</td>
- *      <td><p>Lists all chat rooms.</p></td>
+ *      <td><p> Lists all chat rooms.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -169,9 +169,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>CreateBlurb</td>
- *      <td><p>Creates a blurb. If the parent is a room, the blurb is understood to be a
- *  message in that room. If the parent is a profile, the blurb is understood
- *  to be a post on the profile.</p></td>
+ *      <td><p> Creates a blurb. If the parent is a room, the blurb is understood to be a message in that room. If the parent is a profile, the blurb is understood to be a post on the profile.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -200,7 +198,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetBlurb</td>
- *      <td><p>Retrieves the Blurb with the given resource name.</p></td>
+ *      <td><p> Retrieves the Blurb with the given resource name.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -219,7 +217,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>UpdateBlurb</td>
- *      <td><p>Updates a blurb.</p></td>
+ *      <td><p> Updates a blurb.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -233,7 +231,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>DeleteBlurb</td>
- *      <td><p>Deletes a blurb.</p></td>
+ *      <td><p> Deletes a blurb.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -252,8 +250,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListBlurbs</td>
- *      <td><p>Lists blurbs for a specific chat room or user profile depending on the
- *  parent resource name.</p></td>
+ *      <td><p> Lists blurbs for a specific chat room or user profile depending on the parent resource name.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -274,9 +271,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>SearchBlurbs</td>
- *      <td><p>This method searches through all blurbs across all rooms and profiles
- *  for blurbs containing to words found in the query. Only posts that
- *  contain an exact match of a queried word will be returned.</p></td>
+ *      <td><p> This method searches through all blurbs across all rooms and profiles for blurbs containing to words found in the query. Only posts that contain an exact match of a queried word will be returned.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -297,8 +292,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>StreamBlurbs</td>
- *      <td><p>This returns a stream that emits the blurbs that are created for a
- *  particular chat room or user profile.</p></td>
+ *      <td><p> This returns a stream that emits the blurbs that are created for a particular chat room or user profile.</td>
  *      <td>
  *      <p>Callable method variants take no parameters and return an immutable API callable object, which can be used to initiate calls to the service.</p>
  *      <ul>
@@ -308,8 +302,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>SendBlurbs</td>
- *      <td><p>This is a stream to create multiple blurbs. If an invalid blurb is
- *  requested to be created, the stream will close with an error.</p></td>
+ *      <td><p> This is a stream to create multiple blurbs. If an invalid blurb is requested to be created, the stream will close with an error.</td>
  *      <td>
  *      <p>Callable method variants take no parameters and return an immutable API callable object, which can be used to initiate calls to the service.</p>
  *      <ul>
@@ -319,10 +312,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>Connect</td>
- *      <td><p>This method starts a bidirectional stream that receives all blurbs that
- *  are being created after the stream has started and sends requests to create
- *  blurbs. If an invalid blurb is requested to be created, the stream will
- *  close with an error.</p></td>
+ *      <td><p> This method starts a bidirectional stream that receives all blurbs that are being created after the stream has started and sends requests to create blurbs. If an invalid blurb is requested to be created, the stream will close with an error.</td>
  *      <td>
  *      <p>Callable method variants take no parameters and return an immutable API callable object, which can be used to initiate calls to the service.</p>
  *      <ul>
@@ -332,7 +322,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListLocations</td>
- *      <td><p>Lists information about the supported locations for this service.</p></td>
+ *      <td><p> Lists information about the supported locations for this service.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -347,7 +337,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetLocation</td>
- *      <td><p>Gets information about a location.</p></td>
+ *      <td><p> Gets information about a location.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -361,10 +351,8 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>SetIamPolicy</td>
- *      <td><p>Sets the access control policy on the specified resource. Replaces any
- *  existing policy.
- *
- *  Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.</p></td>
+ *      <td><p> Sets the access control policy on the specified resource. Replaces any existing policy.
+ * <p>  Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -378,9 +366,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetIamPolicy</td>
- *      <td><p>Gets the access control policy for a resource.
- *  Returns an empty policy if the resource exists and does not have a policy
- *  set.</p></td>
+ *      <td><p> Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -394,13 +380,8 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>TestIamPermissions</td>
- *      <td><p>Returns permissions that a caller has on the specified resource.
- *  If the resource does not exist, this will return an empty set of
- *  permissions, not a `NOT_FOUND` error.
- *
- *  Note: This operation is designed to be used for building permission-aware
- *  UIs and command-line tools, not for authorization checking. This operation
- *  may "fail open" without warning.</p></td>
+ *      <td><p> Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error.
+ * <p>  Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may "fail open" without warning.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/SequenceServiceClient.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/SequenceServiceClient.java
@@ -72,7 +72,7 @@ import javax.annotation.Generated;
  *      <th>Method Variants</th>
  *    <tr>
  *      <td>CreateSequence</td>
- *      <td><p>Creates a sequence.</p></td>
+ *      <td><p> Creates a sequence.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -90,7 +90,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>CreateStreamingSequence</td>
- *      <td><p>Creates a sequence.</p></td>
+ *      <td><p> Creates a sequence.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -108,7 +108,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetSequenceReport</td>
- *      <td><p>Retrieves a sequence.</p></td>
+ *      <td><p> Retrieves a sequence.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -127,7 +127,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetStreamingSequenceReport</td>
- *      <td><p>Retrieves a sequence.</p></td>
+ *      <td><p> Retrieves a sequence.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -146,7 +146,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>AttemptSequence</td>
- *      <td><p>Attempts a sequence.</p></td>
+ *      <td><p> Attempts a sequence.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -165,7 +165,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>AttemptStreamingSequence</td>
- *      <td><p>Attempts a streaming sequence.</p></td>
+ *      <td><p> Attempts a streaming sequence.</td>
  *      <td>
  *      <p>Callable method variants take no parameters and return an immutable API callable object, which can be used to initiate calls to the service.</p>
  *      <ul>
@@ -175,7 +175,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListLocations</td>
- *      <td><p>Lists information about the supported locations for this service.</p></td>
+ *      <td><p> Lists information about the supported locations for this service.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -190,7 +190,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetLocation</td>
- *      <td><p>Gets information about a location.</p></td>
+ *      <td><p> Gets information about a location.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -204,10 +204,8 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>SetIamPolicy</td>
- *      <td><p>Sets the access control policy on the specified resource. Replaces any
- *  existing policy.
- *
- *  Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.</p></td>
+ *      <td><p> Sets the access control policy on the specified resource. Replaces any existing policy.
+ * <p>  Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -221,9 +219,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetIamPolicy</td>
- *      <td><p>Gets the access control policy for a resource.
- *  Returns an empty policy if the resource exists and does not have a policy
- *  set.</p></td>
+ *      <td><p> Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -237,13 +233,8 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>TestIamPermissions</td>
- *      <td><p>Returns permissions that a caller has on the specified resource.
- *  If the resource does not exist, this will return an empty set of
- *  permissions, not a `NOT_FOUND` error.
- *
- *  Note: This operation is designed to be used for building permission-aware
- *  UIs and command-line tools, not for authorization checking. This operation
- *  may "fail open" without warning.</p></td>
+ *      <td><p> Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error.
+ * <p>  Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may "fail open" without warning.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/TestingClient.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/TestingClient.java
@@ -73,7 +73,7 @@ import javax.annotation.Generated;
  *      <th>Method Variants</th>
  *    <tr>
  *      <td>CreateSession</td>
- *      <td><p>Creates a new testing session.</p></td>
+ *      <td><p> Creates a new testing session.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -87,7 +87,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetSession</td>
- *      <td><p>Gets a testing session.</p></td>
+ *      <td><p> Gets a testing session.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -101,7 +101,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListSessions</td>
- *      <td><p>Lists the current test sessions.</p></td>
+ *      <td><p> Lists the current test sessions.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -116,7 +116,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>DeleteSession</td>
- *      <td><p>Delete a test session.</p></td>
+ *      <td><p> Delete a test session.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -130,9 +130,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ReportSession</td>
- *      <td><p>Report on the status of a session.
- *  This generates a report detailing which tests have been completed,
- *  and an overall rollup.</p></td>
+ *      <td><p> Report on the status of a session. This generates a report detailing which tests have been completed, and an overall rollup.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -146,7 +144,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListTests</td>
- *      <td><p>List the tests of a sessesion.</p></td>
+ *      <td><p> List the tests of a sessesion.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -161,12 +159,9 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>DeleteTest</td>
- *      <td><p>Explicitly decline to implement a test.
- *
- *  This removes the test from subsequent `ListTests` calls, and
- *  attempting to do the test will error.
- *
- *  This method will error if attempting to delete a required test.</p></td>
+ *      <td><p> Explicitly decline to implement a test.
+ * <p>  This removes the test from subsequent `ListTests` calls, and attempting to do the test will error.
+ * <p>  This method will error if attempting to delete a required test.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -180,10 +175,8 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>VerifyTest</td>
- *      <td><p>Register a response to a test.
- *
- *  In cases where a test involves registering a final answer at the
- *  end of the test, this method provides the means to do so.</p></td>
+ *      <td><p> Register a response to a test.
+ * <p>  In cases where a test involves registering a final answer at the end of the test, this method provides the means to do so.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -197,7 +190,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListLocations</td>
- *      <td><p>Lists information about the supported locations for this service.</p></td>
+ *      <td><p> Lists information about the supported locations for this service.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -212,7 +205,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetLocation</td>
- *      <td><p>Gets information about a location.</p></td>
+ *      <td><p> Gets information about a location.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -226,10 +219,8 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>SetIamPolicy</td>
- *      <td><p>Sets the access control policy on the specified resource. Replaces any
- *  existing policy.
- *
- *  Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.</p></td>
+ *      <td><p> Sets the access control policy on the specified resource. Replaces any existing policy.
+ * <p>  Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -243,9 +234,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetIamPolicy</td>
- *      <td><p>Gets the access control policy for a resource.
- *  Returns an empty policy if the resource exists and does not have a policy
- *  set.</p></td>
+ *      <td><p> Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -259,13 +248,8 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>TestIamPermissions</td>
- *      <td><p>Returns permissions that a caller has on the specified resource.
- *  If the resource does not exist, this will return an empty set of
- *  permissions, not a `NOT_FOUND` error.
- *
- *  Note: This operation is designed to be used for building permission-aware
- *  UIs and command-line tools, not for authorization checking. This operation
- *  may "fail open" without warning.</p></td>
+ *      <td><p> Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error.
+ * <p>  Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may "fail open" without warning.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/ConnectionServiceClient.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/ConnectionServiceClient.java
@@ -64,8 +64,7 @@ import javax.annotation.Generated;
  *      <th>Method Variants</th>
  *    <tr>
  *      <td>ListConnections</td>
- *      <td><p>Lists connections that are currently active for the given Apigee Connect
- *  endpoint.</p></td>
+ *      <td><p> Lists connections that are currently active for the given Apigee Connect endpoint.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/TetherClient.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/TetherClient.java
@@ -68,13 +68,7 @@ import javax.annotation.Generated;
  *      <th>Method Variants</th>
  *    <tr>
  *      <td>Egress</td>
- *      <td><p>Egress streams egress requests and responses. Logically, this is not
- *  actually a streaming request, but uses streaming as a mechanism to flip
- *  the client-server relationship of gRPC so that the server can act as a
- *  client.
- *  The listener, the RPC server, accepts connections from the dialer,
- *  the RPC client.
- *  The listener streams http requests and the dialer streams http responses.</p></td>
+ *      <td><p> Egress streams egress requests and responses. Logically, this is not actually a streaming request, but uses streaming as a mechanism to flip the client-server relationship of gRPC so that the server can act as a client. The listener, the RPC server, accepts connections from the dialer, the RPC client. The listener streams http requests and the dialer streams http responses.</td>
  *      <td>
  *      <p>Callable method variants take no parameters and return an immutable API callable object, which can be used to initiate calls to the service.</p>
  *      <ul>

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/AssetServiceClient.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/AssetServiceClient.java
@@ -76,16 +76,7 @@ import javax.annotation.Generated;
  *      <th>Method Variants</th>
  *    <tr>
  *      <td>ExportAssets</td>
- *      <td><p>Exports assets with time and resource types to a given Cloud Storage
- *  location/BigQuery table. For Cloud Storage location destinations, the
- *  output format is newline-delimited JSON. Each line represents a
- *  [google.cloud.asset.v1.Asset][google.cloud.asset.v1.Asset] in the JSON format; for BigQuery table
- *  destinations, the output table stores the fields in asset Protobuf as
- *  columns. This API implements the [google.longrunning.Operation][google.longrunning.Operation] API,
- *  which allows you to keep track of the export. We recommend intervals of at
- *  least 2 seconds with exponential retry to poll the export operation result.
- *  For regular-size resource parent, the export operation usually finishes
- *  within 5 minutes.</p></td>
+ *      <td><p> Exports assets with time and resource types to a given Cloud Storage location/BigQuery table. For Cloud Storage location destinations, the output format is newline-delimited JSON. Each line represents a [google.cloud.asset.v1.Asset][google.cloud.asset.v1.Asset] in the JSON format; for BigQuery table destinations, the output table stores the fields in asset Protobuf as columns. This API implements the [google.longrunning.Operation][google.longrunning.Operation] API, which allows you to keep track of the export. We recommend intervals of at least 2 seconds with exponential retry to poll the export operation result. For regular-size resource parent, the export operation usually finishes within 5 minutes.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -100,8 +91,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListAssets</td>
- *      <td><p>Lists assets with time and resource types and returns paged results in
- *  response.</p></td>
+ *      <td><p> Lists assets with time and resource types and returns paged results in response.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -121,13 +111,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>BatchGetAssetsHistory</td>
- *      <td><p>Batch gets the update history of assets that overlap a time window.
- *  For IAM_POLICY content, this API outputs history when the asset and its
- *  attached IAM POLICY both exist. This can create gaps in the output history.
- *  Otherwise, this API outputs history with asset in both non-delete or
- *  deleted status.
- *  If a specified asset does not exist, this API returns an INVALID_ARGUMENT
- *  error.</p></td>
+ *      <td><p> Batch gets the update history of assets that overlap a time window. For IAM_POLICY content, this API outputs history when the asset and its attached IAM POLICY both exist. This can create gaps in the output history. Otherwise, this API outputs history with asset in both non-delete or deleted status. If a specified asset does not exist, this API returns an INVALID_ARGUMENT error.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -141,8 +125,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>CreateFeed</td>
- *      <td><p>Creates a feed in a parent project/folder/organization to listen to its
- *  asset updates.</p></td>
+ *      <td><p> Creates a feed in a parent project/folder/organization to listen to its asset updates.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -160,7 +143,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetFeed</td>
- *      <td><p>Gets details about an asset feed.</p></td>
+ *      <td><p> Gets details about an asset feed.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -179,7 +162,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListFeeds</td>
- *      <td><p>Lists all asset feeds in a parent project/folder/organization.</p></td>
+ *      <td><p> Lists all asset feeds in a parent project/folder/organization.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -197,7 +180,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>UpdateFeed</td>
- *      <td><p>Updates an asset feed configuration.</p></td>
+ *      <td><p> Updates an asset feed configuration.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -215,7 +198,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>DeleteFeed</td>
- *      <td><p>Deletes an asset feed.</p></td>
+ *      <td><p> Deletes an asset feed.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -234,10 +217,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>SearchAllResources</td>
- *      <td><p>Searches all Cloud resources within the specified scope, such as a project,
- *  folder, or organization. The caller must be granted the
- *  `cloudasset.assets.searchAllResources` permission on the desired scope,
- *  otherwise the request will be rejected.</p></td>
+ *      <td><p> Searches all Cloud resources within the specified scope, such as a project, folder, or organization. The caller must be granted the `cloudasset.assets.searchAllResources` permission on the desired scope, otherwise the request will be rejected.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -256,10 +236,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>SearchAllIamPolicies</td>
- *      <td><p>Searches all IAM policies within the specified scope, such as a project,
- *  folder, or organization. The caller must be granted the
- *  `cloudasset.assets.searchAllIamPolicies` permission on the desired scope,
- *  otherwise the request will be rejected.</p></td>
+ *      <td><p> Searches all IAM policies within the specified scope, such as a project, folder, or organization. The caller must be granted the `cloudasset.assets.searchAllIamPolicies` permission on the desired scope, otherwise the request will be rejected.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -278,8 +255,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>AnalyzeIamPolicy</td>
- *      <td><p>Analyzes IAM policies to answer which identities have what accesses on
- *  which resources.</p></td>
+ *      <td><p> Analyzes IAM policies to answer which identities have what accesses on which resources.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -293,15 +269,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>AnalyzeIamPolicyLongrunning</td>
- *      <td><p>Analyzes IAM policies asynchronously to answer which identities have what
- *  accesses on which resources, and writes the analysis results to a Google
- *  Cloud Storage or a BigQuery destination. For Cloud Storage destination, the
- *  output format is the JSON format that represents a
- *  [AnalyzeIamPolicyResponse][google.cloud.asset.v1.AnalyzeIamPolicyResponse]. This method implements the
- *  [google.longrunning.Operation][google.longrunning.Operation], which allows you to track the operation
- *  status. We recommend intervals of at least 2 seconds with exponential
- *  backoff retry to poll the operation result. The metadata contains the
- *  metadata for the long-running operation.</p></td>
+ *      <td><p> Analyzes IAM policies asynchronously to answer which identities have what accesses on which resources, and writes the analysis results to a Google Cloud Storage or a BigQuery destination. For Cloud Storage destination, the output format is the JSON format that represents a [AnalyzeIamPolicyResponse][google.cloud.asset.v1.AnalyzeIamPolicyResponse]. This method implements the [google.longrunning.Operation][google.longrunning.Operation], which allows you to track the operation status. We recommend intervals of at least 2 seconds with exponential backoff retry to poll the operation result. The metadata contains the metadata for the long-running operation.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -316,11 +284,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>AnalyzeMove</td>
- *      <td><p>Analyze moving a resource to a specified destination without kicking off
- *  the actual move. The analysis is best effort depending on the user's
- *  permissions of viewing different hierarchical policies and configurations.
- *  The policies and configuration are subject to change before the actual
- *  resource migration takes place.</p></td>
+ *      <td><p> Analyze moving a resource to a specified destination without kicking off the actual move. The analysis is best effort depending on the user's permissions of viewing different hierarchical policies and configurations. The policies and configuration are subject to change before the actual resource migration takes place.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -334,20 +298,10 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>QueryAssets</td>
- *      <td><p>Issue a job that queries assets using a SQL statement compatible with
- *  [BigQuery Standard
- *  SQL](http://cloud/bigquery/docs/reference/standard-sql/enabling-standard-sql).
- *
- *  If the query execution finishes within timeout and there's no pagination,
- *  the full query results will be returned in the `QueryAssetsResponse`.
- *
- *  Otherwise, full query results can be obtained by issuing extra requests
- *  with the `job_reference` from the a previous `QueryAssets` call.
- *
- *  Note, the query result has approximately 10 GB limitation enforced by
- *  BigQuery
- *  https://cloud.google.com/bigquery/docs/best-practices-performance-output,
- *  queries return larger results will result in errors.</p></td>
+ *      <td><p> Issue a job that queries assets using a SQL statement compatible with [BigQuery Standard SQL](http://cloud/bigquery/docs/reference/standard-sql/enabling-standard-sql).
+ * <p>  If the query execution finishes within timeout and there's no pagination, the full query results will be returned in the `QueryAssetsResponse`.
+ * <p>  Otherwise, full query results can be obtained by issuing extra requests with the `job_reference` from the a previous `QueryAssets` call.
+ * <p>  Note, the query result has approximately 10 GB limitation enforced by BigQuery https://cloud.google.com/bigquery/docs/best-practices-performance-output, queries return larger results will result in errors.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -361,7 +315,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>CreateSavedQuery</td>
- *      <td><p>Creates a saved query in a parent project/folder/organization.</p></td>
+ *      <td><p> Creates a saved query in a parent project/folder/organization.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -382,7 +336,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetSavedQuery</td>
- *      <td><p>Gets details about a saved query.</p></td>
+ *      <td><p> Gets details about a saved query.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -401,7 +355,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListSavedQueries</td>
- *      <td><p>Lists all saved queries in a parent project/folder/organization.</p></td>
+ *      <td><p> Lists all saved queries in a parent project/folder/organization.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -423,7 +377,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>UpdateSavedQuery</td>
- *      <td><p>Updates a saved query.</p></td>
+ *      <td><p> Updates a saved query.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -441,7 +395,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>DeleteSavedQuery</td>
- *      <td><p>Deletes a saved query.</p></td>
+ *      <td><p> Deletes a saved query.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -460,7 +414,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>BatchGetEffectiveIamPolicies</td>
- *      <td><p>Gets effective IAM policies for a batch of resources.</p></td>
+ *      <td><p> Gets effective IAM policies for a batch of resources.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>

--- a/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/BaseBigtableDataClient.java
+++ b/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/BaseBigtableDataClient.java
@@ -78,11 +78,7 @@ import javax.annotation.Generated;
  *      <th>Method Variants</th>
  *    <tr>
  *      <td>ReadRows</td>
- *      <td><p>Streams back the contents of all requested rows in key order, optionally
- *  applying the same Reader filter to each. Depending on their size,
- *  rows and cells may be broken up across multiple responses, but
- *  atomicity of each row will still be preserved. See the
- *  ReadRowsResponse documentation for details.</p></td>
+ *      <td><p> Streams back the contents of all requested rows in key order, optionally applying the same Reader filter to each. Depending on their size, rows and cells may be broken up across multiple responses, but atomicity of each row will still be preserved. See the ReadRowsResponse documentation for details.</td>
  *      <td>
  *      <p>Callable method variants take no parameters and return an immutable API callable object, which can be used to initiate calls to the service.</p>
  *      <ul>
@@ -92,10 +88,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>SampleRowKeys</td>
- *      <td><p>Returns a sample of row keys in the table. The returned row keys will
- *  delimit contiguous sections of the table of approximately equal size,
- *  which can be used to break up the data for distributed tasks like
- *  mapreduces.</p></td>
+ *      <td><p> Returns a sample of row keys in the table. The returned row keys will delimit contiguous sections of the table of approximately equal size, which can be used to break up the data for distributed tasks like mapreduces.</td>
  *      <td>
  *      <p>Callable method variants take no parameters and return an immutable API callable object, which can be used to initiate calls to the service.</p>
  *      <ul>
@@ -105,8 +98,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>MutateRow</td>
- *      <td><p>Mutates a row atomically. Cells already present in the row are left
- *  unchanged unless explicitly changed by `mutation`.</p></td>
+ *      <td><p> Mutates a row atomically. Cells already present in the row are left unchanged unless explicitly changed by `mutation`.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -127,9 +119,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>MutateRows</td>
- *      <td><p>Mutates multiple rows in a batch. Each individual row is mutated
- *  atomically as in MutateRow, but the entire batch is not executed
- *  atomically.</p></td>
+ *      <td><p> Mutates multiple rows in a batch. Each individual row is mutated atomically as in MutateRow, but the entire batch is not executed atomically.</td>
  *      <td>
  *      <p>Callable method variants take no parameters and return an immutable API callable object, which can be used to initiate calls to the service.</p>
  *      <ul>
@@ -139,7 +129,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>CheckAndMutateRow</td>
- *      <td><p>Mutates a row atomically based on the output of a predicate Reader filter.</p></td>
+ *      <td><p> Mutates a row atomically based on the output of a predicate Reader filter.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -160,8 +150,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>PingAndWarm</td>
- *      <td><p>Warm up associated instance metadata for this connection.
- *  This call is not required but may be useful for connection keep-alive.</p></td>
+ *      <td><p> Warm up associated instance metadata for this connection. This call is not required but may be useful for connection keep-alive.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -182,11 +171,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ReadModifyWriteRow</td>
- *      <td><p>Modifies a row atomically on the server. The method reads the latest
- *  existing timestamp and value from the specified columns and writes a new
- *  entry based on pre-defined read/modify/write rules. The new value for the
- *  timestamp is the greater of the existing timestamp or the current server
- *  time. The method returns the new contents of all modified cells.</p></td>
+ *      <td><p> Modifies a row atomically on the server. The method reads the latest existing timestamp and value from the specified columns and writes a new entry based on pre-defined read/modify/write rules. The new value for the timestamp is the greater of the existing timestamp or the current server time. The method returns the new contents of all modified cells.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/AddressesClient.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/AddressesClient.java
@@ -70,7 +70,7 @@ import javax.annotation.Generated;
  *      <th>Method Variants</th>
  *    <tr>
  *      <td>AggregatedList</td>
- *      <td><p>Retrieves an aggregated list of addresses.</p></td>
+ *      <td><p> Retrieves an aggregated list of addresses.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -89,7 +89,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>Delete</td>
- *      <td><p>Deletes the specified address resource.</p></td>
+ *      <td><p> Deletes the specified address resource.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -108,7 +108,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>Insert</td>
- *      <td><p>Creates an address resource in the specified project by using the data included in the request.</p></td>
+ *      <td><p> Creates an address resource in the specified project by using the data included in the request.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -127,7 +127,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>List</td>
- *      <td><p>Retrieves a list of addresses contained within the specified region.</p></td>
+ *      <td><p> Retrieves a list of addresses contained within the specified region.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/RegionOperationsClient.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/RegionOperationsClient.java
@@ -56,7 +56,7 @@ import javax.annotation.Generated;
  *      <th>Method Variants</th>
  *    <tr>
  *      <td>Get</td>
- *      <td><p>Retrieves the specified region-specific Operations resource.</p></td>
+ *      <td><p> Retrieves the specified region-specific Operations resource.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -74,11 +74,8 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>Wait</td>
- *      <td><p>Waits for the specified Operation resource to return as `DONE` or for the request to approach the 2 minute deadline, and retrieves the specified Operation resource. This method differs from the `GET` method in that it waits for no more than the default deadline (2 minutes) and then returns the current state of the operation, which might be `DONE` or still in progress.
- *
- *  This method is called on a best-effort basis. Specifically:
- *  - In uncommon cases, when the server is overloaded, the request might return before the default deadline is reached, or might return after zero seconds.
- *  - If the default deadline is reached, there is no guarantee that the operation is actually done when the method returns. Be prepared to retry if the operation is not `DONE`.</p></td>
+ *      <td><p> Waits for the specified Operation resource to return as `DONE` or for the request to approach the 2 minute deadline, and retrieves the specified Operation resource. This method differs from the `GET` method in that it waits for no more than the default deadline (2 minutes) and then returns the current state of the operation, which might be `DONE` or still in progress.
+ * <p>  This method is called on a best-effort basis. Specifically: - In uncommon cases, when the server is overloaded, the request might return before the default deadline is reached, or might return after zero seconds. - If the default deadline is reached, there is no guarantee that the operation is actually done when the method returns. Be prepared to retry if the operation is not `DONE`.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>

--- a/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/IamCredentialsClient.java
+++ b/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/IamCredentialsClient.java
@@ -67,7 +67,7 @@ import javax.annotation.Generated;
  *      <th>Method Variants</th>
  *    <tr>
  *      <td>GenerateAccessToken</td>
- *      <td><p>Generates an OAuth 2.0 access token for a service account.</p></td>
+ *      <td><p> Generates an OAuth 2.0 access token for a service account.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -86,7 +86,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GenerateIdToken</td>
- *      <td><p>Generates an OpenID Connect ID token for a service account.</p></td>
+ *      <td><p> Generates an OpenID Connect ID token for a service account.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -105,7 +105,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>SignBlob</td>
- *      <td><p>Signs a blob using a service account's system-managed private key.</p></td>
+ *      <td><p> Signs a blob using a service account's system-managed private key.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -124,7 +124,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>SignJwt</td>
- *      <td><p>Signs a JWT using a service account's system-managed private key.</p></td>
+ *      <td><p> Signs a JWT using a service account's system-managed private key.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>

--- a/test/integration/goldens/iam/src/com/google/iam/v1/IAMPolicyClient.java
+++ b/test/integration/goldens/iam/src/com/google/iam/v1/IAMPolicyClient.java
@@ -79,10 +79,8 @@ import javax.annotation.Generated;
  *      <th>Method Variants</th>
  *    <tr>
  *      <td>SetIamPolicy</td>
- *      <td><p>Sets the access control policy on the specified resource. Replaces any
- *  existing policy.
- *
- *  Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.</p></td>
+ *      <td><p> Sets the access control policy on the specified resource. Replaces any existing policy.
+ * <p>  Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -96,9 +94,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetIamPolicy</td>
- *      <td><p>Gets the access control policy for a resource.
- *  Returns an empty policy if the resource exists and does not have a policy
- *  set.</p></td>
+ *      <td><p> Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -112,13 +108,8 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>TestIamPermissions</td>
- *      <td><p>Returns permissions that a caller has on the specified resource.
- *  If the resource does not exist, this will return an empty set of
- *  permissions, not a `NOT_FOUND` error.
- *
- *  Note: This operation is designed to be used for building permission-aware
- *  UIs and command-line tools, not for authorization checking. This operation
- *  may "fail open" without warning.</p></td>
+ *      <td><p> Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error.
+ * <p>  Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may "fail open" without warning.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/KeyManagementServiceClient.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/KeyManagementServiceClient.java
@@ -87,7 +87,7 @@ import javax.annotation.Generated;
  *      <th>Method Variants</th>
  *    <tr>
  *      <td>ListKeyRings</td>
- *      <td><p>Lists [KeyRings][google.cloud.kms.v1.KeyRing].</p></td>
+ *      <td><p> Lists [KeyRings][google.cloud.kms.v1.KeyRing].</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -107,7 +107,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListCryptoKeys</td>
- *      <td><p>Lists [CryptoKeys][google.cloud.kms.v1.CryptoKey].</p></td>
+ *      <td><p> Lists [CryptoKeys][google.cloud.kms.v1.CryptoKey].</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -127,7 +127,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListCryptoKeyVersions</td>
- *      <td><p>Lists [CryptoKeyVersions][google.cloud.kms.v1.CryptoKeyVersion].</p></td>
+ *      <td><p> Lists [CryptoKeyVersions][google.cloud.kms.v1.CryptoKeyVersion].</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -147,7 +147,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListImportJobs</td>
- *      <td><p>Lists [ImportJobs][google.cloud.kms.v1.ImportJob].</p></td>
+ *      <td><p> Lists [ImportJobs][google.cloud.kms.v1.ImportJob].</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -167,7 +167,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetKeyRing</td>
- *      <td><p>Returns metadata for a given [KeyRing][google.cloud.kms.v1.KeyRing].</p></td>
+ *      <td><p> Returns metadata for a given [KeyRing][google.cloud.kms.v1.KeyRing].</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -186,9 +186,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetCryptoKey</td>
- *      <td><p>Returns metadata for a given [CryptoKey][google.cloud.kms.v1.CryptoKey], as
- *  well as its [primary][google.cloud.kms.v1.CryptoKey.primary]
- *  [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion].</p></td>
+ *      <td><p> Returns metadata for a given [CryptoKey][google.cloud.kms.v1.CryptoKey], as well as its [primary][google.cloud.kms.v1.CryptoKey.primary] [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion].</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -207,8 +205,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetCryptoKeyVersion</td>
- *      <td><p>Returns metadata for a given
- *  [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion].</p></td>
+ *      <td><p> Returns metadata for a given [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion].</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -227,12 +224,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetPublicKey</td>
- *      <td><p>Returns the public key for the given
- *  [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion]. The
- *  [CryptoKey.purpose][google.cloud.kms.v1.CryptoKey.purpose] must be
- *  [ASYMMETRIC_SIGN][google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ASYMMETRIC_SIGN]
- *  or
- *  [ASYMMETRIC_DECRYPT][google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ASYMMETRIC_DECRYPT].</p></td>
+ *      <td><p> Returns the public key for the given [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion]. The [CryptoKey.purpose][google.cloud.kms.v1.CryptoKey.purpose] must be [ASYMMETRIC_SIGN][google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ASYMMETRIC_SIGN] or [ASYMMETRIC_DECRYPT][google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ASYMMETRIC_DECRYPT].</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -251,7 +243,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetImportJob</td>
- *      <td><p>Returns metadata for a given [ImportJob][google.cloud.kms.v1.ImportJob].</p></td>
+ *      <td><p> Returns metadata for a given [ImportJob][google.cloud.kms.v1.ImportJob].</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -270,8 +262,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>CreateKeyRing</td>
- *      <td><p>Create a new [KeyRing][google.cloud.kms.v1.KeyRing] in a given Project and
- *  Location.</p></td>
+ *      <td><p> Create a new [KeyRing][google.cloud.kms.v1.KeyRing] in a given Project and Location.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -290,12 +281,8 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>CreateCryptoKey</td>
- *      <td><p>Create a new [CryptoKey][google.cloud.kms.v1.CryptoKey] within a
- *  [KeyRing][google.cloud.kms.v1.KeyRing].
- *
- *  [CryptoKey.purpose][google.cloud.kms.v1.CryptoKey.purpose] and
- *  [CryptoKey.version_template.algorithm][google.cloud.kms.v1.CryptoKeyVersionTemplate.algorithm]
- *  are required.</p></td>
+ *      <td><p> Create a new [CryptoKey][google.cloud.kms.v1.CryptoKey] within a [KeyRing][google.cloud.kms.v1.KeyRing].
+ * <p>  [CryptoKey.purpose][google.cloud.kms.v1.CryptoKey.purpose] and [CryptoKey.version_template.algorithm][google.cloud.kms.v1.CryptoKeyVersionTemplate.algorithm] are required.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -314,12 +301,8 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>CreateCryptoKeyVersion</td>
- *      <td><p>Create a new [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] in a
- *  [CryptoKey][google.cloud.kms.v1.CryptoKey].
- *
- *  The server will assign the next sequential id. If unset,
- *  [state][google.cloud.kms.v1.CryptoKeyVersion.state] will be set to
- *  [ENABLED][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED].</p></td>
+ *      <td><p> Create a new [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] in a [CryptoKey][google.cloud.kms.v1.CryptoKey].
+ * <p>  The server will assign the next sequential id. If unset, [state][google.cloud.kms.v1.CryptoKeyVersion.state] will be set to [ENABLED][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED].</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -338,12 +321,8 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ImportCryptoKeyVersion</td>
- *      <td><p>Imports a new [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] into
- *  an existing [CryptoKey][google.cloud.kms.v1.CryptoKey] using the wrapped
- *  key material provided in the request.
- *
- *  The version ID will be assigned the next sequential id within the
- *  [CryptoKey][google.cloud.kms.v1.CryptoKey].</p></td>
+ *      <td><p> Imports a new [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] into an existing [CryptoKey][google.cloud.kms.v1.CryptoKey] using the wrapped key material provided in the request.
+ * <p>  The version ID will be assigned the next sequential id within the [CryptoKey][google.cloud.kms.v1.CryptoKey].</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -357,11 +336,8 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>CreateImportJob</td>
- *      <td><p>Create a new [ImportJob][google.cloud.kms.v1.ImportJob] within a
- *  [KeyRing][google.cloud.kms.v1.KeyRing].
- *
- *  [ImportJob.import_method][google.cloud.kms.v1.ImportJob.import_method] is
- *  required.</p></td>
+ *      <td><p> Create a new [ImportJob][google.cloud.kms.v1.ImportJob] within a [KeyRing][google.cloud.kms.v1.KeyRing].
+ * <p>  [ImportJob.import_method][google.cloud.kms.v1.ImportJob.import_method] is required.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -380,7 +356,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>UpdateCryptoKey</td>
- *      <td><p>Update a [CryptoKey][google.cloud.kms.v1.CryptoKey].</p></td>
+ *      <td><p> Update a [CryptoKey][google.cloud.kms.v1.CryptoKey].</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -398,18 +374,8 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>UpdateCryptoKeyVersion</td>
- *      <td><p>Update a [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion]'s
- *  metadata.
- *
- *  [state][google.cloud.kms.v1.CryptoKeyVersion.state] may be changed between
- *  [ENABLED][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED]
- *  and
- *  [DISABLED][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DISABLED]
- *  using this method. See
- *  [DestroyCryptoKeyVersion][google.cloud.kms.v1.KeyManagementService.DestroyCryptoKeyVersion]
- *  and
- *  [RestoreCryptoKeyVersion][google.cloud.kms.v1.KeyManagementService.RestoreCryptoKeyVersion]
- *  to move between other states.</p></td>
+ *      <td><p> Update a [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion]'s metadata.
+ * <p>  [state][google.cloud.kms.v1.CryptoKeyVersion.state] may be changed between [ENABLED][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED] and [DISABLED][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DISABLED] using this method. See [DestroyCryptoKeyVersion][google.cloud.kms.v1.KeyManagementService.DestroyCryptoKeyVersion] and [RestoreCryptoKeyVersion][google.cloud.kms.v1.KeyManagementService.RestoreCryptoKeyVersion] to move between other states.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -427,10 +393,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>Encrypt</td>
- *      <td><p>Encrypts data, so that it can only be recovered by a call to
- *  [Decrypt][google.cloud.kms.v1.KeyManagementService.Decrypt]. The
- *  [CryptoKey.purpose][google.cloud.kms.v1.CryptoKey.purpose] must be
- *  [ENCRYPT_DECRYPT][google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT].</p></td>
+ *      <td><p> Encrypts data, so that it can only be recovered by a call to [Decrypt][google.cloud.kms.v1.KeyManagementService.Decrypt]. The [CryptoKey.purpose][google.cloud.kms.v1.CryptoKey.purpose] must be [ENCRYPT_DECRYPT][google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT].</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -449,10 +412,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>Decrypt</td>
- *      <td><p>Decrypts data that was protected by
- *  [Encrypt][google.cloud.kms.v1.KeyManagementService.Encrypt]. The
- *  [CryptoKey.purpose][google.cloud.kms.v1.CryptoKey.purpose] must be
- *  [ENCRYPT_DECRYPT][google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT].</p></td>
+ *      <td><p> Decrypts data that was protected by [Encrypt][google.cloud.kms.v1.KeyManagementService.Encrypt]. The [CryptoKey.purpose][google.cloud.kms.v1.CryptoKey.purpose] must be [ENCRYPT_DECRYPT][google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT].</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -471,11 +431,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>AsymmetricSign</td>
- *      <td><p>Signs data using a [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion]
- *  with [CryptoKey.purpose][google.cloud.kms.v1.CryptoKey.purpose]
- *  ASYMMETRIC_SIGN, producing a signature that can be verified with the public
- *  key retrieved from
- *  [GetPublicKey][google.cloud.kms.v1.KeyManagementService.GetPublicKey].</p></td>
+ *      <td><p> Signs data using a [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] with [CryptoKey.purpose][google.cloud.kms.v1.CryptoKey.purpose] ASYMMETRIC_SIGN, producing a signature that can be verified with the public key retrieved from [GetPublicKey][google.cloud.kms.v1.KeyManagementService.GetPublicKey].</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -494,11 +450,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>AsymmetricDecrypt</td>
- *      <td><p>Decrypts data that was encrypted with a public key retrieved from
- *  [GetPublicKey][google.cloud.kms.v1.KeyManagementService.GetPublicKey]
- *  corresponding to a [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion]
- *  with [CryptoKey.purpose][google.cloud.kms.v1.CryptoKey.purpose]
- *  ASYMMETRIC_DECRYPT.</p></td>
+ *      <td><p> Decrypts data that was encrypted with a public key retrieved from [GetPublicKey][google.cloud.kms.v1.KeyManagementService.GetPublicKey] corresponding to a [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] with [CryptoKey.purpose][google.cloud.kms.v1.CryptoKey.purpose] ASYMMETRIC_DECRYPT.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -517,11 +469,8 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>UpdateCryptoKeyPrimaryVersion</td>
- *      <td><p>Update the version of a [CryptoKey][google.cloud.kms.v1.CryptoKey] that
- *  will be used in
- *  [Encrypt][google.cloud.kms.v1.KeyManagementService.Encrypt].
- *
- *  Returns an error if called on an asymmetric key.</p></td>
+ *      <td><p> Update the version of a [CryptoKey][google.cloud.kms.v1.CryptoKey] that will be used in [Encrypt][google.cloud.kms.v1.KeyManagementService.Encrypt].
+ * <p>  Returns an error if called on an asymmetric key.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -540,24 +489,9 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>DestroyCryptoKeyVersion</td>
- *      <td><p>Schedule a [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] for
- *  destruction.
- *
- *  Upon calling this method,
- *  [CryptoKeyVersion.state][google.cloud.kms.v1.CryptoKeyVersion.state] will
- *  be set to
- *  [DESTROY_SCHEDULED][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROY_SCHEDULED]
- *  and [destroy_time][google.cloud.kms.v1.CryptoKeyVersion.destroy_time] will
- *  be set to a time 24 hours in the future, at which point the
- *  [state][google.cloud.kms.v1.CryptoKeyVersion.state] will be changed to
- *  [DESTROYED][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROYED],
- *  and the key material will be irrevocably destroyed.
- *
- *  Before the
- *  [destroy_time][google.cloud.kms.v1.CryptoKeyVersion.destroy_time] is
- *  reached,
- *  [RestoreCryptoKeyVersion][google.cloud.kms.v1.KeyManagementService.RestoreCryptoKeyVersion]
- *  may be called to reverse the process.</p></td>
+ *      <td><p> Schedule a [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] for destruction.
+ * <p>  Upon calling this method, [CryptoKeyVersion.state][google.cloud.kms.v1.CryptoKeyVersion.state] will be set to [DESTROY_SCHEDULED][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROY_SCHEDULED] and [destroy_time][google.cloud.kms.v1.CryptoKeyVersion.destroy_time] will be set to a time 24 hours in the future, at which point the [state][google.cloud.kms.v1.CryptoKeyVersion.state] will be changed to [DESTROYED][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROYED], and the key material will be irrevocably destroyed.
+ * <p>  Before the [destroy_time][google.cloud.kms.v1.CryptoKeyVersion.destroy_time] is reached, [RestoreCryptoKeyVersion][google.cloud.kms.v1.KeyManagementService.RestoreCryptoKeyVersion] may be called to reverse the process.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -576,15 +510,8 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>RestoreCryptoKeyVersion</td>
- *      <td><p>Restore a [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] in the
- *  [DESTROY_SCHEDULED][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROY_SCHEDULED]
- *  state.
- *
- *  Upon restoration of the CryptoKeyVersion,
- *  [state][google.cloud.kms.v1.CryptoKeyVersion.state] will be set to
- *  [DISABLED][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DISABLED],
- *  and [destroy_time][google.cloud.kms.v1.CryptoKeyVersion.destroy_time] will
- *  be cleared.</p></td>
+ *      <td><p> Restore a [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] in the [DESTROY_SCHEDULED][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROY_SCHEDULED] state.
+ * <p>  Upon restoration of the CryptoKeyVersion, [state][google.cloud.kms.v1.CryptoKeyVersion.state] will be set to [DISABLED][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DISABLED], and [destroy_time][google.cloud.kms.v1.CryptoKeyVersion.destroy_time] will be cleared.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -603,9 +530,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetIamPolicy</td>
- *      <td><p>Gets the access control policy for a resource. ADDED ONLY FOR MIXIN TESTS.
- *  Returns an empty policy if the resource exists and does not have a policy
- *  set.</p></td>
+ *      <td><p> Gets the access control policy for a resource. ADDED ONLY FOR MIXIN TESTS. Returns an empty policy if the resource exists and does not have a policy set.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -619,7 +544,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListLocations</td>
- *      <td><p>Lists information about the supported locations for this service.</p></td>
+ *      <td><p> Lists information about the supported locations for this service.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -634,7 +559,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetLocation</td>
- *      <td><p>Gets information about a location.</p></td>
+ *      <td><p> Gets information about a location.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -648,7 +573,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>TestIamPermissions</td>
- *      <td><p>This is a different comment for TestIamPermissions in the yaml file that should clobber the documentation in iam_policy.proto.</p></td>
+ *      <td><p> This is a different comment for TestIamPermissions in the yaml file that should clobber the documentation in iam_policy.proto.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>

--- a/test/integration/goldens/library/src/com/google/cloud/example/library/v1/LibraryServiceClient.java
+++ b/test/integration/goldens/library/src/com/google/cloud/example/library/v1/LibraryServiceClient.java
@@ -87,7 +87,7 @@ import javax.annotation.Generated;
  *      <th>Method Variants</th>
  *    <tr>
  *      <td>CreateShelf</td>
- *      <td><p>Creates a shelf, and returns the new Shelf.</p></td>
+ *      <td><p> Creates a shelf, and returns the new Shelf.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -105,7 +105,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetShelf</td>
- *      <td><p>Gets a shelf. Returns NOT_FOUND if the shelf does not exist.</p></td>
+ *      <td><p> Gets a shelf. Returns NOT_FOUND if the shelf does not exist.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -124,8 +124,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListShelves</td>
- *      <td><p>Lists shelves. The order is unspecified but deterministic. Newly created
- *  shelves will not necessarily be added to the end of this list.</p></td>
+ *      <td><p> Lists shelves. The order is unspecified but deterministic. Newly created shelves will not necessarily be added to the end of this list.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -140,7 +139,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>DeleteShelf</td>
- *      <td><p>Deletes a shelf. Returns NOT_FOUND if the shelf does not exist.</p></td>
+ *      <td><p> Deletes a shelf. Returns NOT_FOUND if the shelf does not exist.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -159,13 +158,8 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>MergeShelves</td>
- *      <td><p>Merges two shelves by adding all books from the shelf named
- *  `other_shelf_name` to shelf `name`, and deletes
- *  `other_shelf_name`. Returns the updated shelf.
- *  The book ids of the moved books may not be the same as the original books.
- *
- *  Returns NOT_FOUND if either shelf does not exist.
- *  This call is a no-op if the specified shelves are the same.</p></td>
+ *      <td><p> Merges two shelves by adding all books from the shelf named `other_shelf_name` to shelf `name`, and deletes `other_shelf_name`. Returns the updated shelf. The book ids of the moved books may not be the same as the original books.
+ * <p>  Returns NOT_FOUND if either shelf does not exist. This call is a no-op if the specified shelves are the same.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -186,7 +180,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>CreateBook</td>
- *      <td><p>Creates a book, and returns the new Book.</p></td>
+ *      <td><p> Creates a book, and returns the new Book.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -205,7 +199,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetBook</td>
- *      <td><p>Gets a book. Returns NOT_FOUND if the book does not exist.</p></td>
+ *      <td><p> Gets a book. Returns NOT_FOUND if the book does not exist.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -224,9 +218,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListBooks</td>
- *      <td><p>Lists books in a shelf. The order is unspecified but deterministic. Newly
- *  created books will not necessarily be added to the end of this list.
- *  Returns NOT_FOUND if the shelf does not exist.</p></td>
+ *      <td><p> Lists books in a shelf. The order is unspecified but deterministic. Newly created books will not necessarily be added to the end of this list. Returns NOT_FOUND if the shelf does not exist.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -246,7 +238,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>DeleteBook</td>
- *      <td><p>Deletes a book. Returns NOT_FOUND if the book does not exist.</p></td>
+ *      <td><p> Deletes a book. Returns NOT_FOUND if the book does not exist.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -265,8 +257,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>UpdateBook</td>
- *      <td><p>Updates a book. Returns INVALID_ARGUMENT if the name of the book
- *  is non-empty and does not equal the existing name.</p></td>
+ *      <td><p> Updates a book. Returns INVALID_ARGUMENT if the name of the book is non-empty and does not equal the existing name.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -284,8 +275,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>MoveBook</td>
- *      <td><p>Moves a book to another shelf, and returns the new book. The book
- *  id of the new book may not be the same as the original book.</p></td>
+ *      <td><p> Moves a book to another shelf, and returns the new book. The book id of the new book may not be the same as the original book.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/ConfigClient.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/ConfigClient.java
@@ -121,7 +121,7 @@ import javax.annotation.Generated;
  *      <th>Method Variants</th>
  *    <tr>
  *      <td>ListBuckets</td>
- *      <td><p>Lists log buckets.</p></td>
+ *      <td><p> Lists log buckets.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -144,7 +144,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetBucket</td>
- *      <td><p>Gets a log bucket.</p></td>
+ *      <td><p> Gets a log bucket.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -158,8 +158,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>CreateBucket</td>
- *      <td><p>Creates a log bucket that can be used to store log entries. After a bucket
- *  has been created, the bucket's location cannot be changed.</p></td>
+ *      <td><p> Creates a log bucket that can be used to store log entries. After a bucket has been created, the bucket's location cannot be changed.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -173,16 +172,10 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>UpdateBucket</td>
- *      <td><p>Updates a log bucket. This method replaces the following fields in the
- *  existing bucket with values from the new bucket: `retention_period`
- *
- *  If the retention period is decreased and the bucket is locked,
- *  `FAILED_PRECONDITION` will be returned.
- *
- *  If the bucket has a `lifecycle_state` of `DELETE_REQUESTED`, then
- *  `FAILED_PRECONDITION` will be returned.
- *
- *  After a bucket has been created, the bucket's location cannot be changed.</p></td>
+ *      <td><p> Updates a log bucket. This method replaces the following fields in the existing bucket with values from the new bucket: `retention_period`
+ * <p>  If the retention period is decreased and the bucket is locked, `FAILED_PRECONDITION` will be returned.
+ * <p>  If the bucket has a `lifecycle_state` of `DELETE_REQUESTED`, then `FAILED_PRECONDITION` will be returned.
+ * <p>  After a bucket has been created, the bucket's location cannot be changed.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -196,11 +189,8 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>DeleteBucket</td>
- *      <td><p>Deletes a log bucket.
- *
- *  Changes the bucket's `lifecycle_state` to the `DELETE_REQUESTED` state.
- *  After 7 days, the bucket will be purged and all log entries in the bucket
- *  will be permanently deleted.</p></td>
+ *      <td><p> Deletes a log bucket.
+ * <p>  Changes the bucket's `lifecycle_state` to the `DELETE_REQUESTED` state. After 7 days, the bucket will be purged and all log entries in the bucket will be permanently deleted.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -214,8 +204,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>UndeleteBucket</td>
- *      <td><p>Undeletes a log bucket. A bucket that has been deleted can be undeleted
- *  within the grace period of 7 days.</p></td>
+ *      <td><p> Undeletes a log bucket. A bucket that has been deleted can be undeleted within the grace period of 7 days.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -229,7 +218,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListViews</td>
- *      <td><p>Lists views on a log bucket.</p></td>
+ *      <td><p> Lists views on a log bucket.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -248,7 +237,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetView</td>
- *      <td><p>Gets a view on a log bucket..</p></td>
+ *      <td><p> Gets a view on a log bucket..</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -262,8 +251,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>CreateView</td>
- *      <td><p>Creates a view over log entries in a log bucket. A bucket may contain a
- *  maximum of 30 views.</p></td>
+ *      <td><p> Creates a view over log entries in a log bucket. A bucket may contain a maximum of 30 views.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -277,11 +265,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>UpdateView</td>
- *      <td><p>Updates a view on a log bucket. This method replaces the following fields
- *  in the existing view with values from the new view: `filter`.
- *  If an `UNAVAILABLE` error is returned, this indicates that system is not in
- *  a state where it can update the view. If this occurs, please try again in a
- *  few minutes.</p></td>
+ *      <td><p> Updates a view on a log bucket. This method replaces the following fields in the existing view with values from the new view: `filter`. If an `UNAVAILABLE` error is returned, this indicates that system is not in a state where it can update the view. If this occurs, please try again in a few minutes.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -295,10 +279,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>DeleteView</td>
- *      <td><p>Deletes a view on a log bucket.
- *  If an `UNAVAILABLE` error is returned, this indicates that system is not in
- *  a state where it can delete the view. If this occurs, please try again in a
- *  few minutes.</p></td>
+ *      <td><p> Deletes a view on a log bucket. If an `UNAVAILABLE` error is returned, this indicates that system is not in a state where it can delete the view. If this occurs, please try again in a few minutes.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -312,7 +293,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListSinks</td>
- *      <td><p>Lists sinks.</p></td>
+ *      <td><p> Lists sinks.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -335,7 +316,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetSink</td>
- *      <td><p>Gets a sink.</p></td>
+ *      <td><p> Gets a sink.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -354,10 +335,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>CreateSink</td>
- *      <td><p>Creates a sink that exports specified log entries to a destination. The
- *  export of newly-ingested log entries begins immediately, unless the sink's
- *  `writer_identity` is not permitted to write to the destination. A sink can
- *  export log entries only from the resource owning the sink.</p></td>
+ *      <td><p> Creates a sink that exports specified log entries to a destination. The export of newly-ingested log entries begins immediately, unless the sink's `writer_identity` is not permitted to write to the destination. A sink can export log entries only from the resource owning the sink.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -379,11 +357,8 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>UpdateSink</td>
- *      <td><p>Updates a sink. This method replaces the following fields in the existing
- *  sink with values from the new sink: `destination`, and `filter`.
- *
- *  The updated sink might also have a new `writer_identity`; see the
- *  `unique_writer_identity` field.</p></td>
+ *      <td><p> Updates a sink. This method replaces the following fields in the existing sink with values from the new sink: `destination`, and `filter`.
+ * <p>  The updated sink might also have a new `writer_identity`; see the `unique_writer_identity` field.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -404,8 +379,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>DeleteSink</td>
- *      <td><p>Deletes a sink. If the sink has a unique `writer_identity`, then that
- *  service account is also deleted.</p></td>
+ *      <td><p> Deletes a sink. If the sink has a unique `writer_identity`, then that service account is also deleted.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -424,7 +398,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListExclusions</td>
- *      <td><p>Lists all the exclusions on the _Default sink in a parent resource.</p></td>
+ *      <td><p> Lists all the exclusions on the _Default sink in a parent resource.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -447,7 +421,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetExclusion</td>
- *      <td><p>Gets the description of an exclusion in the _Default sink.</p></td>
+ *      <td><p> Gets the description of an exclusion in the _Default sink.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -466,9 +440,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>CreateExclusion</td>
- *      <td><p>Creates a new exclusion in the _Default sink in a specified parent
- *  resource. Only log entries belonging to that resource can be excluded. You
- *  can have up to 10 exclusions in a resource.</p></td>
+ *      <td><p> Creates a new exclusion in the _Default sink in a specified parent resource. Only log entries belonging to that resource can be excluded. You can have up to 10 exclusions in a resource.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -490,8 +462,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>UpdateExclusion</td>
- *      <td><p>Changes one or more properties of an existing exclusion in the _Default
- *  sink.</p></td>
+ *      <td><p> Changes one or more properties of an existing exclusion in the _Default sink.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -510,7 +481,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>DeleteExclusion</td>
- *      <td><p>Deletes an exclusion in the _Default sink.</p></td>
+ *      <td><p> Deletes an exclusion in the _Default sink.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -529,16 +500,9 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetCmekSettings</td>
- *      <td><p>Gets the Logging CMEK settings for the given resource.
- *
- *  Note: CMEK for the Log Router can be configured for Google Cloud projects,
- *  folders, organizations and billing accounts. Once configured for an
- *  organization, it applies to all projects and folders in the Google Cloud
- *  organization.
- *
- *  See [Enabling CMEK for Log
- *  Router](https://cloud.google.com/logging/docs/routing/managed-encryption)
- *  for more information.</p></td>
+ *      <td><p> Gets the Logging CMEK settings for the given resource.
+ * <p>  Note: CMEK for the Log Router can be configured for Google Cloud projects, folders, organizations and billing accounts. Once configured for an organization, it applies to all projects and folders in the Google Cloud organization.
+ * <p>  See [Enabling CMEK for Log Router](https://cloud.google.com/logging/docs/routing/managed-encryption) for more information.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -552,21 +516,10 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>UpdateCmekSettings</td>
- *      <td><p>Updates the Log Router CMEK settings for the given resource.
- *
- *  Note: CMEK for the Log Router can currently only be configured for Google
- *  Cloud organizations. Once configured, it applies to all projects and
- *  folders in the Google Cloud organization.
- *
- *  [UpdateCmekSettings][google.logging.v2.ConfigServiceV2.UpdateCmekSettings]
- *  will fail if 1) `kms_key_name` is invalid, or 2) the associated service
- *  account does not have the required
- *  `roles/cloudkms.cryptoKeyEncrypterDecrypter` role assigned for the key, or
- *  3) access to the key is disabled.
- *
- *  See [Enabling CMEK for Log
- *  Router](https://cloud.google.com/logging/docs/routing/managed-encryption)
- *  for more information.</p></td>
+ *      <td><p> Updates the Log Router CMEK settings for the given resource.
+ * <p>  Note: CMEK for the Log Router can currently only be configured for Google Cloud organizations. Once configured, it applies to all projects and folders in the Google Cloud organization.
+ * <p>  [UpdateCmekSettings][google.logging.v2.ConfigServiceV2.UpdateCmekSettings] will fail if 1) `kms_key_name` is invalid, or 2) the associated service account does not have the required `roles/cloudkms.cryptoKeyEncrypterDecrypter` role assigned for the key, or 3) access to the key is disabled.
+ * <p>  See [Enabling CMEK for Log Router](https://cloud.google.com/logging/docs/routing/managed-encryption) for more information.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -580,16 +533,9 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetSettings</td>
- *      <td><p>Gets the Log Router settings for the given resource.
- *
- *  Note: Settings for the Log Router can be get for Google Cloud projects,
- *  folders, organizations and billing accounts. Currently it can only be
- *  configured for organizations. Once configured for an organization, it
- *  applies to all projects and folders in the Google Cloud organization.
- *
- *  See [Enabling CMEK for Log
- *  Router](https://cloud.google.com/logging/docs/routing/managed-encryption)
- *  for more information.</p></td>
+ *      <td><p> Gets the Log Router settings for the given resource.
+ * <p>  Note: Settings for the Log Router can be get for Google Cloud projects, folders, organizations and billing accounts. Currently it can only be configured for organizations. Once configured for an organization, it applies to all projects and folders in the Google Cloud organization.
+ * <p>  See [Enabling CMEK for Log Router](https://cloud.google.com/logging/docs/routing/managed-encryption) for more information.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -608,22 +554,10 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>UpdateSettings</td>
- *      <td><p>Updates the Log Router settings for the given resource.
- *
- *  Note: Settings for the Log Router can currently only be configured for
- *  Google Cloud organizations. Once configured, it applies to all projects and
- *  folders in the Google Cloud organization.
- *
- *  [UpdateSettings][google.logging.v2.ConfigServiceV2.UpdateSettings]
- *  will fail if 1) `kms_key_name` is invalid, or 2) the associated service
- *  account does not have the required
- *  `roles/cloudkms.cryptoKeyEncrypterDecrypter` role assigned for the key, or
- *  3) access to the key is disabled. 4) `location_id` is not supported by
- *  Logging. 5) `location_id` violate OrgPolicy.
- *
- *  See [Enabling CMEK for Log
- *  Router](https://cloud.google.com/logging/docs/routing/managed-encryption)
- *  for more information.</p></td>
+ *      <td><p> Updates the Log Router settings for the given resource.
+ * <p>  Note: Settings for the Log Router can currently only be configured for Google Cloud organizations. Once configured, it applies to all projects and folders in the Google Cloud organization.
+ * <p>  [UpdateSettings][google.logging.v2.ConfigServiceV2.UpdateSettings] will fail if 1) `kms_key_name` is invalid, or 2) the associated service account does not have the required `roles/cloudkms.cryptoKeyEncrypterDecrypter` role assigned for the key, or 3) access to the key is disabled. 4) `location_id` is not supported by Logging. 5) `location_id` violate OrgPolicy.
+ * <p>  See [Enabling CMEK for Log Router](https://cloud.google.com/logging/docs/routing/managed-encryption) for more information.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -641,7 +575,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>CopyLogEntries</td>
- *      <td><p>Copies a set of log entries from a log bucket to a Cloud Storage bucket.</p></td>
+ *      <td><p> Copies a set of log entries from a log bucket to a Cloud Storage bucket.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/LoggingClient.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/LoggingClient.java
@@ -83,10 +83,7 @@ import javax.annotation.Generated;
  *      <th>Method Variants</th>
  *    <tr>
  *      <td>DeleteLog</td>
- *      <td><p>Deletes all the log entries in a log for the _Default Log Bucket. The log
- *  reappears if it receives new entries. Log entries written shortly before
- *  the delete operation might not be deleted. Entries received after the
- *  delete operation with a timestamp before the operation will be deleted.</p></td>
+ *      <td><p> Deletes all the log entries in a log for the _Default Log Bucket. The log reappears if it receives new entries. Log entries written shortly before the delete operation might not be deleted. Entries received after the delete operation with a timestamp before the operation will be deleted.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -105,13 +102,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>WriteLogEntries</td>
- *      <td><p>Writes log entries to Logging. This API method is the
- *  only way to send log entries to Logging. This method
- *  is used, directly or indirectly, by the Logging agent
- *  (fluentd) and all logging libraries configured to use Logging.
- *  A single request may contain log entries for a maximum of 1000
- *  different resources (projects, organizations, billing accounts or
- *  folders)</p></td>
+ *      <td><p> Writes log entries to Logging. This API method is the only way to send log entries to Logging. This method is used, directly or indirectly, by the Logging agent (fluentd) and all logging libraries configured to use Logging. A single request may contain log entries for a maximum of 1000 different resources (projects, organizations, billing accounts or folders)</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -130,10 +121,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListLogEntries</td>
- *      <td><p>Lists log entries.  Use this method to retrieve log entries that originated
- *  from a project/folder/organization/billing account.  For ways to export log
- *  entries, see [Exporting
- *  Logs](https://cloud.google.com/logging/docs/export).</p></td>
+ *      <td><p> Lists log entries.  Use this method to retrieve log entries that originated from a project/folder/organization/billing account.  For ways to export log entries, see [Exporting Logs](https://cloud.google.com/logging/docs/export).</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -152,7 +140,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListMonitoredResourceDescriptors</td>
- *      <td><p>Lists the descriptors for monitored resource types used by Logging.</p></td>
+ *      <td><p> Lists the descriptors for monitored resource types used by Logging.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -167,8 +155,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListLogs</td>
- *      <td><p>Lists the logs in projects, organizations, folders, or billing accounts.
- *  Only logs that have entries are listed.</p></td>
+ *      <td><p> Lists the logs in projects, organizations, folders, or billing accounts. Only logs that have entries are listed.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -191,8 +178,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>TailLogEntries</td>
- *      <td><p>Streaming read of log entries as they are ingested. Until the stream is
- *  terminated, it will continue reading logs.</p></td>
+ *      <td><p> Streaming read of log entries as they are ingested. Until the stream is terminated, it will continue reading logs.</td>
  *      <td>
  *      <p>Callable method variants take no parameters and return an immutable API callable object, which can be used to initiate calls to the service.</p>
  *      <ul>

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MetricsClient.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MetricsClient.java
@@ -71,7 +71,7 @@ import javax.annotation.Generated;
  *      <th>Method Variants</th>
  *    <tr>
  *      <td>ListLogMetrics</td>
- *      <td><p>Lists logs-based metrics.</p></td>
+ *      <td><p> Lists logs-based metrics.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -91,7 +91,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetLogMetric</td>
- *      <td><p>Gets a logs-based metric.</p></td>
+ *      <td><p> Gets a logs-based metric.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -110,7 +110,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>CreateLogMetric</td>
- *      <td><p>Creates a logs-based metric.</p></td>
+ *      <td><p> Creates a logs-based metric.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -129,7 +129,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>UpdateLogMetric</td>
- *      <td><p>Creates or updates a logs-based metric.</p></td>
+ *      <td><p> Creates or updates a logs-based metric.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -148,7 +148,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>DeleteLogMetric</td>
- *      <td><p>Deletes a logs-based metric.</p></td>
+ *      <td><p> Deletes a logs-based metric.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SchemaServiceClient.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SchemaServiceClient.java
@@ -86,7 +86,7 @@ import javax.annotation.Generated;
  *      <th>Method Variants</th>
  *    <tr>
  *      <td>CreateSchema</td>
- *      <td><p>Creates a schema.</p></td>
+ *      <td><p> Creates a schema.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -105,7 +105,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetSchema</td>
- *      <td><p>Gets a schema.</p></td>
+ *      <td><p> Gets a schema.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -124,7 +124,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListSchemas</td>
- *      <td><p>Lists schemas in a project.</p></td>
+ *      <td><p> Lists schemas in a project.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -144,7 +144,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListSchemaRevisions</td>
- *      <td><p>Lists all schema revisions for the named schema.</p></td>
+ *      <td><p> Lists all schema revisions for the named schema.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -164,7 +164,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>CommitSchema</td>
- *      <td><p>Commits a new schema revision to an existing schema.</p></td>
+ *      <td><p> Commits a new schema revision to an existing schema.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -183,7 +183,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>RollbackSchema</td>
- *      <td><p>Creates a new schema revision that is a copy of the provided revision_id.</p></td>
+ *      <td><p> Creates a new schema revision that is a copy of the provided revision_id.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -202,7 +202,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>DeleteSchemaRevision</td>
- *      <td><p>Deletes a specific schema revision.</p></td>
+ *      <td><p> Deletes a specific schema revision.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -221,7 +221,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>DeleteSchema</td>
- *      <td><p>Deletes a schema.</p></td>
+ *      <td><p> Deletes a schema.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -240,7 +240,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ValidateSchema</td>
- *      <td><p>Validates a schema.</p></td>
+ *      <td><p> Validates a schema.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -259,7 +259,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ValidateMessage</td>
- *      <td><p>Validates a message against a schema.</p></td>
+ *      <td><p> Validates a message against a schema.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -273,11 +273,8 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>SetIamPolicy</td>
- *      <td><p>Sets the access control policy on the specified resource. Replaces
- * any existing policy.
- *
- * Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
- * errors.</p></td>
+ *      <td><p> Sets the access control policy on the specified resource. Replacesany existing policy.
+ * <p> Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`errors.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -291,8 +288,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetIamPolicy</td>
- *      <td><p>Gets the access control policy for a resource. Returns an empty policy
- * if the resource exists and does not have a policy set.</p></td>
+ *      <td><p> Gets the access control policy for a resource. Returns an empty policyif the resource exists and does not have a policy set.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -306,13 +302,8 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>TestIamPermissions</td>
- *      <td><p>Returns permissions that a caller has on the specified resource. If the
- * resource does not exist, this will return an empty set of
- * permissions, not a `NOT_FOUND` error.
- *
- * Note: This operation is designed to be used for building
- * permission-aware UIs and command-line tools, not for authorization
- * checking. This operation may "fail open" without warning.</p></td>
+ *      <td><p> Returns permissions that a caller has on the specified resource. If theresource does not exist, this will return an empty set ofpermissions, not a `NOT_FOUND` error.
+ * <p> Note: This operation is designed to be used for buildingpermission-aware UIs and command-line tools, not for authorizationchecking. This operation may "fail open" without warning.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SubscriptionAdminClient.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SubscriptionAdminClient.java
@@ -102,17 +102,8 @@ import javax.annotation.Generated;
  *      <th>Method Variants</th>
  *    <tr>
  *      <td>CreateSubscription</td>
- *      <td><p>Creates a subscription to a given topic. See the [resource name rules]
- *  (https://cloud.google.com/pubsub/docs/admin#resource_names).
- *  If the subscription already exists, returns `ALREADY_EXISTS`.
- *  If the corresponding topic doesn't exist, returns `NOT_FOUND`.
- *
- *  If the name is not provided in the request, the server will assign a random
- *  name for this subscription on the same project as the topic, conforming
- *  to the [resource name format]
- *  (https://cloud.google.com/pubsub/docs/admin#resource_names). The generated
- *  name is populated in the returned Subscription object. Note that for REST
- *  API requests, you must specify a name in the request.</p></td>
+ *      <td><p> Creates a subscription to a given topic. See the [resource name rules] (https://cloud.google.com/pubsub/docs/admin#resource_names). If the subscription already exists, returns `ALREADY_EXISTS`. If the corresponding topic doesn't exist, returns `NOT_FOUND`.
+ * <p>  If the name is not provided in the request, the server will assign a random name for this subscription on the same project as the topic, conforming to the [resource name format] (https://cloud.google.com/pubsub/docs/admin#resource_names). The generated name is populated in the returned Subscription object. Note that for REST API requests, you must specify a name in the request.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -133,7 +124,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetSubscription</td>
- *      <td><p>Gets the configuration details of a subscription.</p></td>
+ *      <td><p> Gets the configuration details of a subscription.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -152,8 +143,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>UpdateSubscription</td>
- *      <td><p>Updates an existing subscription. Note that certain properties of a
- *  subscription, such as its topic, are not modifiable.</p></td>
+ *      <td><p> Updates an existing subscription. Note that certain properties of a subscription, such as its topic, are not modifiable.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -167,7 +157,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListSubscriptions</td>
- *      <td><p>Lists matching subscriptions.</p></td>
+ *      <td><p> Lists matching subscriptions.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -187,11 +177,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>DeleteSubscription</td>
- *      <td><p>Deletes an existing subscription. All messages retained in the subscription
- *  are immediately dropped. Calls to `Pull` after deletion will return
- *  `NOT_FOUND`. After a subscription is deleted, a new one may be created with
- *  the same name, but the new one has no association with the old
- *  subscription or its topic unless the same topic is specified.</p></td>
+ *      <td><p> Deletes an existing subscription. All messages retained in the subscription are immediately dropped. Calls to `Pull` after deletion will return `NOT_FOUND`. After a subscription is deleted, a new one may be created with the same name, but the new one has no association with the old subscription or its topic unless the same topic is specified.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -210,11 +196,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ModifyAckDeadline</td>
- *      <td><p>Modifies the ack deadline for a specific message. This method is useful
- *  to indicate that more time is needed to process a message by the
- *  subscriber, or to make the message available for redelivery if the
- *  processing was interrupted. Note that this does not modify the
- *  subscription-level `ackDeadlineSeconds` used for subsequent messages.</p></td>
+ *      <td><p> Modifies the ack deadline for a specific message. This method is useful to indicate that more time is needed to process a message by the subscriber, or to make the message available for redelivery if the processing was interrupted. Note that this does not modify the subscription-level `ackDeadlineSeconds` used for subsequent messages.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -233,13 +215,8 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>Acknowledge</td>
- *      <td><p>Acknowledges the messages associated with the `ack_ids` in the
- *  `AcknowledgeRequest`. The Pub/Sub system can remove the relevant messages
- *  from the subscription.
- *
- *  Acknowledging a message whose ack deadline has expired may succeed,
- *  but such a message may be redelivered later. Acknowledging a message more
- *  than once will not result in an error.</p></td>
+ *      <td><p> Acknowledges the messages associated with the `ack_ids` in the `AcknowledgeRequest`. The Pub/Sub system can remove the relevant messages from the subscription.
+ * <p>  Acknowledging a message whose ack deadline has expired may succeed, but such a message may be redelivered later. Acknowledging a message more than once will not result in an error.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -258,9 +235,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>Pull</td>
- *      <td><p>Pulls messages from the server. The server may return `UNAVAILABLE` if
- *  there are too many concurrent pull requests pending for the given
- *  subscription.</p></td>
+ *      <td><p> Pulls messages from the server. The server may return `UNAVAILABLE` if there are too many concurrent pull requests pending for the given subscription.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -281,13 +256,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>StreamingPull</td>
- *      <td><p>Establishes a stream with the server, which sends messages down to the
- *  client. The client streams acknowledgements and ack deadline modifications
- *  back to the server. The server will close the stream and return the status
- *  on any error. The server may close the stream with status `UNAVAILABLE` to
- *  reassign server-side resources, in which case, the client should
- *  re-establish the stream. Flow control can be achieved by configuring the
- *  underlying RPC channel.</p></td>
+ *      <td><p> Establishes a stream with the server, which sends messages down to the client. The client streams acknowledgements and ack deadline modifications back to the server. The server will close the stream and return the status on any error. The server may close the stream with status `UNAVAILABLE` to reassign server-side resources, in which case, the client should re-establish the stream. Flow control can be achieved by configuring the underlying RPC channel.</td>
  *      <td>
  *      <p>Callable method variants take no parameters and return an immutable API callable object, which can be used to initiate calls to the service.</p>
  *      <ul>
@@ -297,12 +266,8 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ModifyPushConfig</td>
- *      <td><p>Modifies the `PushConfig` for a specified subscription.
- *
- *  This may be used to change a push subscription to a pull one (signified by
- *  an empty `PushConfig`) or vice versa, or change the endpoint URL and other
- *  attributes of a push subscription. Messages will accumulate for delivery
- *  continuously through the call regardless of changes to the `PushConfig`.</p></td>
+ *      <td><p> Modifies the `PushConfig` for a specified subscription.
+ * <p>  This may be used to change a push subscription to a pull one (signified by an empty `PushConfig`) or vice versa, or change the endpoint URL and other attributes of a push subscription. Messages will accumulate for delivery continuously through the call regardless of changes to the `PushConfig`.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -321,11 +286,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetSnapshot</td>
- *      <td><p>Gets the configuration details of a snapshot. Snapshots are used in
- *  <a href="https://cloud.google.com/pubsub/docs/replay-overview">Seek</a>
- *  operations, which allow you to manage message acknowledgments in bulk. That
- *  is, you can set the acknowledgment state of messages in an existing
- *  subscription to the state captured by a snapshot.</p></td>
+ *      <td><p> Gets the configuration details of a snapshot. Snapshots are used in &lt;a href="https://cloud.google.com/pubsub/docs/replay-overview"&gt;Seek&lt;/a&gt; operations, which allow you to manage message acknowledgments in bulk. That is, you can set the acknowledgment state of messages in an existing subscription to the state captured by a snapshot.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -344,11 +305,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListSnapshots</td>
- *      <td><p>Lists the existing snapshots. Snapshots are used in [Seek](
- *  https://cloud.google.com/pubsub/docs/replay-overview) operations, which
- *  allow you to manage message acknowledgments in bulk. That is, you can set
- *  the acknowledgment state of messages in an existing subscription to the
- *  state captured by a snapshot.</p></td>
+ *      <td><p> Lists the existing snapshots. Snapshots are used in [Seek]( https://cloud.google.com/pubsub/docs/replay-overview) operations, which allow you to manage message acknowledgments in bulk. That is, you can set the acknowledgment state of messages in an existing subscription to the state captured by a snapshot.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -368,22 +325,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>CreateSnapshot</td>
- *      <td><p>Creates a snapshot from the requested subscription. Snapshots are used in
- *  [Seek](https://cloud.google.com/pubsub/docs/replay-overview) operations,
- *  which allow you to manage message acknowledgments in bulk. That is, you can
- *  set the acknowledgment state of messages in an existing subscription to the
- *  state captured by a snapshot.
- *  If the snapshot already exists, returns `ALREADY_EXISTS`.
- *  If the requested subscription doesn't exist, returns `NOT_FOUND`.
- *  If the backlog in the subscription is too old -- and the resulting snapshot
- *  would expire in less than 1 hour -- then `FAILED_PRECONDITION` is returned.
- *  See also the `Snapshot.expire_time` field. If the name is not provided in
- *  the request, the server will assign a random
- *  name for this snapshot on the same project as the subscription, conforming
- *  to the [resource name format]
- *  (https://cloud.google.com/pubsub/docs/admin#resource_names). The
- *  generated name is populated in the returned Snapshot object. Note that for
- *  REST API requests, you must specify a name in the request.</p></td>
+ *      <td><p> Creates a snapshot from the requested subscription. Snapshots are used in [Seek](https://cloud.google.com/pubsub/docs/replay-overview) operations, which allow you to manage message acknowledgments in bulk. That is, you can set the acknowledgment state of messages in an existing subscription to the state captured by a snapshot. If the snapshot already exists, returns `ALREADY_EXISTS`. If the requested subscription doesn't exist, returns `NOT_FOUND`. If the backlog in the subscription is too old -- and the resulting snapshot would expire in less than 1 hour -- then `FAILED_PRECONDITION` is returned. See also the `Snapshot.expire_time` field. If the name is not provided in the request, the server will assign a random name for this snapshot on the same project as the subscription, conforming to the [resource name format] (https://cloud.google.com/pubsub/docs/admin#resource_names). The generated name is populated in the returned Snapshot object. Note that for REST API requests, you must specify a name in the request.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -404,12 +346,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>UpdateSnapshot</td>
- *      <td><p>Updates an existing snapshot. Snapshots are used in
- *  <a href="https://cloud.google.com/pubsub/docs/replay-overview">Seek</a>
- *  operations, which allow
- *  you to manage message acknowledgments in bulk. That is, you can set the
- *  acknowledgment state of messages in an existing subscription to the state
- *  captured by a snapshot.</p></td>
+ *      <td><p> Updates an existing snapshot. Snapshots are used in &lt;a href="https://cloud.google.com/pubsub/docs/replay-overview"&gt;Seek&lt;/a&gt; operations, which allow you to manage message acknowledgments in bulk. That is, you can set the acknowledgment state of messages in an existing subscription to the state captured by a snapshot.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -423,15 +360,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>DeleteSnapshot</td>
- *      <td><p>Removes an existing snapshot. Snapshots are used in [Seek]
- *  (https://cloud.google.com/pubsub/docs/replay-overview) operations, which
- *  allow you to manage message acknowledgments in bulk. That is, you can set
- *  the acknowledgment state of messages in an existing subscription to the
- *  state captured by a snapshot.
- *  When the snapshot is deleted, all messages retained in the snapshot
- *  are immediately dropped. After a snapshot is deleted, a new one may be
- *  created with the same name, but the new one has no association with the old
- *  snapshot or its subscription, unless the same subscription is specified.</p></td>
+ *      <td><p> Removes an existing snapshot. Snapshots are used in [Seek] (https://cloud.google.com/pubsub/docs/replay-overview) operations, which allow you to manage message acknowledgments in bulk. That is, you can set the acknowledgment state of messages in an existing subscription to the state captured by a snapshot. When the snapshot is deleted, all messages retained in the snapshot are immediately dropped. After a snapshot is deleted, a new one may be created with the same name, but the new one has no association with the old snapshot or its subscription, unless the same subscription is specified.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -450,13 +379,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>Seek</td>
- *      <td><p>Seeks an existing subscription to a point in time or to a given snapshot,
- *  whichever is provided in the request. Snapshots are used in [Seek]
- *  (https://cloud.google.com/pubsub/docs/replay-overview) operations, which
- *  allow you to manage message acknowledgments in bulk. That is, you can set
- *  the acknowledgment state of messages in an existing subscription to the
- *  state captured by a snapshot. Note that both the subscription and the
- *  snapshot must be on the same topic.</p></td>
+ *      <td><p> Seeks an existing subscription to a point in time or to a given snapshot, whichever is provided in the request. Snapshots are used in [Seek] (https://cloud.google.com/pubsub/docs/replay-overview) operations, which allow you to manage message acknowledgments in bulk. That is, you can set the acknowledgment state of messages in an existing subscription to the state captured by a snapshot. Note that both the subscription and the snapshot must be on the same topic.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -470,11 +393,8 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>SetIamPolicy</td>
- *      <td><p>Sets the access control policy on the specified resource. Replaces
- * any existing policy.
- *
- * Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
- * errors.</p></td>
+ *      <td><p> Sets the access control policy on the specified resource. Replacesany existing policy.
+ * <p> Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`errors.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -488,8 +408,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetIamPolicy</td>
- *      <td><p>Gets the access control policy for a resource. Returns an empty policy
- * if the resource exists and does not have a policy set.</p></td>
+ *      <td><p> Gets the access control policy for a resource. Returns an empty policyif the resource exists and does not have a policy set.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -503,13 +422,8 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>TestIamPermissions</td>
- *      <td><p>Returns permissions that a caller has on the specified resource. If the
- * resource does not exist, this will return an empty set of
- * permissions, not a `NOT_FOUND` error.
- *
- * Note: This operation is designed to be used for building
- * permission-aware UIs and command-line tools, not for authorization
- * checking. This operation may "fail open" without warning.</p></td>
+ *      <td><p> Returns permissions that a caller has on the specified resource. If theresource does not exist, this will return an empty set ofpermissions, not a `NOT_FOUND` error.
+ * <p> Note: This operation is designed to be used for buildingpermission-aware UIs and command-line tools, not for authorizationchecking. This operation may "fail open" without warning.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/TopicAdminClient.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/TopicAdminClient.java
@@ -85,8 +85,7 @@ import javax.annotation.Generated;
  *      <th>Method Variants</th>
  *    <tr>
  *      <td>CreateTopic</td>
- *      <td><p>Creates the given topic with the given name. See the [resource name rules]
- *  (https://cloud.google.com/pubsub/docs/admin#resource_names).</p></td>
+ *      <td><p> Creates the given topic with the given name. See the [resource name rules] (https://cloud.google.com/pubsub/docs/admin#resource_names).</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -105,8 +104,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>UpdateTopic</td>
- *      <td><p>Updates an existing topic. Note that certain properties of a
- *  topic are not modifiable.</p></td>
+ *      <td><p> Updates an existing topic. Note that certain properties of a topic are not modifiable.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -120,8 +118,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>Publish</td>
- *      <td><p>Adds one or more messages to the topic. Returns `NOT_FOUND` if the topic
- *  does not exist.</p></td>
+ *      <td><p> Adds one or more messages to the topic. Returns `NOT_FOUND` if the topic does not exist.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -140,7 +137,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetTopic</td>
- *      <td><p>Gets the configuration of a topic.</p></td>
+ *      <td><p> Gets the configuration of a topic.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -159,7 +156,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListTopics</td>
- *      <td><p>Lists matching topics.</p></td>
+ *      <td><p> Lists matching topics.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -179,7 +176,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListTopicSubscriptions</td>
- *      <td><p>Lists the names of the attached subscriptions on this topic.</p></td>
+ *      <td><p> Lists the names of the attached subscriptions on this topic.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -199,11 +196,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListTopicSnapshots</td>
- *      <td><p>Lists the names of the snapshots on this topic. Snapshots are used in
- *  [Seek](https://cloud.google.com/pubsub/docs/replay-overview) operations,
- *  which allow you to manage message acknowledgments in bulk. That is, you can
- *  set the acknowledgment state of messages in an existing subscription to the
- *  state captured by a snapshot.</p></td>
+ *      <td><p> Lists the names of the snapshots on this topic. Snapshots are used in [Seek](https://cloud.google.com/pubsub/docs/replay-overview) operations, which allow you to manage message acknowledgments in bulk. That is, you can set the acknowledgment state of messages in an existing subscription to the state captured by a snapshot.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -223,11 +216,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>DeleteTopic</td>
- *      <td><p>Deletes the topic with the given name. Returns `NOT_FOUND` if the topic
- *  does not exist. After a topic is deleted, a new topic may be created with
- *  the same name; this is an entirely new topic with none of the old
- *  configuration or subscriptions. Existing subscriptions to this topic are
- *  not deleted, but their `topic` field is set to `_deleted-topic_`.</p></td>
+ *      <td><p> Deletes the topic with the given name. Returns `NOT_FOUND` if the topic does not exist. After a topic is deleted, a new topic may be created with the same name; this is an entirely new topic with none of the old configuration or subscriptions. Existing subscriptions to this topic are not deleted, but their `topic` field is set to `_deleted-topic_`.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -246,10 +235,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>DetachSubscription</td>
- *      <td><p>Detaches a subscription from this topic. All messages retained in the
- *  subscription are dropped. Subsequent `Pull` and `StreamingPull` requests
- *  will return FAILED_PRECONDITION. If the subscription is a push
- *  subscription, pushes to the endpoint will stop.</p></td>
+ *      <td><p> Detaches a subscription from this topic. All messages retained in the subscription are dropped. Subsequent `Pull` and `StreamingPull` requests will return FAILED_PRECONDITION. If the subscription is a push subscription, pushes to the endpoint will stop.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -263,11 +249,8 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>SetIamPolicy</td>
- *      <td><p>Sets the access control policy on the specified resource. Replaces
- * any existing policy.
- *
- * Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
- * errors.</p></td>
+ *      <td><p> Sets the access control policy on the specified resource. Replacesany existing policy.
+ * <p> Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`errors.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -281,8 +264,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetIamPolicy</td>
- *      <td><p>Gets the access control policy for a resource. Returns an empty policy
- * if the resource exists and does not have a policy set.</p></td>
+ *      <td><p> Gets the access control policy for a resource. Returns an empty policyif the resource exists and does not have a policy set.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -296,13 +278,8 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>TestIamPermissions</td>
- *      <td><p>Returns permissions that a caller has on the specified resource. If the
- * resource does not exist, this will return an empty set of
- * permissions, not a `NOT_FOUND` error.
- *
- * Note: This operation is designed to be used for building
- * permission-aware UIs and command-line tools, not for authorization
- * checking. This operation may "fail open" without warning.</p></td>
+ *      <td><p> Returns permissions that a caller has on the specified resource. If theresource does not exist, this will return an empty set ofpermissions, not a `NOT_FOUND` error.
+ * <p> Note: This operation is designed to be used for buildingpermission-aware UIs and command-line tools, not for authorizationchecking. This operation may "fail open" without warning.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>

--- a/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/CloudRedisClient.java
+++ b/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/CloudRedisClient.java
@@ -89,15 +89,12 @@ import javax.annotation.Generated;
  *      <th>Method Variants</th>
  *    <tr>
  *      <td>ListInstances</td>
- *      <td><p>Lists all Redis instances owned by a project in either the specified
- *  location (region) or all locations.
- *
- *  The location should have the following format:
- *
- *  * `projects/{project_id}/locations/{location_id}`
- *
- *  If `location_id` is specified as `-` (wildcard), then all regions
- *  available to the project are queried, and the results are aggregated.</p></td>
+ *      <td><p> Lists all Redis instances owned by a project in either the specified location (region) or all locations.
+ * <p>  The location should have the following format:
+ * <ul>
+ * <li>  `projects/{project_id}/locations/{location_id}`
+ * </ul>
+ * <p>  If `location_id` is specified as `-` (wildcard), then all regions available to the project are queried, and the results are aggregated.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -117,7 +114,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetInstance</td>
- *      <td><p>Gets the details of a specific Redis instance.</p></td>
+ *      <td><p> Gets the details of a specific Redis instance.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -136,9 +133,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetInstanceAuthString</td>
- *      <td><p>Gets the AUTH string for a Redis instance. If AUTH is not enabled for the
- *  instance the response will be empty. This information is not included in
- *  the details returned to GetInstance.</p></td>
+ *      <td><p> Gets the AUTH string for a Redis instance. If AUTH is not enabled for the instance the response will be empty. This information is not included in the details returned to GetInstance.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -157,18 +152,10 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>CreateInstance</td>
- *      <td><p>Creates a Redis instance based on the specified tier and memory size.
- *
- *  By default, the instance is accessible from the project's
- *  [default network](https://cloud.google.com/vpc/docs/vpc).
- *
- *  The creation is executed asynchronously and callers may check the returned
- *  operation to track its progress. Once the operation is completed the Redis
- *  instance will be fully functional. The completed longrunning.Operation will
- *  contain the new instance object in the response field.
- *
- *  The returned operation is automatically deleted after a few hours, so there
- *  is no need to call DeleteOperation.</p></td>
+ *      <td><p> Creates a Redis instance based on the specified tier and memory size.
+ * <p>  By default, the instance is accessible from the project's [default network](https://cloud.google.com/vpc/docs/vpc).
+ * <p>  The creation is executed asynchronously and callers may check the returned operation to track its progress. Once the operation is completed the Redis instance will be fully functional. The completed longrunning.Operation will contain the new instance object in the response field.
+ * <p>  The returned operation is automatically deleted after a few hours, so there is no need to call DeleteOperation.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -188,11 +175,8 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>UpdateInstance</td>
- *      <td><p>Updates the metadata and configuration of a specific Redis instance.
- *
- *  Completed longrunning.Operation will contain the new instance object
- *  in the response field. The returned operation is automatically deleted
- *  after a few hours, so there is no need to call DeleteOperation.</p></td>
+ *      <td><p> Updates the metadata and configuration of a specific Redis instance.
+ * <p>  Completed longrunning.Operation will contain the new instance object in the response field. The returned operation is automatically deleted after a few hours, so there is no need to call DeleteOperation.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -211,8 +195,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>UpgradeInstance</td>
- *      <td><p>Upgrades Redis instance to the newer Redis version specified in the
- *  request.</p></td>
+ *      <td><p> Upgrades Redis instance to the newer Redis version specified in the request.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -232,14 +215,9 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ImportInstance</td>
- *      <td><p>Import a Redis RDB snapshot file from Cloud Storage into a Redis instance.
- *
- *  Redis may stop serving during this operation. Instance state will be
- *  IMPORTING for entire operation. When complete, the instance will contain
- *  only data from the imported file.
- *
- *  The returned operation is automatically deleted after a few hours, so
- *  there is no need to call DeleteOperation.</p></td>
+ *      <td><p> Import a Redis RDB snapshot file from Cloud Storage into a Redis instance.
+ * <p>  Redis may stop serving during this operation. Instance state will be IMPORTING for entire operation. When complete, the instance will contain only data from the imported file.
+ * <p>  The returned operation is automatically deleted after a few hours, so there is no need to call DeleteOperation.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -258,12 +236,9 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ExportInstance</td>
- *      <td><p>Export Redis instance data into a Redis RDB format file in Cloud Storage.
- *
- *  Redis will continue serving during this operation.
- *
- *  The returned operation is automatically deleted after a few hours, so
- *  there is no need to call DeleteOperation.</p></td>
+ *      <td><p> Export Redis instance data into a Redis RDB format file in Cloud Storage.
+ * <p>  Redis will continue serving during this operation.
+ * <p>  The returned operation is automatically deleted after a few hours, so there is no need to call DeleteOperation.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -282,8 +257,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>FailoverInstance</td>
- *      <td><p>Initiates a failover of the primary node to current replica node for a
- *  specific STANDARD tier Cloud Memorystore for Redis instance.</p></td>
+ *      <td><p> Initiates a failover of the primary node to current replica node for a specific STANDARD tier Cloud Memorystore for Redis instance.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -303,8 +277,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>DeleteInstance</td>
- *      <td><p>Deletes a specific Redis instance.  Instance stops serving and data is
- *  deleted.</p></td>
+ *      <td><p> Deletes a specific Redis instance.  Instance stops serving and data is deleted.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -324,8 +297,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>RescheduleMaintenance</td>
- *      <td><p>Reschedule maintenance for a given instance in a given project and
- *  location.</p></td>
+ *      <td><p> Reschedule maintenance for a given instance in a given project and location.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>

--- a/test/integration/goldens/storage/src/com/google/storage/v2/StorageClient.java
+++ b/test/integration/goldens/storage/src/com/google/storage/v2/StorageClient.java
@@ -85,7 +85,7 @@ import javax.annotation.Generated;
  *      <th>Method Variants</th>
  *    <tr>
  *      <td>DeleteBucket</td>
- *      <td><p>Permanently deletes an empty bucket.</p></td>
+ *      <td><p> Permanently deletes an empty bucket.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -104,7 +104,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetBucket</td>
- *      <td><p>Returns metadata for the specified bucket.</p></td>
+ *      <td><p> Returns metadata for the specified bucket.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -123,7 +123,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>CreateBucket</td>
- *      <td><p>Creates a new bucket.</p></td>
+ *      <td><p> Creates a new bucket.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -142,7 +142,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListBuckets</td>
- *      <td><p>Retrieves a list of buckets for a given project.</p></td>
+ *      <td><p> Retrieves a list of buckets for a given project.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -162,7 +162,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>LockBucketRetentionPolicy</td>
- *      <td><p>Locks retention policy on a bucket.</p></td>
+ *      <td><p> Locks retention policy on a bucket.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -181,10 +181,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetIamPolicy</td>
- *      <td><p>Gets the IAM policy for a specified bucket or object.
- *  The `resource` field in the request should be
- *  projects/_/buckets/<bucket_name> for a bucket or
- *  projects/_/buckets/<bucket_name>/objects/<object_name> for an object.</p></td>
+ *      <td><p> Gets the IAM policy for a specified bucket or object. The `resource` field in the request should be projects/_/buckets/&lt;bucket_name&gt; for a bucket or projects/_/buckets/&lt;bucket_name&gt;/objects/&lt;object_name&gt; for an object.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -203,10 +200,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>SetIamPolicy</td>
- *      <td><p>Updates an IAM policy for the specified bucket or object.
- *  The `resource` field in the request should be
- *  projects/_/buckets/<bucket_name> for a bucket or
- *  projects/_/buckets/<bucket_name>/objects/<object_name> for an object.</p></td>
+ *      <td><p> Updates an IAM policy for the specified bucket or object. The `resource` field in the request should be projects/_/buckets/&lt;bucket_name&gt; for a bucket or projects/_/buckets/&lt;bucket_name&gt;/objects/&lt;object_name&gt; for an object.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -225,11 +219,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>TestIamPermissions</td>
- *      <td><p>Tests a set of permissions on the given bucket or object to see which, if
- *  any, are held by the caller.
- *  The `resource` field in the request should be
- *  projects/_/buckets/<bucket_name> for a bucket or
- *  projects/_/buckets/<bucket_name>/objects/<object_name> for an object.</p></td>
+ *      <td><p> Tests a set of permissions on the given bucket or object to see which, if any, are held by the caller. The `resource` field in the request should be projects/_/buckets/&lt;bucket_name&gt; for a bucket or projects/_/buckets/&lt;bucket_name&gt;/objects/&lt;object_name&gt; for an object.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -248,7 +238,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>UpdateBucket</td>
- *      <td><p>Updates a bucket. Equivalent to JSON API's storage.buckets.patch method.</p></td>
+ *      <td><p> Updates a bucket. Equivalent to JSON API's storage.buckets.patch method.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -266,7 +256,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>DeleteNotification</td>
- *      <td><p>Permanently deletes a notification subscription.</p></td>
+ *      <td><p> Permanently deletes a notification subscription.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -285,7 +275,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetNotification</td>
- *      <td><p>View a notification config.</p></td>
+ *      <td><p> View a notification config.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -304,10 +294,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>CreateNotification</td>
- *      <td><p>Creates a notification subscription for a given bucket.
- *  These notifications, when triggered, publish messages to the specified
- *  Pub/Sub topics.
- *  See https://cloud.google.com/storage/docs/pubsub-notifications.</p></td>
+ *      <td><p> Creates a notification subscription for a given bucket. These notifications, when triggered, publish messages to the specified Pub/Sub topics. See https://cloud.google.com/storage/docs/pubsub-notifications.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -326,7 +313,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListNotifications</td>
- *      <td><p>Retrieves a list of notification subscriptions for a given bucket.</p></td>
+ *      <td><p> Retrieves a list of notification subscriptions for a given bucket.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -346,8 +333,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ComposeObject</td>
- *      <td><p>Concatenates a list of existing objects into a new object in the same
- *  bucket.</p></td>
+ *      <td><p> Concatenates a list of existing objects into a new object in the same bucket.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -361,8 +347,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>DeleteObject</td>
- *      <td><p>Deletes an object and its metadata. Deletions are permanent if versioning
- *  is not enabled for the bucket, or if the `generation` parameter is used.</p></td>
+ *      <td><p> Deletes an object and its metadata. Deletions are permanent if versioning is not enabled for the bucket, or if the `generation` parameter is used.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -381,7 +366,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>CancelResumableWrite</td>
- *      <td><p>Cancels an in-progress resumable upload.</p></td>
+ *      <td><p> Cancels an in-progress resumable upload.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -399,7 +384,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetObject</td>
- *      <td><p>Retrieves an object's metadata.</p></td>
+ *      <td><p> Retrieves an object's metadata.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -418,7 +403,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ReadObject</td>
- *      <td><p>Reads an object's data.</p></td>
+ *      <td><p> Reads an object's data.</td>
  *      <td>
  *      <p>Callable method variants take no parameters and return an immutable API callable object, which can be used to initiate calls to the service.</p>
  *      <ul>
@@ -428,8 +413,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>UpdateObject</td>
- *      <td><p>Updates an object's metadata.
- *  Equivalent to JSON API's storage.objects.patch.</p></td>
+ *      <td><p> Updates an object's metadata. Equivalent to JSON API's storage.objects.patch.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -447,58 +431,11 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>WriteObject</td>
- *      <td><p>Stores a new object and metadata.
- *
- *  An object can be written either in a single message stream or in a
- *  resumable sequence of message streams. To write using a single stream,
- *  the client should include in the first message of the stream an
- *  `WriteObjectSpec` describing the destination bucket, object, and any
- *  preconditions. Additionally, the final message must set 'finish_write' to
- *  true, or else it is an error.
- *
- *  For a resumable write, the client should instead call
- *  `StartResumableWrite()`, populating a `WriteObjectSpec` into that request.
- *  They should then attach the returned `upload_id` to the first message of
- *  each following call to `WriteObject`. If the stream is closed before
- *  finishing the upload (either explicitly by the client or due to a network
- *  error or an error response from the server), the client should do as
- *  follows:
- *    - Check the result Status of the stream, to determine if writing can be
- *      resumed on this stream or must be restarted from scratch (by calling
- *      `StartResumableWrite()`). The resumable errors are DEADLINE_EXCEEDED,
- *      INTERNAL, and UNAVAILABLE. For each case, the client should use binary
- *      exponential backoff before retrying.  Additionally, writes can be
- *      resumed after RESOURCE_EXHAUSTED errors, but only after taking
- *      appropriate measures, which may include reducing aggregate send rate
- *      across clients and/or requesting a quota increase for your project.
- *    - If the call to `WriteObject` returns `ABORTED`, that indicates
- *      concurrent attempts to update the resumable write, caused either by
- *      multiple racing clients or by a single client where the previous
- *      request was timed out on the client side but nonetheless reached the
- *      server. In this case the client should take steps to prevent further
- *      concurrent writes (e.g., increase the timeouts, stop using more than
- *      one process to perform the upload, etc.), and then should follow the
- *      steps below for resuming the upload.
- *    - For resumable errors, the client should call `QueryWriteStatus()` and
- *      then continue writing from the returned `persisted_size`. This may be
- *      less than the amount of data the client previously sent. Note also that
- *      it is acceptable to send data starting at an offset earlier than the
- *      returned `persisted_size`; in this case, the service will skip data at
- *      offsets that were already persisted (without checking that it matches
- *      the previously written data), and write only the data starting from the
- *      persisted offset. This behavior can make client-side handling simpler
- *      in some cases.
- *
- *  The service will not view the object as complete until the client has
- *  sent a `WriteObjectRequest` with `finish_write` set to `true`. Sending any
- *  requests on a stream after sending a request with `finish_write` set to
- *  `true` will cause an error. The client **should** check the response it
- *  receives to determine how much data the service was able to commit and
- *  whether the service views the object as complete.
- *
- *  Attempting to resume an already finalized object will result in an OK
- *  status, with a WriteObjectResponse containing the finalized object's
- *  metadata.</p></td>
+ *      <td><p> Stores a new object and metadata.
+ * <p>  An object can be written either in a single message stream or in a resumable sequence of message streams. To write using a single stream, the client should include in the first message of the stream an `WriteObjectSpec` describing the destination bucket, object, and any preconditions. Additionally, the final message must set 'finish_write' to true, or else it is an error.
+ * <p>  For a resumable write, the client should instead call `StartResumableWrite()`, populating a `WriteObjectSpec` into that request. They should then attach the returned `upload_id` to the first message of each following call to `WriteObject`. If the stream is closed before finishing the upload (either explicitly by the client or due to a network error or an error response from the server), the client should do as follows:   - Check the result Status of the stream, to determine if writing can be     resumed on this stream or must be restarted from scratch (by calling     `StartResumableWrite()`). The resumable errors are DEADLINE_EXCEEDED,     INTERNAL, and UNAVAILABLE. For each case, the client should use binary     exponential backoff before retrying.  Additionally, writes can be     resumed after RESOURCE_EXHAUSTED errors, but only after taking     appropriate measures, which may include reducing aggregate send rate     across clients and/or requesting a quota increase for your project.   - If the call to `WriteObject` returns `ABORTED`, that indicates     concurrent attempts to update the resumable write, caused either by     multiple racing clients or by a single client where the previous     request was timed out on the client side but nonetheless reached the     server. In this case the client should take steps to prevent further     concurrent writes (e.g., increase the timeouts, stop using more than     one process to perform the upload, etc.), and then should follow the     steps below for resuming the upload.   - For resumable errors, the client should call `QueryWriteStatus()` and     then continue writing from the returned `persisted_size`. This may be     less than the amount of data the client previously sent. Note also that     it is acceptable to send data starting at an offset earlier than the     returned `persisted_size`; in this case, the service will skip data at     offsets that were already persisted (without checking that it matches     the previously written data), and write only the data starting from the     persisted offset. This behavior can make client-side handling simpler     in some cases.
+ * <p>  The service will not view the object as complete until the client has sent a `WriteObjectRequest` with `finish_write` set to `true`. Sending any requests on a stream after sending a request with `finish_write` set to `true` will cause an error. The client &#42;&#42;should&#42;&#42; check the response it receives to determine how much data the service was able to commit and whether the service views the object as complete.
+ * <p>  Attempting to resume an already finalized object will result in an OK status, with a WriteObjectResponse containing the finalized object's metadata.</td>
  *      <td>
  *      <p>Callable method variants take no parameters and return an immutable API callable object, which can be used to initiate calls to the service.</p>
  *      <ul>
@@ -508,7 +445,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListObjects</td>
- *      <td><p>Retrieves a list of objects matching the criteria.</p></td>
+ *      <td><p> Retrieves a list of objects matching the criteria.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -528,8 +465,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>RewriteObject</td>
- *      <td><p>Rewrites a source object to a destination object. Optionally overrides
- *  metadata.</p></td>
+ *      <td><p> Rewrites a source object to a destination object. Optionally overrides metadata.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -543,9 +479,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>StartResumableWrite</td>
- *      <td><p>Starts a resumable write. How long the write operation remains valid, and
- *  what happens when the write operation becomes invalid, are
- *  service-dependent.</p></td>
+ *      <td><p> Starts a resumable write. How long the write operation remains valid, and what happens when the write operation becomes invalid, are service-dependent.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -559,19 +493,9 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>QueryWriteStatus</td>
- *      <td><p>Determines the `persisted_size` for an object that is being written, which
- *  can then be used as the `write_offset` for the next `Write()` call.
- *
- *  If the object does not exist (i.e., the object has been deleted, or the
- *  first `Write()` has not yet reached the service), this method returns the
- *  error `NOT_FOUND`.
- *
- *  The client **may** call `QueryWriteStatus()` at any time to determine how
- *  much data has been processed for this object. This is useful if the
- *  client is buffering data and needs to know which data can be safely
- *  evicted. For any sequence of `QueryWriteStatus()` calls for a given
- *  object name, the sequence of returned `persisted_size` values will be
- *  non-decreasing.</p></td>
+ *      <td><p> Determines the `persisted_size` for an object that is being written, which can then be used as the `write_offset` for the next `Write()` call.
+ * <p>  If the object does not exist (i.e., the object has been deleted, or the first `Write()` has not yet reached the service), this method returns the error `NOT_FOUND`.
+ * <p>  The client &#42;&#42;may&#42;&#42; call `QueryWriteStatus()` at any time to determine how much data has been processed for this object. This is useful if the client is buffering data and needs to know which data can be safely evicted. For any sequence of `QueryWriteStatus()` calls for a given object name, the sequence of returned `persisted_size` values will be non-decreasing.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -589,7 +513,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetServiceAccount</td>
- *      <td><p>Retrieves the name of a project's Google Cloud Storage service account.</p></td>
+ *      <td><p> Retrieves the name of a project's Google Cloud Storage service account.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -608,7 +532,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>CreateHmacKey</td>
- *      <td><p>Creates a new HMAC key for the given service account.</p></td>
+ *      <td><p> Creates a new HMAC key for the given service account.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -627,7 +551,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>DeleteHmacKey</td>
- *      <td><p>Deletes a given HMAC key.  Key must be in an INACTIVE state.</p></td>
+ *      <td><p> Deletes a given HMAC key.  Key must be in an INACTIVE state.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -646,7 +570,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>GetHmacKey</td>
- *      <td><p>Gets an existing HMAC key metadata for the given id.</p></td>
+ *      <td><p> Gets an existing HMAC key metadata for the given id.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -665,7 +589,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>ListHmacKeys</td>
- *      <td><p>Lists HMAC keys under a given project with the additional filters provided.</p></td>
+ *      <td><p> Lists HMAC keys under a given project with the additional filters provided.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>
@@ -685,7 +609,7 @@ import javax.annotation.Generated;
  *    </tr>
  *    <tr>
  *      <td>UpdateHmacKey</td>
- *      <td><p>Updates a given HMAC key state between ACTIVE and INACTIVE.</p></td>
+ *      <td><p> Updates a given HMAC key state between ACTIVE and INACTIVE.</td>
  *      <td>
  *      <p>Request object method variants only take one parameter, a request object, which must be constructed before the call.</p>
  *      <ul>


### PR DESCRIPTION
Follow up PR to https://github.com/googleapis/sdk-platform-java/pull/2114 which breaks generation for java-bigqueryreservation due to errant formatting of the proto comments.

cl/587006892 contains the mock for bigqueryreservation's ReservationServiceClent.

I think it could make sense to add an integration test for this as the original integration tests didn't catch this bug, but I also understand that there are already a lot of integration tests. Thoughts? 