### PR TITLE
chore: add cloudbuild setup to publish docker images

### DIFF
--- a/.cloudbuild/cloudbuild-test-a.yaml
+++ b/.cloudbuild/cloudbuild-test-a.yaml
@@ -29,5 +29,5 @@ steps:
     args: [ './.kokoro/presubmit/downstream-build.sh' ]
     waitFor: [ "graalvm-a-build" ]
     env:
-      - 'MODULES_UNDER_TEST=java-kms,java-os-login'
+      - 'MODULES_UNDER_TEST=java-kms'
       - 'GOOGLE_CLOUD_PROJECT=cloud-java-ci-test'

--- a/.cloudbuild/cloudbuild-test-a.yaml
+++ b/.cloudbuild/cloudbuild-test-a.yaml
@@ -30,3 +30,4 @@ steps:
     waitFor: [ "graalvm-a-build" ]
     env:
       - 'MODULES_UNDER_TEST=java-kms,java-os-login'
+      - 'GOOGLE_CLOUD_PROJECT=cloud-java-ci-test'

--- a/.cloudbuild/cloudbuild-test-a.yaml
+++ b/.cloudbuild/cloudbuild-test-a.yaml
@@ -24,7 +24,7 @@ steps:
     dir: .cloudbuild
     id: graalvm-a-build
     waitFor: ["-"]
-  - name: gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:${_SDK_PLATFORM_SHARED_CONFIG_VERSION}
+  - name: gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:${_SHARED_DEPENDENCIES_VERSION}
     entrypoint: bash
     args: [ './.kokoro/presubmit/downstream-build.sh' ]
     waitFor: [ "graalvm-a-build" ]

--- a/.cloudbuild/cloudbuild-test-a.yaml
+++ b/.cloudbuild/cloudbuild-test-a.yaml
@@ -14,13 +14,13 @@
 
 timeout: 7200s # 2 hours
 substitutions:
-  _SDK_PLATFORM_SHARED_CONFIG_VERSION: '3.20.0' # {x-version-update:google-cloud-shared-dependencies:current}
+  _SHARED_DEPENDENCIES_VERSION: '3.20.0' # {x-version-update:google-cloud-shared-dependencies:current}
   _JAVA_SHARED_CONFIG_VERSION: '1.7.1'
 
 steps:
   # GraalVM A build
   - name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:${_SDK_PLATFORM_SHARED_CONFIG_VERSION}", "--file", "graalvm_a.Dockerfile", "--build-arg", "JAVA_SHARED_CONFIG_VERSION=$_JAVA_SHARED_CONFIG_VERSION", "."]
+    args: ["build", "-t", "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:${_SHARED_DEPENDENCIES_VERSION}", "--file", "graalvm_a.Dockerfile", "--build-arg", "JAVA_SHARED_CONFIG_VERSION=$_JAVA_SHARED_CONFIG_VERSION", "."]
     dir: .cloudbuild
     id: graalvm-a-build
     waitFor: ["-"]

--- a/.cloudbuild/cloudbuild-test-a.yaml
+++ b/.cloudbuild/cloudbuild-test-a.yaml
@@ -1,0 +1,32 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+timeout: 7200s # 2 hours
+substitutions:
+  _SDK_PLATFORM_SHARED_CONFIG_VERSION: '2.30.0' # {x-version-update:gapic-generator-java:current}
+  _JAVA_SHARED_CONFIG_VERSION: '1.7.1'
+
+steps:
+  # GraalVM A build
+  - name: gcr.io/cloud-builders/docker
+    args: ["build", "-t", "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:${_SDK_PLATFORM_SHARED_CONFIG_VERSION}", "--file", "graalvm_a.Dockerfile", "--build-arg", "JAVA_SHARED_CONFIG_VERSION=$_JAVA_SHARED_CONFIG_VERSION", "."]
+    dir: .cloudbuild
+    id: graalvm-a-build
+    waitFor: ["-"]
+  - name: gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:${_SDK_PLATFORM_SHARED_CONFIG_VERSION}
+    entrypoint: bash
+    args: [ './.kokoro/presubmit/downstream-build.sh' ]
+    waitFor: [ "graalvm-a-build" ]
+    env:
+      - 'MODULES_UNDER_TEST=java-kms,java-os-login'

--- a/.cloudbuild/cloudbuild-test-b.yaml
+++ b/.cloudbuild/cloudbuild-test-b.yaml
@@ -29,4 +29,4 @@ steps:
     args: [ './.kokoro/presubmit/downstream-build.sh' ]
     waitFor: [ "graalvm-a-build" ]
     env:
-      - 'MODULES_UNDER_TEST=java-kms,java-os-login'
+      - 'MODULES_UNDER_TEST=java-kms'

--- a/.cloudbuild/cloudbuild-test-b.yaml
+++ b/.cloudbuild/cloudbuild-test-b.yaml
@@ -14,19 +14,19 @@
 
 timeout: 7200s # 2 hours
 substitutions:
-  _SDK_PLATFORM_SHARED_CONFIG_VERSION: '3.20.0' # {x-version-update:google-cloud-shared-dependencies:current}
+  _SHARED_DEPENDENCIES_VERSION: '3.20.0' # {x-version-update:google-cloud-shared-dependencies:current}
   _JAVA_SHARED_CONFIG_VERSION: '1.7.1'
 
 steps:
   # GraalVM A build
   - name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:${_SDK_PLATFORM_SHARED_CONFIG_VERSION}", "--file", "graalvm_b.Dockerfile", "--build-arg", "JAVA_SHARED_CONFIG_VERSION=$_JAVA_SHARED_CONFIG_VERSION", "."]
+    args: ["build", "-t", "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:${_SHARED_DEPENDENCIES_VERSION}", "--file", "graalvm_b.Dockerfile", "--build-arg", "JAVA_SHARED_CONFIG_VERSION=$_JAVA_SHARED_CONFIG_VERSION", "."]
     dir: .cloudbuild
-    id: graalvm-a-build
+    id: graalvm-b-build
     waitFor: ["-"]
   - name: gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:${_SDK_PLATFORM_SHARED_CONFIG_VERSION}
     entrypoint: bash
     args: [ './.kokoro/presubmit/downstream-build.sh' ]
-    waitFor: [ "graalvm-a-build" ]
+    waitFor: [ "graalvm-b-build" ]
     env:
       - 'MODULES_UNDER_TEST=java-kms'

--- a/.cloudbuild/cloudbuild-test-b.yaml
+++ b/.cloudbuild/cloudbuild-test-b.yaml
@@ -20,11 +20,11 @@ substitutions:
 steps:
   # GraalVM A build
   - name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:${_SDK_PLATFORM_SHARED_CONFIG_VERSION}", "--file", "graalvm_a.Dockerfile", "--build-arg", "JAVA_SHARED_CONFIG_VERSION=$_JAVA_SHARED_CONFIG_VERSION", "."]
+    args: ["build", "-t", "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:${_SDK_PLATFORM_SHARED_CONFIG_VERSION}", "--file", "graalvm_b.Dockerfile", "--build-arg", "JAVA_SHARED_CONFIG_VERSION=$_JAVA_SHARED_CONFIG_VERSION", "."]
     dir: .cloudbuild
     id: graalvm-a-build
     waitFor: ["-"]
-  - name: gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:${_SDK_PLATFORM_SHARED_CONFIG_VERSION}
+  - name: gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:${_SDK_PLATFORM_SHARED_CONFIG_VERSION}
     entrypoint: bash
     args: [ './.kokoro/presubmit/downstream-build.sh' ]
     waitFor: [ "graalvm-a-build" ]

--- a/.cloudbuild/cloudbuild-test-b.yaml
+++ b/.cloudbuild/cloudbuild-test-b.yaml
@@ -24,7 +24,7 @@ steps:
     dir: .cloudbuild
     id: graalvm-b-build
     waitFor: ["-"]
-  - name: gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:${_SDK_PLATFORM_SHARED_CONFIG_VERSION}
+  - name: gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:${_SHARED_DEPENDENCIES_VERSION}
     entrypoint: bash
     args: [ './.kokoro/presubmit/downstream-build.sh' ]
     waitFor: [ "graalvm-b-build" ]

--- a/.cloudbuild/cloudbuild-test-b.yaml
+++ b/.cloudbuild/cloudbuild-test-b.yaml
@@ -30,3 +30,4 @@ steps:
     waitFor: [ "graalvm-b-build" ]
     env:
       - 'MODULES_UNDER_TEST=java-kms'
+      - 'GOOGLE_CLOUD_PROJECT=cloud-java-ci-test'

--- a/.cloudbuild/cloudbuild.yaml
+++ b/.cloudbuild/cloudbuild.yaml
@@ -1,0 +1,37 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+timeout: 7200s # 2 hours
+substitutions:
+  _SDK_PLATFORM_SHARED_CONFIG_VERSION: '2.30.0' # {x-version-update:gapic-generator-java:current}
+  _JAVA_SHARED_CONFIG_VERSION: '1.7.1'
+steps:
+  # GraalVM A build
+  - name: gcr.io/cloud-builders/docker
+    args: ["build", "-t", "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:${_SDK_PLATFORM_SHARED_CONFIG_VERSION}", "--file", "graalvm_a.Dockerfile", "--build-arg", "JAVA_SHARED_CONFIG_VERSION=$_JAVA_SHARED_CONFIG_VERSION", "."]
+    dir: .cloudbuild
+    id: graalvm-a-build
+    waitFor: ["-"]
+
+  # GraalVM B build
+  - name: gcr.io/cloud-builders/docker
+    args: [ "build", "-t", "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:${_SDK_PLATFORM_SHARED_CONFIG_VERSION}", "--file", "graalvm_b.Dockerfile",  "--build-arg", "JAVA_SHARED_CONFIG_VERSION=$_JAVA_SHARED_CONFIG_VERSION", "." ]
+    dir: .cloudbuild
+    id: graalvm-b-build
+    waitFor: [ "-" ]
+
+
+images:
+  - gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:${_SDK_PLATFORM_SHARED_CONFIG_VERSION}
+  - gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:${_SDK_PLATFORM_SHARED_CONFIG_VERSION}

--- a/.cloudbuild/cloudbuild.yaml
+++ b/.cloudbuild/cloudbuild.yaml
@@ -14,7 +14,7 @@
 
 timeout: 7200s # 2 hours
 substitutions:
-  _SDK_PLATFORM_SHARED_CONFIG_VERSION: '2.30.0' # {x-version-update:gapic-generator-java:current}
+  _SDK_PLATFORM_SHARED_CONFIG_VERSION: '3.20.0' # {x-version-update:google-cloud-shared-dependencies:released}
   _JAVA_SHARED_CONFIG_VERSION: '1.7.1'
 steps:
   # GraalVM A build

--- a/.cloudbuild/cloudbuild.yaml
+++ b/.cloudbuild/cloudbuild.yaml
@@ -14,24 +14,24 @@
 
 timeout: 7200s # 2 hours
 substitutions:
-  _SDK_PLATFORM_SHARED_CONFIG_VERSION: '3.20.0' # {x-version-update:google-cloud-shared-dependencies:released}
+  _SHARED_DEPENDENCIES_VERSION: '3.20.0' # {x-version-update:google-cloud-shared-dependencies:released}
   _JAVA_SHARED_CONFIG_VERSION: '1.7.1'
 steps:
   # GraalVM A build
   - name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:${_SDK_PLATFORM_SHARED_CONFIG_VERSION}", "--file", "graalvm_a.Dockerfile", "--build-arg", "JAVA_SHARED_CONFIG_VERSION=$_JAVA_SHARED_CONFIG_VERSION", "."]
+    args: ["build", "-t", "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:${_SHARED_DEPENDENCIES_VERSION}", "--file", "graalvm_a.Dockerfile", "--build-arg", "JAVA_SHARED_CONFIG_VERSION=$_JAVA_SHARED_CONFIG_VERSION", "."]
     dir: .cloudbuild
     id: graalvm-a-build
     waitFor: ["-"]
 
   # GraalVM B build
   - name: gcr.io/cloud-builders/docker
-    args: [ "build", "-t", "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:${_SDK_PLATFORM_SHARED_CONFIG_VERSION}", "--file", "graalvm_b.Dockerfile",  "--build-arg", "JAVA_SHARED_CONFIG_VERSION=$_JAVA_SHARED_CONFIG_VERSION", "." ]
+    args: [ "build", "-t", "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:${_SHARED_DEPENDENCIES_VERSION}", "--file", "graalvm_b.Dockerfile",  "--build-arg", "JAVA_SHARED_CONFIG_VERSION=$_JAVA_SHARED_CONFIG_VERSION", "." ]
     dir: .cloudbuild
     id: graalvm-b-build
     waitFor: [ "-" ]
 
 
 images:
-  - gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:${_SDK_PLATFORM_SHARED_CONFIG_VERSION}
-  - gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:${_SDK_PLATFORM_SHARED_CONFIG_VERSION}
+  - gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:${_SHARED_DEPENDENCIES_VERSION}
+  - gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:${_SHARED_DEPENDENCIES_VERSION}

--- a/.cloudbuild/google-cloud-sdk.repo
+++ b/.cloudbuild/google-cloud-sdk.repo
@@ -1,0 +1,8 @@
+[google-cloud-sdk]
+name=Google Cloud SDK
+baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el7-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=0
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
+       https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg

--- a/.cloudbuild/graalvm_a.Dockerfile
+++ b/.cloudbuild/graalvm_a.Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+ARG JAVA_SHARED_CONFIG_VERSION
+
+FROM gcr.io/cloud-devrel-public-resources/graalvm_a:$JAVA_SHARED_CONFIG_VERSION
+

--- a/.cloudbuild/graalvm_b.Dockerfile
+++ b/.cloudbuild/graalvm_b.Dockerfile
@@ -1,0 +1,18 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+ARG JAVA_SHARED_CONFIG_VERSION
+
+FROM gcr.io/cloud-devrel-public-resources/graalvm_b:$JAVA_SHARED_CONFIG_VERSION

--- a/.kokoro/presubmit/downstream-build.sh
+++ b/.kokoro/presubmit/downstream-build.sh
@@ -42,20 +42,20 @@ mvn -B -ntp install --projects '!gapic-generator-java' \
 SHARED_DEPS_VERSION=$(parse_pom_version java-shared-dependencies)
 
 ### Round 2 : Run showcase integration tests in GraalVM
-pushd showcase/gapic-showcase
-SHOWCASE_VERSION=$(mvn help:evaluate -Dexpression=gapic-showcase.version -q -DforceStdout)
-popd
-# Start showcase server
-mkdir -p /usr/src/showcase
-curl --location https://github.com/googleapis/gapic-showcase/releases/download/v"${SHOWCASE_VERSION}"/gapic-showcase-"${SHOWCASE_VERSION}"-linux-amd64.tar.gz --output /usr/src/showcase/showcase-"${SHOWCASE_VERSION}"-linux-amd64.tar.gz
-pushd /usr/src/showcase/
-tar -xf showcase-*
-./gapic-showcase run &
-popd
-# Run showcase tests with `native` profile
-pushd showcase
-mvn test -Pnative,-showcase -Denforcer.skip=true -ntp -B
-popd
+#pushd showcase/gapic-showcase
+#SHOWCASE_VERSION=$(mvn help:evaluate -Dexpression=gapic-showcase.version -q -DforceStdout)
+#popd
+## Start showcase server
+#mkdir -p /usr/src/showcase
+#curl --location https://github.com/googleapis/gapic-showcase/releases/download/v"${SHOWCASE_VERSION}"/gapic-showcase-"${SHOWCASE_VERSION}"-linux-amd64.tar.gz --output /usr/src/showcase/showcase-"${SHOWCASE_VERSION}"-linux-amd64.tar.gz
+#pushd /usr/src/showcase/
+#tar -xf showcase-*
+#./gapic-showcase run &
+#popd
+## Run showcase tests with `native` profile
+#pushd showcase
+#mvn test -Pnative,-showcase -Denforcer.skip=true -ntp -B
+#popd
 
 ### Round 3
 # Update the shared-dependencies version in google-cloud-jar-parent

--- a/.kokoro/presubmit/downstream-build.sh
+++ b/.kokoro/presubmit/downstream-build.sh
@@ -42,20 +42,20 @@ mvn -B -ntp install --projects '!gapic-generator-java' \
 SHARED_DEPS_VERSION=$(parse_pom_version java-shared-dependencies)
 
 ### Round 2 : Run showcase integration tests in GraalVM
-#pushd showcase/gapic-showcase
-#SHOWCASE_VERSION=$(mvn help:evaluate -Dexpression=gapic-showcase.version -q -DforceStdout)
-#popd
-## Start showcase server
-#mkdir -p /usr/src/showcase
-#curl --location https://github.com/googleapis/gapic-showcase/releases/download/v"${SHOWCASE_VERSION}"/gapic-showcase-"${SHOWCASE_VERSION}"-linux-amd64.tar.gz --output /usr/src/showcase/showcase-"${SHOWCASE_VERSION}"-linux-amd64.tar.gz
-#pushd /usr/src/showcase/
-#tar -xf showcase-*
-#./gapic-showcase run &
-#popd
-## Run showcase tests with `native` profile
-#pushd showcase
-#mvn test -Pnative,-showcase -Denforcer.skip=true -ntp -B
-#popd
+pushd showcase/gapic-showcase
+SHOWCASE_VERSION=$(mvn help:evaluate -Dexpression=gapic-showcase.version -q -DforceStdout)
+popd
+# Start showcase server
+mkdir -p /usr/src/showcase
+curl --location https://github.com/googleapis/gapic-showcase/releases/download/v"${SHOWCASE_VERSION}"/gapic-showcase-"${SHOWCASE_VERSION}"-linux-amd64.tar.gz --output /usr/src/showcase/showcase-"${SHOWCASE_VERSION}"-linux-amd64.tar.gz
+pushd /usr/src/showcase/
+tar -xf showcase-*
+./gapic-showcase run &
+popd
+# Run showcase tests with `native` profile
+pushd showcase
+mvn test -Pnative,-showcase -Denforcer.skip=true -ntp -B
+popd
 
 ### Round 3
 # Update the shared-dependencies version in google-cloud-jar-parent

--- a/renovate.json
+++ b/renovate.json
@@ -57,6 +57,17 @@
         "value: \"gcr.io/cloud-devrel-kokoro-resources/graalvm17:(?<currentValue>.*?)\""],
       "depNameTemplate": "ghcr.io/graalvm/graalvm-ce",
       "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^.cloudbuild/**"
+      ],
+      "matchStrings": [
+        "_JAVA_SHARED_CONFIG: \"(?<currentValue>.+?)\""
+      ],
+      "depNameTemplate": "com.google.cloud:google-cloud-shared-config",
+      "datasourceTemplate": "maven"
     }
   ],
   "packageRules": [

--- a/renovate.json
+++ b/renovate.json
@@ -64,7 +64,7 @@
         "^.cloudbuild/**"
       ],
       "matchStrings": [
-        "_JAVA_SHARED_CONFIG: \"(?<currentValue>.+?)\""
+        "_JAVA_SHARED_CONFIG_VERSION: \"(?<currentValue>.+?)\""
       ],
       "depNameTemplate": "com.google.cloud:google-cloud-shared-config",
       "datasourceTemplate": "maven"


### PR DESCRIPTION
Cloud Build Trigger for the docker image push is set to:

<img width="555" alt="Screenshot 2023-12-14 at 3 06 16 PM" src="https://github.com/googleapis/sdk-platform-java/assets/66699525/1214d78d-32e9-476b-a730-9a572de78ff3">
