### PR TITLE
test: increasing timeout in testOnResponseError

### DIFF
--- a/gax-java/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonDirectServerStreamingCallableTest.java
+++ b/gax-java/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonDirectServerStreamingCallableTest.java
@@ -263,7 +263,7 @@ public class HttpJsonDirectServerStreamingCallableTest {
     MoneyObserver moneyObserver = new MoneyObserver(true, latch);
 
     streamingCallable.call(ERROR_REQUEST, moneyObserver);
-    Truth.assertThat(latch.await(2000, TimeUnit.MILLISECONDS)).isTrue();
+    Truth.assertThat(latch.await(60, TimeUnit.SECONDS)).isTrue();
 
     Truth.assertThat(moneyObserver.error).isInstanceOf(ApiException.class);
     Truth.assertThat(((ApiException) moneyObserver.error).getStatusCode().getCode())


### PR DESCRIPTION
Fixes #1975 

(This test is multithread because RetryingServerStreamingCallable uses an executor.)

This change increases the timeout in HttpJsonDirectServerStreamingCallableTest.testOnResponseError to avoid flakiness. There's no guarantee that this multithread test executes the CountDownLatch.countDown() within 2 seconds.

Will this 60-second timeout make the test execution slower? => No, it won't. `CountDownLatch.await(timeout)` returns immediately when the count becomes zero, without waiting for timeout.

![image](https://github.com/googleapis/sdk-platform-java/assets/28604/5d58f933-a36b-4818-b388-17aa432e9177)


In b/281936326, Lawrence tried to reproduce the issue in Windows, but it didn't. I think the best way is to increase timeout and observe any recurrence.
