### PR TITLE
refactor: Use EndpointContext's resolved endpoint for TransportChannelProvider

### DIFF
--- a/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
+++ b/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
@@ -189,6 +189,11 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
     return endpoint == null;
   }
 
+  @Override
+  public boolean needsResolvedEndpoint() {
+    return true;
+  }
+
   /**
    * Specify the endpoint the channel should connect to.
    *

--- a/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/InstantiatingHttpJsonChannelProvider.java
+++ b/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/InstantiatingHttpJsonChannelProvider.java
@@ -120,6 +120,11 @@ public final class InstantiatingHttpJsonChannelProvider implements TransportChan
   }
 
   @Override
+  public boolean needsResolvedEndpoint() {
+    return true;
+  }
+
+  @Override
   public TransportChannelProvider withEndpoint(String endpoint) {
     return toBuilder().setEndpoint(endpoint).build();
   }

--- a/gax-java/gax/clirr-ignored-differences.xml
+++ b/gax-java/gax/clirr-ignored-differences.xml
@@ -25,4 +25,9 @@
     <className>com/google/api/gax/rpc/TransportChannelProvider</className>
     <method>* getEndpoint()</method>
   </difference>
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/api/gax/rpc/TransportChannelProvider</className>
+    <method>* needsResolvedEndpoint()</method>
+  </difference>
 </differences>

--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
@@ -209,7 +209,7 @@ public abstract class ClientContext {
             .setSwitchToMtlsEndpointAllowed(settings.getSwitchToMtlsEndpointAllowed())
             .build();
     String endpoint = endpointContext.getResolvedEndpoint();
-    if (transportChannelProvider.needsEndpoint()) {
+    if (transportChannelProvider.needsResolvedEndpoint()) {
       transportChannelProvider = transportChannelProvider.withEndpoint(endpoint);
     }
     TransportChannel transportChannel = transportChannelProvider.getTransportChannel();

--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/TransportChannelProvider.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/TransportChannelProvider.java
@@ -91,6 +91,15 @@ public interface TransportChannelProvider {
   boolean needsEndpoint();
 
   /**
+   * TransportChannelProvider allows setting a custom endpoint which may not be the resolved
+   * endpoint. Resolving the endpoint is required for gRPC and HttpJson Transports. Unlike {@link
+   * #needsEndpoint()}, it is not determined if the user set a custom endpoint.
+   */
+  default boolean needsResolvedEndpoint() {
+    return false;
+  }
+
+  /**
    * Sets the endpoint to use when constructing a new {@link TransportChannel}.
    *
    * <p>This method should only be called if {@link #needsEndpoint()} returns true.

--- a/gax-java/gax/src/test/java/com/google/api/gax/rpc/ClientContextTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/rpc/ClientContextTest.java
@@ -183,6 +183,11 @@ public class ClientContextTest {
     }
 
     @Override
+    public boolean needsResolvedEndpoint() {
+      return true;
+    }
+
+    @Override
     public TransportChannelProvider withEndpoint(String endpoint) {
       return new FakeTransportProvider(
           this.transport,


### PR DESCRIPTION
Fixes https://github.com/googleapis/sdk-platform-java/issues/2296

Changing from `needsEndpoint()` -> `needsResolvedEndpoint()` would not be a breaking behavior change as the EndpointContext would use the TransportChannelProvider's endpoint over the ClientSettings endpoint if provided.

