### PR TITLE
feat: new artifact for sdk-platform-java configs. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
     <module>java-core</module>
     <module>gapic-generator-java-bom</module>
     <module>java-shared-dependencies</module>
+    <module>sdk-platform-java-config</module>
   </modules>
   <!-- Do not deploy the aggregator POM -->
   <build>

--- a/sdk-platform-java-config/pom.xml
+++ b/sdk-platform-java-config/pom.xml
@@ -18,6 +18,6 @@
 
     <properties>
         <checkstyle.skip>true</checkstyle.skip>
-        <shared-dependencies.version>3.20.1-SNAPSHOT</shared-dependencies.version> <!-- {x-version-update:google-cloud-shared-dependencies:current} -->
+        <google-cloud-shared-dependencies.version>3.20.1-SNAPSHOT</google-cloud-shared-dependencies.version> <!-- {x-version-update:google-cloud-shared-dependencies:current} -->
     </properties>
 </project>

--- a/sdk-platform-java-config/pom.xml
+++ b/sdk-platform-java-config/pom.xml
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>sdk-platform-java-config</artifactId>
+    <packaging>pom</packaging>
+    <version>3.20.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-shared-dependencies:current} -->
+    <name>SDK Platform For Java Configurations</name>
+    <description>
+        Shared build configuration for Google Cloud Java libraries.
+    </description>
+
+    <parent>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-shared-config</artifactId>
+        <version>1.7.1</version>
+    </parent>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <site.installationModule>${project.artifactId}</site.installationModule>
+        <checkstyle.skip>true</checkstyle.skip>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>google-cloud-shared-dependencies</artifactId>
+                <version>3.20.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-shared-dependencies:current} -->
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/sdk-platform-java-config/pom.xml
+++ b/sdk-platform-java-config/pom.xml
@@ -17,20 +17,6 @@
     </parent>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <site.installationModule>${project.artifactId}</site.installationModule>
         <checkstyle.skip>true</checkstyle.skip>
     </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>com.google.cloud</groupId>
-                <artifactId>google-cloud-shared-dependencies</artifactId>
-                <version>3.20.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-shared-dependencies:current} -->
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 </project>

--- a/sdk-platform-java-config/pom.xml
+++ b/sdk-platform-java-config/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.google.cloud</groupId>
     <artifactId>sdk-platform-java-config</artifactId>
     <packaging>pom</packaging>
-    <version>3.20.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-shared-dependencies:current} -->
+    <version>3.20.1-SNAPSHOT</version> <!-- {x-version-update:google-cloud-shared-dependencies:current} -->
     <name>SDK Platform For Java Configurations</name>
     <description>
         Shared build configuration for Google Cloud Java libraries.
@@ -18,5 +18,6 @@
 
     <properties>
         <checkstyle.skip>true</checkstyle.skip>
+        <shared-dependencies.version>3.20.1-SNAPSHOT</shared-dependencies.version> <!-- {x-version-update:google-cloud-shared-dependencies:current} -->
     </properties>
 </project>


### PR DESCRIPTION
This artifact is meant to mirror java-shared-config with the java-shared-dependencies version to then be consumed by downstream libraries (including the monorepo and handwritten libraries). The purpose of this artifact is to have a single update PR in the downstream libs to update shared-config and shared-dependencies instead of two. 

Name of the artifact: `sdk-platform-java-config`