### PR TITLE
feat: Add Getters/Setters for Universe Domain

### DIFF
--- a/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
+++ b/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
@@ -189,6 +189,11 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
     return endpoint == null;
   }
 
+  @Override
+  public boolean needsResolvedEndpoint() {
+    return true;
+  }
+
   /**
    * Specify the endpoint the channel should connect to.
    *
@@ -199,6 +204,7 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
    */
   @Override
   public TransportChannelProvider withEndpoint(String endpoint) {
+    // validateEndpoint is for gRPC to ensure format of host:port
     validateEndpoint(endpoint);
     return toBuilder().setEndpoint(endpoint).build();
   }
@@ -430,6 +436,7 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
   }
 
   /** The endpoint to be used for the channel. */
+  @Override
   public String getEndpoint() {
     return endpoint;
   }
@@ -787,6 +794,10 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
     return ImmutableMap.<String, Object>of("loadBalancingConfig", ImmutableList.of(grpcLbPolicy));
   }
 
+  /**
+   * gRPC-Java's ManagedChannel expects a format of host:port. This is different from HttpJson's
+   * ManagedChannel which allows the endpoint to contain the scheme prefix.
+   */
   private static void validateEndpoint(String endpoint) {
     int colon = endpoint.lastIndexOf(':');
     if (colon < 0) {

--- a/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/InstantiatingHttpJsonChannelProvider.java
+++ b/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/InstantiatingHttpJsonChannelProvider.java
@@ -120,6 +120,11 @@ public final class InstantiatingHttpJsonChannelProvider implements TransportChan
   }
 
   @Override
+  public boolean needsResolvedEndpoint() {
+    return true;
+  }
+
+  @Override
   public TransportChannelProvider withEndpoint(String endpoint) {
     return toBuilder().setEndpoint(endpoint).build();
   }
@@ -207,6 +212,7 @@ public final class InstantiatingHttpJsonChannelProvider implements TransportChan
   }
 
   /** The endpoint to be used for the channel. */
+  @Override
   public String getEndpoint() {
     return endpoint;
   }

--- a/gax-java/gax/clirr-ignored-differences.xml
+++ b/gax-java/gax/clirr-ignored-differences.xml
@@ -19,4 +19,21 @@
     <method>*setWaitTimeout*</method>
     <to>com.google.api.gax.rpc.ServerStreamingCallSettings$Builder</to>
   </difference>
+  <!-- Add a default Endpoint Getter -->
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/api/gax/rpc/TransportChannelProvider</className>
+    <method>* getEndpoint()</method>
+  </difference>
+  <!-- Add Universe Domain to ClientContext -->
+  <difference>
+    <differenceType>7013</differenceType>
+    <className>com/google/api/gax/rpc/ClientContext*</className>
+    <method>* *UniverseDomain*(*)</method>
+  </difference>
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/api/gax/rpc/TransportChannelProvider</className>
+    <method>* needsResolvedEndpoint()</method>
+  </difference>
 </differences>

--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
@@ -207,8 +207,8 @@ public abstract class ClientContext {
         EndpointContext.newBuilder()
             .setUniverseDomain(settings.getUniverseDomain())
             .setClientSettingsEndpoint(settings.getEndpoint())
-            .setMtlsEndpoint(settings.getMtlsEndpoint())
             .setTransportChannelEndpoint(settings.getTransportChannelProvider().getEndpoint())
+            .setMtlsEndpoint(settings.getMtlsEndpoint())
             .setSwitchToMtlsEndpointAllowed(settings.getSwitchToMtlsEndpointAllowed())
             .build();
     String endpoint = endpointContext.getResolvedEndpoint();

--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
@@ -101,6 +101,9 @@ public abstract class ClientContext {
   public abstract Duration getStreamWatchdogCheckInterval();
 
   @Nullable
+  public abstract String getUniverseDomain();
+
+  @Nullable
   public abstract String getEndpoint();
 
   @Nullable
@@ -202,12 +205,15 @@ public abstract class ClientContext {
     }
     EndpointContext endpointContext =
         EndpointContext.newBuilder()
+            .setUniverseDomain(settings.getUniverseDomain())
             .setClientSettingsEndpoint(settings.getEndpoint())
             .setMtlsEndpoint(settings.getMtlsEndpoint())
+            .setTransportChannelEndpoint(settings.getTransportChannelProvider().getEndpoint())
             .setSwitchToMtlsEndpointAllowed(settings.getSwitchToMtlsEndpointAllowed())
             .build();
     String endpoint = endpointContext.getResolvedEndpoint();
-    if (transportChannelProvider.needsEndpoint()) {
+    String universeDomain = endpointContext.getResolvedUniverseDomain();
+    if (transportChannelProvider.needsResolvedEndpoint()) {
       transportChannelProvider = transportChannelProvider.withEndpoint(endpoint);
     }
     TransportChannel transportChannel = transportChannelProvider.getTransportChannel();
@@ -256,7 +262,8 @@ public abstract class ClientContext {
         .setInternalHeaders(ImmutableMap.copyOf(settings.getInternalHeaderProvider().getHeaders()))
         .setClock(clock)
         .setDefaultCallContext(defaultCallContext)
-        .setEndpoint(settings.getEndpoint())
+        .setUniverseDomain(universeDomain)
+        .setEndpoint(endpoint)
         .setQuotaProjectId(settings.getQuotaProjectId())
         .setStreamWatchdog(watchdog)
         .setStreamWatchdogCheckInterval(settings.getStreamWatchdogCheckInterval())
@@ -320,6 +327,8 @@ public abstract class ClientContext {
     public abstract Builder setClock(ApiClock clock);
 
     public abstract Builder setDefaultCallContext(ApiCallContext defaultCallContext);
+
+    public abstract Builder setUniverseDomain(String universeDomain);
 
     public abstract Builder setEndpoint(String endpoint);
 

--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/EndpointContext.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/EndpointContext.java
@@ -33,10 +33,11 @@ import com.google.api.core.InternalApi;
 import com.google.api.gax.rpc.mtls.MtlsProvider;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 import java.io.IOException;
 import javax.annotation.Nullable;
 
-/** Contains the fields required to resolve the endpoint */
+/** Contains the fields required to resolve the endpoint and Universe Domain */
 @InternalApi
 @AutoValue
 public abstract class EndpointContext {
@@ -51,6 +52,7 @@ public abstract class EndpointContext {
   @Nullable
   public abstract String clientSettingsEndpoint();
 
+  /** TransportChannelEndpoint is the endpoint value set via the TransportChannelProvider class. */
   @Nullable
   public abstract String transportChannelEndpoint();
 
@@ -117,6 +119,10 @@ public abstract class EndpointContext {
     return resolvedEndpoint;
   }
 
+  /**
+   * The resolved Universe Domain is the computed Universe Domain after accounting for the custom
+   * Universe Domain
+   */
   public String getResolvedUniverseDomain() {
     return resolvedUniverseDomain;
   }
@@ -130,6 +136,9 @@ public abstract class EndpointContext {
      */
     public abstract Builder setClientSettingsEndpoint(String clientSettingsEndpoint);
 
+    /**
+     * TransportChannelEndpoint is the endpoint value set via the TransportChannelProvider class.
+     */
     public abstract Builder setTransportChannelEndpoint(String transportChannelEndpoint);
 
     public abstract Builder setMtlsEndpoint(String mtlsEndpoint);

--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
@@ -79,6 +79,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
   @Nonnull private final ApiTracerFactory tracerFactory;
   // Track if deprecated setExecutorProvider is called
   private boolean deprecatedExecutorProviderSet;
+  private final String universeDomain;
 
   /**
    * Indicate when creating transport whether it is allowed to use mTLS endpoint instead of the
@@ -105,6 +106,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
     this.tracerFactory = builder.tracerFactory;
     this.deprecatedExecutorProviderSet = builder.deprecatedExecutorProviderSet;
     this.gdchApiAudience = builder.gdchApiAudience;
+    this.universeDomain = builder.universeDomain;
   }
 
   /** @deprecated Please use {@link #getBackgroundExecutorProvider()}. */
@@ -135,6 +137,10 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
 
   public final ApiClock getClock() {
     return clock;
+  }
+
+  public final String getUniverseDomain() {
+    return universeDomain;
   }
 
   public final String getEndpoint() {
@@ -219,6 +225,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
     @Nonnull private Duration streamWatchdogCheckInterval;
     @Nonnull private ApiTracerFactory tracerFactory;
     private boolean deprecatedExecutorProviderSet;
+    private String universeDomain;
 
     /**
      * Indicate when creating transport whether it is allowed to use mTLS endpoint instead of the
@@ -245,6 +252,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
       this.tracerFactory = settings.tracerFactory;
       this.deprecatedExecutorProviderSet = settings.deprecatedExecutorProviderSet;
       this.gdchApiAudience = settings.gdchApiAudience;
+      this.universeDomain = settings.universeDomain;
     }
 
     /** Get Quota Project ID from Client Context * */
@@ -280,6 +288,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
         this.tracerFactory = BaseApiTracerFactory.getInstance();
         this.deprecatedExecutorProviderSet = false;
         this.gdchApiAudience = null;
+        this.universeDomain = null;
       } else {
         ExecutorProvider fixedExecutorProvider =
             FixedExecutorProvider.create(clientContext.getExecutor());
@@ -302,6 +311,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
         this.tracerFactory = clientContext.getTracerFactory();
         this.quotaProjectId = getQuotaProjectIdFromClientContext(clientContext);
         this.gdchApiAudience = clientContext.getGdchApiAudience();
+        this.universeDomain = clientContext.getUniverseDomain();
       }
     }
 
@@ -411,6 +421,11 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
      */
     public B setClock(ApiClock clock) {
       this.clock = clock;
+      return self();
+    }
+
+    public B setUniverseDomain(String universeDomain) {
+      this.universeDomain = universeDomain;
       return self();
     }
 

--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/TransportChannelProvider.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/TransportChannelProvider.java
@@ -91,6 +91,15 @@ public interface TransportChannelProvider {
   boolean needsEndpoint();
 
   /**
+   * TransportChannelProvider allows setting a custom endpoint which may not be the resolved
+   * endpoint. Resolving the endpoint is always required for gRPC and HttpJson Transports and is not
+   * dependent if the user set a custom endpoint.
+   */
+  default boolean needsResolvedEndpoint() {
+    return false;
+  }
+
+  /**
    * Sets the endpoint to use when constructing a new {@link TransportChannel}.
    *
    * <p>This method should only be called if {@link #needsEndpoint()} returns true.
@@ -142,4 +151,13 @@ public interface TransportChannelProvider {
    * <p>This string can be used for identifying transports for switching logic.
    */
   String getTransportName();
+
+  /**
+   * User set custom endpoint for the Transport Channel Provider
+   *
+   * <p>This is the unresolved endpoint used by GAPICs
+   */
+  default String getEndpoint() {
+    return null;
+  }
 }

--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/TransportChannelProvider.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/TransportChannelProvider.java
@@ -92,8 +92,8 @@ public interface TransportChannelProvider {
 
   /**
    * TransportChannelProvider allows setting a custom endpoint which may not be the resolved
-   * endpoint. Resolving the endpoint is always required for gRPC and HttpJson Transports and is not
-   * dependent if the user set a custom endpoint.
+   * endpoint. Resolving the endpoint is _always_ required for gRPC and HttpJson Transports.
+   * Unlike {@link #needsEndpoint()}, it is not dependent if the user set a custom endpoint.
    */
   default boolean needsResolvedEndpoint() {
     return false;

--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/TransportChannelProvider.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/TransportChannelProvider.java
@@ -92,8 +92,8 @@ public interface TransportChannelProvider {
 
   /**
    * TransportChannelProvider allows setting a custom endpoint which may not be the resolved
-   * endpoint. Resolving the endpoint is _always_ required for gRPC and HttpJson Transports.
-   * Unlike {@link #needsEndpoint()}, it is not dependent if the user set a custom endpoint.
+   * endpoint. Resolving the endpoint is _always_ required for gRPC and HttpJson Transports. Unlike
+   * {@link #needsEndpoint()}, it is not dependent if the user set a custom endpoint.
    */
   default boolean needsResolvedEndpoint() {
     return false;

--- a/gax-java/gax/src/test/java/com/google/api/gax/rpc/ClientContextTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/rpc/ClientContextTest.java
@@ -72,6 +72,8 @@ import org.threeten.bp.Duration;
 
 @RunWith(JUnit4.class)
 public class ClientContextTest {
+  private static final String DEFAULT_ENDPOINT = "test.googleapis.com";
+  private static final String DEFAULT_UNIVERSE_DOMAIN = "googleapis.com";
 
   private static class InterceptingExecutor extends ScheduledThreadPoolExecutor {
     boolean shutdownCalled = false;
@@ -111,19 +113,22 @@ public class ClientContextTest {
     final boolean shouldAutoClose;
     final Map<String, String> headers;
     final Credentials credentials;
+    final String endpoint;
 
     FakeTransportProvider(
         FakeTransportChannel transport,
         Executor executor,
         boolean shouldAutoClose,
         Map<String, String> headers,
-        Credentials credentials) {
+        Credentials credentials,
+        String endpoint) {
       this.transport = transport;
       this.executor = executor;
       this.shouldAutoClose = shouldAutoClose;
       this.headers = headers;
       this.transport.setHeaders(headers);
       this.credentials = credentials;
+      this.endpoint = endpoint;
     }
 
     @Override
@@ -144,7 +149,12 @@ public class ClientContextTest {
     @Override
     public TransportChannelProvider withExecutor(Executor executor) {
       return new FakeTransportProvider(
-          this.transport, executor, this.shouldAutoClose, this.headers, this.credentials);
+          this.transport,
+          executor,
+          this.shouldAutoClose,
+          this.headers,
+          this.credentials,
+          this.endpoint);
     }
 
     @Override
@@ -155,7 +165,12 @@ public class ClientContextTest {
     @Override
     public TransportChannelProvider withHeaders(Map<String, String> headers) {
       return new FakeTransportProvider(
-          this.transport, this.executor, this.shouldAutoClose, headers, this.credentials);
+          this.transport,
+          this.executor,
+          this.shouldAutoClose,
+          headers,
+          this.credentials,
+          this.endpoint);
     }
 
     @Override
@@ -164,8 +179,24 @@ public class ClientContextTest {
     }
 
     @Override
+    public boolean needsResolvedEndpoint() {
+      return true;
+    }
+
+    @Override
+    public String getEndpoint() {
+      return endpoint;
+    }
+
+    @Override
     public TransportChannelProvider withEndpoint(String endpoint) {
-      return this;
+      return new FakeTransportProvider(
+          this.transport,
+          this.executor,
+          this.shouldAutoClose,
+          this.headers,
+          this.credentials,
+          endpoint);
     }
 
     @Override
@@ -201,7 +232,12 @@ public class ClientContextTest {
     @Override
     public TransportChannelProvider withCredentials(Credentials credentials) {
       return new FakeTransportProvider(
-          this.transport, this.executor, this.shouldAutoClose, this.headers, credentials);
+          this.transport,
+          this.executor,
+          this.shouldAutoClose,
+          this.headers,
+          credentials,
+          this.endpoint);
     }
   }
 
@@ -248,7 +284,8 @@ public class ClientContextTest {
             contextNeedsExecutor ? null : executor,
             shouldAutoClose,
             needHeaders ? null : headers,
-            null);
+            null,
+            DEFAULT_ENDPOINT);
     Credentials credentials = Mockito.mock(Credentials.class);
     ApiClock clock = Mockito.mock(ApiClock.class);
     Watchdog watchdog =
@@ -322,7 +359,7 @@ public class ClientContextTest {
     InterceptingExecutor executor = new InterceptingExecutor(1);
     FakeTransportChannel transportChannel = FakeTransportChannel.create(new FakeChannel());
     FakeTransportProvider transportProvider =
-        new FakeTransportProvider(transportChannel, executor, true, null, null);
+        new FakeTransportProvider(transportChannel, executor, true, null, null, DEFAULT_ENDPOINT);
     ApiClock clock = Mockito.mock(ApiClock.class);
 
     builder.setClock(clock);
@@ -361,7 +398,7 @@ public class ClientContextTest {
     InterceptingExecutor executor = new InterceptingExecutor(1);
     FakeTransportChannel transportChannel = FakeTransportChannel.create(new FakeChannel());
     FakeTransportProvider transportProvider =
-        new FakeTransportProvider(transportChannel, executor, true, null, null);
+        new FakeTransportProvider(transportChannel, executor, true, null, null, DEFAULT_ENDPOINT);
 
     HeaderProvider headerProvider = Mockito.mock(HeaderProvider.class);
     Mockito.when(headerProvider.getHeaders()).thenReturn(ImmutableMap.of("header_k1", "v1"));
@@ -397,7 +434,7 @@ public class ClientContextTest {
     InterceptingExecutor executor = new InterceptingExecutor(1);
     FakeTransportChannel transportChannel = FakeTransportChannel.create(new FakeChannel());
     FakeTransportProvider transportProvider =
-        new FakeTransportProvider(transportChannel, executor, true, null, null);
+        new FakeTransportProvider(transportChannel, executor, true, null, null, DEFAULT_ENDPOINT);
 
     HeaderProvider headerProvider =
         new HeaderProvider() {
@@ -443,7 +480,7 @@ public class ClientContextTest {
     InterceptingExecutor executor = new InterceptingExecutor(1);
     FakeTransportChannel transportChannel = FakeTransportChannel.create(new FakeChannel());
     FakeTransportProvider transportProvider =
-        new FakeTransportProvider(transportChannel, executor, true, null, null);
+        new FakeTransportProvider(transportChannel, executor, true, null, null, DEFAULT_ENDPOINT);
 
     HeaderProvider headerProvider = Mockito.mock(HeaderProvider.class);
     Mockito.when(headerProvider.getHeaders()).thenReturn(ImmutableMap.of("header_k1", "v1"));
@@ -474,7 +511,7 @@ public class ClientContextTest {
     InterceptingExecutor executor = new InterceptingExecutor(1);
     FakeTransportChannel transportChannel = FakeTransportChannel.create(new FakeChannel());
     FakeTransportProvider transportProvider =
-        new FakeTransportProvider(transportChannel, executor, true, null, null);
+        new FakeTransportProvider(transportChannel, executor, true, null, null, DEFAULT_ENDPOINT);
     Map<String, List<String>> metaDataWithQuota =
         ImmutableMap.of(
             "k1",
@@ -515,7 +552,7 @@ public class ClientContextTest {
     InterceptingExecutor executor = new InterceptingExecutor(1);
     FakeTransportChannel transportChannel = FakeTransportChannel.create(new FakeChannel());
     FakeTransportProvider transportProvider =
-        new FakeTransportProvider(transportChannel, executor, true, null, null);
+        new FakeTransportProvider(transportChannel, executor, true, null, null, DEFAULT_ENDPOINT);
     Map<String, List<String>> metaData = ImmutableMap.of("k1", Collections.singletonList("v1"));
     final Credentials credentialsWithoutQuotaProjectId = Mockito.mock(GoogleCredentials.class);
     Mockito.when(credentialsWithoutQuotaProjectId.getRequestMetadata(null)).thenReturn(metaData);
@@ -546,7 +583,12 @@ public class ClientContextTest {
     final FakeTransportChannel transportChannel = FakeTransportChannel.create(new FakeChannel());
     final FakeTransportProvider transportProvider =
         new FakeTransportProvider(
-            transportChannel, executor, true, null, Mockito.mock(Credentials.class));
+            transportChannel,
+            executor,
+            true,
+            null,
+            Mockito.mock(Credentials.class),
+            DEFAULT_ENDPOINT);
 
     final FakeClientSettings.Builder settingsBuilder = new FakeClientSettings.Builder();
 
@@ -562,7 +604,12 @@ public class ClientContextTest {
   public void testUserAgentInternalOnly() throws Exception {
     TransportChannelProvider transportChannelProvider =
         new FakeTransportProvider(
-            FakeTransportChannel.create(new FakeChannel()), null, true, null, null);
+            FakeTransportChannel.create(new FakeChannel()),
+            null,
+            true,
+            null,
+            null,
+            DEFAULT_ENDPOINT);
 
     ClientSettings.Builder builder =
         new FakeClientSettings.Builder()
@@ -585,7 +632,12 @@ public class ClientContextTest {
   public void testUserAgentExternalOnly() throws Exception {
     TransportChannelProvider transportChannelProvider =
         new FakeTransportProvider(
-            FakeTransportChannel.create(new FakeChannel()), null, true, null, null);
+            FakeTransportChannel.create(new FakeChannel()),
+            null,
+            true,
+            null,
+            null,
+            DEFAULT_ENDPOINT);
 
     ClientSettings.Builder builder =
         new FakeClientSettings.Builder()
@@ -608,7 +660,12 @@ public class ClientContextTest {
   public void testUserAgentConcat() throws Exception {
     TransportChannelProvider transportChannelProvider =
         new FakeTransportProvider(
-            FakeTransportChannel.create(new FakeChannel()), null, true, null, null);
+            FakeTransportChannel.create(new FakeChannel()),
+            null,
+            true,
+            null,
+            null,
+            DEFAULT_ENDPOINT);
 
     ClientSettings.Builder builder =
         new FakeClientSettings.Builder()
@@ -660,7 +717,12 @@ public class ClientContextTest {
   public void testExecutorSettings() throws Exception {
     TransportChannelProvider transportChannelProvider =
         new FakeTransportProvider(
-            FakeTransportChannel.create(new FakeChannel()), null, true, null, null);
+            FakeTransportChannel.create(new FakeChannel()),
+            null,
+            true,
+            null,
+            null,
+            DEFAULT_ENDPOINT);
 
     ClientSettings.Builder builder =
         new FakeClientSettings.Builder()
@@ -702,7 +764,12 @@ public class ClientContextTest {
     builder.setExecutorProvider(executorProvider);
     builder.setTransportChannelProvider(
         new FakeTransportProvider(
-            FakeTransportChannel.create(new FakeChannel()), null, true, null, null));
+            FakeTransportChannel.create(new FakeChannel()),
+            null,
+            true,
+            null,
+            null,
+            DEFAULT_ENDPOINT));
     context = ClientContext.create(builder.build());
     transportChannel = (FakeTransportChannel) context.getTransportChannel();
     assertThat(transportChannel.getExecutor()).isSameInstanceAs(executorProvider.getExecutor());
@@ -724,7 +791,7 @@ public class ClientContextTest {
 
   private TransportChannelProvider getFakeTransportChannelProvider() {
     return new FakeTransportProvider(
-        FakeTransportChannel.create(new FakeChannel()), null, true, null, null);
+        FakeTransportChannel.create(new FakeChannel()), null, true, null, null, DEFAULT_ENDPOINT);
   }
 
   @Test
@@ -858,5 +925,87 @@ public class ClientContextTest {
                 IllegalArgumentException.class, () -> ClientContext.create(withComputeCredentials))
             .getMessage();
     assertThat(exMessage).contains("GDC-H API audience can only be set when using GdchCredentials");
+  }
+
+  @Test
+  public void testCreateClientContext_SetEndpointViaClientSettings() throws IOException {
+    TransportChannelProvider transportChannelProvider =
+        new FakeTransportProvider(
+            FakeTransportChannel.create(new FakeChannel()), null, true, null, null, null);
+    StubSettings settings = new FakeStubSettings.Builder().setEndpoint(DEFAULT_ENDPOINT).build();
+    ClientSettings.Builder clientSettingsBuilder = new FakeClientSettings.Builder(settings);
+    clientSettingsBuilder.setTransportChannelProvider(transportChannelProvider);
+    clientSettingsBuilder.setCredentialsProvider(
+        FixedCredentialsProvider.create(Mockito.mock(Credentials.class)));
+    ClientSettings clientSettings = clientSettingsBuilder.build();
+    ClientContext clientContext = ClientContext.create(clientSettings);
+    assertThat(clientContext.getEndpoint()).isEqualTo(DEFAULT_ENDPOINT);
+    assertThat(clientContext.getUniverseDomain()).isEqualTo(DEFAULT_UNIVERSE_DOMAIN);
+  }
+
+  @Test
+  public void testCreateClientContext_SetEndpointViaTransportChannelProvider() throws IOException {
+    TransportChannelProvider transportChannelProvider =
+        new FakeTransportProvider(
+            FakeTransportChannel.create(new FakeChannel()),
+            null,
+            true,
+            null,
+            null,
+            DEFAULT_ENDPOINT);
+    StubSettings settings = new FakeStubSettings.Builder().setEndpoint(null).build();
+    ClientSettings.Builder clientSettingsBuilder = new FakeClientSettings.Builder(settings);
+    clientSettingsBuilder.setTransportChannelProvider(transportChannelProvider);
+    clientSettingsBuilder.setCredentialsProvider(
+        FixedCredentialsProvider.create(Mockito.mock(Credentials.class)));
+    ClientSettings clientSettings = clientSettingsBuilder.build();
+    ClientContext clientContext = ClientContext.create(clientSettings);
+    assertThat(clientContext.getEndpoint()).isEqualTo(DEFAULT_ENDPOINT);
+    assertThat(clientContext.getUniverseDomain()).isEqualTo(DEFAULT_UNIVERSE_DOMAIN);
+  }
+
+  @Test
+  public void testCreateClientContext_SetEndpointViaClientSettingsAndTransportChannelProvider()
+      throws IOException {
+    String transportChannelProviderEndpoint = "transportChannelProviderEndpoint.com";
+    TransportChannelProvider transportChannelProvider =
+        new FakeTransportProvider(
+            FakeTransportChannel.create(new FakeChannel()),
+            null,
+            true,
+            null,
+            null,
+            transportChannelProviderEndpoint);
+    String clientSettingsEndpoint = "clientSettingsEndpoint.com";
+    StubSettings settings =
+        new FakeStubSettings.Builder().setEndpoint(clientSettingsEndpoint).build();
+    ClientSettings.Builder clientSettingsBuilder = new FakeClientSettings.Builder(settings);
+    clientSettingsBuilder.setTransportChannelProvider(transportChannelProvider);
+    clientSettingsBuilder.setCredentialsProvider(
+        FixedCredentialsProvider.create(Mockito.mock(Credentials.class)));
+    ClientSettings clientSettings = clientSettingsBuilder.build();
+    ClientContext clientContext = ClientContext.create(clientSettings);
+    assertThat(clientContext.getEndpoint()).isEqualTo(transportChannelProviderEndpoint);
+    assertThat(clientContext.getUniverseDomain()).isEqualTo(DEFAULT_UNIVERSE_DOMAIN);
+  }
+
+  @Test
+  public void testCreateClientContext_SetUniverseDomain() throws IOException {
+    TransportChannelProvider transportChannelProvider =
+        new FakeTransportProvider(
+            FakeTransportChannel.create(new FakeChannel()), null, true, null, null, null);
+    StubSettings settings =
+        new FakeStubSettings.Builder()
+            .setEndpoint(null)
+            .setUniverseDomain(DEFAULT_UNIVERSE_DOMAIN)
+            .build();
+    ClientSettings.Builder clientSettingsBuilder = new FakeClientSettings.Builder(settings);
+    clientSettingsBuilder.setTransportChannelProvider(transportChannelProvider);
+    clientSettingsBuilder.setCredentialsProvider(
+        FixedCredentialsProvider.create(Mockito.mock(Credentials.class)));
+    ClientSettings clientSettings = clientSettingsBuilder.build();
+    ClientContext clientContext = ClientContext.create(clientSettings);
+    assertThat(clientContext.getEndpoint()).isEqualTo(null);
+    assertThat(clientContext.getUniverseDomain()).isEqualTo(DEFAULT_UNIVERSE_DOMAIN);
   }
 }


### PR DESCRIPTION
Introduce new Getter/Setter for Universe Domain inside the StubSettings and ClientContext.

TransportChannelProvider adds a new method `getEndpoint()` to expose the custom set endpoint value.