### PR TITLE
fix: re-enable checkstyle in sdk-platform-java-config

### DIFF
--- a/sdk-platform-java-config/java.header
+++ b/sdk-platform-java-config/java.header
@@ -1,0 +1,15 @@
+^/\*$
+^ \* Copyright \d\d\d\d,? Google (Inc\.|LLC)$
+^ \*$
+^ \* Licensed under the Apache License, Version 2\.0 \(the "License"\);$
+^ \* you may not use this file except in compliance with the License\.$
+^ \* You may obtain a copy of the License at$
+^ \*$
+^ \*[ ]+https?://www.apache.org/licenses/LICENSE-2\.0$
+^ \*$
+^ \* Unless required by applicable law or agreed to in writing, software$
+^ \* distributed under the License is distributed on an "AS IS" BASIS,$
+^ \* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied\.$
+^ \* See the License for the specific language governing permissions and$
+^ \* limitations under the License\.$
+^ \*/$

--- a/sdk-platform-java-config/license-checks.xml
+++ b/sdk-platform-java-config/license-checks.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+    "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+    "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <module name="RegexpHeader">
+    <property name="fileExtensions" value="java"/>
+    <property name="headerFile" value="${checkstyle.header.file}"/>
+  </module>
+</module>

--- a/sdk-platform-java-config/pom.xml
+++ b/sdk-platform-java-config/pom.xml
@@ -17,7 +17,6 @@
     </parent>
 
     <properties>
-        <checkstyle.skip>true</checkstyle.skip>
         <google-cloud-shared-dependencies.version>3.20.1-SNAPSHOT</google-cloud-shared-dependencies.version> <!-- {x-version-update:google-cloud-shared-dependencies:current} -->
     </properties>
 </project>


### PR DESCRIPTION
The checkstyle was initially disabled to address the following error when executing `mvn clean install`:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-checkstyle-plugin:3.3.1:check (checkstyle) on project sdk-platform-java-config: Failed during checkstyle execution: Unable to find configuration file at location: license-checks.xml: Could not find resource 'license-checks.xml'. -> [Help 1]
```

However, since this artifact is meant to be used as a parent for downstream libraries, there is a risk that the `checkstyle.skip` property will be inherited by child poms in the future. This may cause checkstyle to be unintentionally disabled. 