### PR TITLE
chore: one time manual docker images update for shared-deps 3.21.0 release

### DIFF
--- a/.cloudbuild/cloudbuild-test-a.yaml
+++ b/.cloudbuild/cloudbuild-test-a.yaml
@@ -14,7 +14,7 @@
 
 timeout: 7200s # 2 hours
 substitutions:
-  _SHARED_DEPENDENCIES_VERSION: '3.20.0' # {x-version-update:google-cloud-shared-dependencies:current}
+  _SHARED_DEPENDENCIES_VERSION: '3.21.0' # {x-version-update:google-cloud-shared-dependencies:current}
   _JAVA_SHARED_CONFIG_VERSION: '1.7.1'
 
 steps:

--- a/.cloudbuild/cloudbuild-test-b.yaml
+++ b/.cloudbuild/cloudbuild-test-b.yaml
@@ -14,7 +14,7 @@
 
 timeout: 7200s # 2 hours
 substitutions:
-  _SHARED_DEPENDENCIES_VERSION: '3.20.0' # {x-version-update:google-cloud-shared-dependencies:current}
+  _SHARED_DEPENDENCIES_VERSION: '3.21.0' # {x-version-update:google-cloud-shared-dependencies:current}
   _JAVA_SHARED_CONFIG_VERSION: '1.7.1'
 
 steps:

--- a/.cloudbuild/cloudbuild.yaml
+++ b/.cloudbuild/cloudbuild.yaml
@@ -14,7 +14,7 @@
 
 timeout: 7200s # 2 hours
 substitutions:
-  _SHARED_DEPENDENCIES_VERSION: '3.20.0' # {x-version-update:google-cloud-shared-dependencies:released}
+  _SHARED_DEPENDENCIES_VERSION: '3.21.0' # {x-version-update:google-cloud-shared-dependencies:released}
   _JAVA_SHARED_CONFIG_VERSION: '1.7.1'
 steps:
   # GraalVM A build

--- a/.cloudbuild/cloudbuild.yaml
+++ b/.cloudbuild/cloudbuild.yaml
@@ -14,7 +14,7 @@
 
 timeout: 7200s # 2 hours
 substitutions:
-  _SHARED_DEPENDENCIES_VERSION: '3.21.0' # {x-version-update:google-cloud-shared-dependencies:released}
+  _SHARED_DEPENDENCIES_VERSION: '3.21.0' # {x-version-update:google-cloud-shared-dependencies:current}
   _JAVA_SHARED_CONFIG_VERSION: '1.7.1'
 steps:
   # GraalVM A build


### PR DESCRIPTION
Preparing docker images for #2290. Similar to the observations in https://github.com/googleapis/java-shared-config/issues/730, release-please doesn't update these files despite the following configs being applied:
-  Inline annotation with `x-version-update:<artifact-name>:released` 
- Addition of `.cloudbuild/` yamls files to `extraFiles` parameter in `release-please.yaml` ([line](https://github.com/googleapis/sdk-platform-java/blob/99e51953f319c97b225a0209b093367fa440f9d3/.github/release-please.yml#L6))

These files were updated after the the release PR was opened. In the case of java-shared-config, the update to these extra files didn't happen until a new release PR was opened. Created a follow-up task to verify the automation in the next release #2327. 