### PR TITLE
refactor: Add TransportChannelProvider's endpoint to EndpointContext

### DIFF
--- a/gax-java/gax/clirr-ignored-differences.xml
+++ b/gax-java/gax/clirr-ignored-differences.xml
@@ -19,4 +19,10 @@
     <method>*setWaitTimeout*</method>
     <to>com.google.api.gax.rpc.ServerStreamingCallSettings$Builder</to>
   </difference>
+  <!-- Add a default Endpoint Getter -->
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/api/gax/rpc/TransportChannelProvider</className>
+    <method>* getEndpoint()</method>
+  </difference>
 </differences>

--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
@@ -258,7 +258,7 @@ public abstract class ClientContext {
         .setInternalHeaders(ImmutableMap.copyOf(settings.getInternalHeaderProvider().getHeaders()))
         .setClock(clock)
         .setDefaultCallContext(defaultCallContext)
-        .setEndpoint(settings.getEndpoint())
+        .setEndpoint(endpoint)
         .setQuotaProjectId(settings.getQuotaProjectId())
         .setStreamWatchdog(watchdog)
         .setStreamWatchdogCheckInterval(settings.getStreamWatchdogCheckInterval())

--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
@@ -203,6 +203,8 @@ public abstract class ClientContext {
     EndpointContext endpointContext =
         EndpointContext.newBuilder()
             .setClientSettingsEndpoint(settings.getEndpoint())
+            .setTransportChannelProviderEndpoint(
+                settings.getTransportChannelProvider().getEndpoint())
             .setMtlsEndpoint(settings.getMtlsEndpoint())
             .setSwitchToMtlsEndpointAllowed(settings.getSwitchToMtlsEndpointAllowed())
             .build();

--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/EndpointContext.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/EndpointContext.java
@@ -46,6 +46,13 @@ public abstract class EndpointContext {
   @Nullable
   public abstract String clientSettingsEndpoint();
 
+  /**
+   * TransportChannelProviderEndpoint is the endpoint value set via the TransportChannelProvider
+   * class.
+   */
+  @Nullable
+  public abstract String transportChannelProviderEndpoint();
+
   @Nullable
   public abstract String mtlsEndpoint();
 
@@ -65,9 +72,13 @@ public abstract class EndpointContext {
   @VisibleForTesting
   void determineEndpoint() throws IOException {
     MtlsProvider mtlsProvider = mtlsProvider() == null ? new MtlsProvider() : mtlsProvider();
+    String customEndpoint =
+        transportChannelProviderEndpoint() == null
+            ? clientSettingsEndpoint()
+            : transportChannelProviderEndpoint();
     resolvedEndpoint =
         mtlsEndpointResolver(
-            clientSettingsEndpoint(), mtlsEndpoint(), switchToMtlsEndpointAllowed(), mtlsProvider);
+            customEndpoint, mtlsEndpoint(), switchToMtlsEndpointAllowed(), mtlsProvider);
   }
 
   // This takes in parameters because determineEndpoint()'s logic will be updated
@@ -110,6 +121,12 @@ public abstract class EndpointContext {
      * ClientSettingsEndpoint is the endpoint value set via the ClientSettings/StubSettings classes.
      */
     public abstract Builder setClientSettingsEndpoint(String clientSettingsEndpoint);
+
+    /**
+     * TransportChannelProviderEndpoint is the endpoint value set via the TransportChannelProvider
+     * class.
+     */
+    public abstract Builder setTransportChannelProviderEndpoint(String transportChannelEndpoint);
 
     public abstract Builder setMtlsEndpoint(String mtlsEndpoint);
 

--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/TransportChannelProvider.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/TransportChannelProvider.java
@@ -142,4 +142,13 @@ public interface TransportChannelProvider {
    * <p>This string can be used for identifying transports for switching logic.
    */
   String getTransportName();
+
+  /**
+   * User set custom endpoint for the Transport Channel Provider
+   *
+   * <p>This is the unresolved endpoint used by GAPICs
+   */
+  default String getEndpoint() {
+    return null;
+  }
 }


### PR DESCRIPTION
Add TransportChannelProvider's endpoint to EndpointContext. EndpointContext's endpoint resolution works as:
1. Use TransportChannelProvider's endpoint if set
2. Use ClientSettings endpoint (this should always be set as of now)