### PR TITLE
test: increasing timeout in testServerStreamingStart

### DIFF
--- a/gax-java/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonDirectServerStreamingCallableTest.java
+++ b/gax-java/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonDirectServerStreamingCallableTest.java
@@ -200,9 +200,9 @@ public class HttpJsonDirectServerStreamingCallableTest {
 
     Truth.assertThat(moneyObserver.controller).isNotNull();
     // wait for the task to complete, otherwise it may interfere with other tests, since they share
-    // the same MockService and unfinished request in this tes may start readind messages designated
-    // for other tests.
-    Truth.assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue();
+    // the same MockService and unfinished request in this test may start reading messages
+    // designated for other tests.
+    Truth.assertThat(latch.await(60, TimeUnit.SECONDS)).isTrue();
   }
 
   @Test


### PR DESCRIPTION
Fixes https://github.com/googleapis/sdk-platform-java/issues/1678

The assertion error tells `latch.await(2, TimeUnit.SECONDS)` did not return true.

https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CountDownLatch.html#await-long-java.util.concurrent.TimeUnit-

> Returns:
> true if the count reached zero and false if the waiting time elapsed before the count reached zero

Under a multithreading test, there's no guarantee that `latch.await(2, TimeUnit.SECONDS)` finishes within 2 second.
Increasing the value to 60 second to (drastically) reduce the flakiness. (This is the same tactics as https://github.com/googleapis/sdk-platform-java/pull/2291)

Will this 60-second timeout make the test execution slower? => No, it won't. `CountDownLatch.await(timeout)` returns immediately when the count becomes zero, without waiting for timeout.