### PR TITLE
build: remove caching in java 8 setup

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -55,7 +55,6 @@ jobs:
         with:
           java-version: 8
           distribution: temurin
-          cache: maven
       - run: mvn -version
       - name: Test with Java 8
         # Direct goal invocation ("surefire:test") prevents recompiling tests


### PR DESCRIPTION
There was an issue where the nightly jobs were failing due to the Windows/MacOS tests using an outdated cache (https://github.com/googleapis/sdk-platform-java/actions/runs/7381299031).

Removing the caching on the Java8 setup should ensure that the jobs will use the artifacts from the previous step: `run: mvn install --errors --batch-mode --no-transfer-progress -Dcheckstyle.skip -DskipTests -T 1C`. This should ensure this issue does not happen again.

The Java11 setup cache should be okay to leave as-is, as it should get updated whenever it finds the `mvn install` creates different files. The issue was that the Java8 setup was pulling it's own cache instead of using the latest artifacts from `mvn install`. 

