### PR TITLE
feat: Mark `getDefaultEndpoint()` with @ObsoleteApi

### DIFF
--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceStubSettingsClassComposer.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceStubSettingsClassComposer.java
@@ -18,6 +18,7 @@ import com.google.api.MonitoredResourceDescriptor;
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.BetaApi;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.batching.BatchingSettings;
 import com.google.api.gax.batching.FlowControlSettings;
 import com.google.api.gax.batching.FlowController.LimitExceededBehavior;
@@ -1190,6 +1191,13 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
             .setReturnType(returnType)
             .setName("getDefaultEndpoint")
             .setReturnExpr(ValueExpr.withValue(StringObjectValue.withValue(service.defaultHost())))
+            .setAnnotations(
+                ImmutableList.of(
+                    AnnotationNode.builder()
+                        .setType(FIXED_TYPESTORE.get(ObsoleteApi.class.getSimpleName()))
+                        .setDescription(
+                            "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
+                        .build()))
             .build());
 
     // Create the getDefaultMtlsEndpoint method.
@@ -2068,6 +2076,7 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
             List.class,
             Lists.class,
             MonitoredResourceDescriptor.class,
+            ObsoleteApi.class,
             Operation.class,
             OperationCallSettings.class,
             OperationSnapshot.class,

--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceStubSettingsClassComposer.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceStubSettingsClassComposer.java
@@ -1195,8 +1195,7 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
                 ImmutableList.of(
                     AnnotationNode.builder()
                         .setType(FIXED_TYPESTORE.get(ObsoleteApi.class.getSimpleName()))
-                        .setDescription(
-                            "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
+                        .setDescription("Use getEndpoint() instead")
                         .build()))
             .build());
 

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/ApiVersionTestingStubSettings.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/ApiVersionTestingStubSettings.golden
@@ -92,8 +92,7 @@ public class EchoWithVersionStubSettings extends StubSettings<EchoWithVersionStu
   }
 
   /** Returns the default service endpoint. */
-  @ObsoleteApi(
-      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
+  @ObsoleteApi("Use getEndpoint() instead")
   public static String getDefaultEndpoint() {
     return "localhost:7469";
   }

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/ApiVersionTestingStubSettings.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/ApiVersionTestingStubSettings.golden
@@ -1,6 +1,7 @@
 package com.google.api.version.test.stub;
 
 import com.google.api.core.ApiFunction;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
@@ -91,6 +92,8 @@ public class EchoWithVersionStubSettings extends StubSettings<EchoWithVersionStu
   }
 
   /** Returns the default service endpoint. */
+  @ObsoleteApi(
+      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
   public static String getDefaultEndpoint() {
     return "localhost:7469";
   }

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/DeprecatedServiceStubSettings.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/DeprecatedServiceStubSettings.golden
@@ -1,6 +1,7 @@
 package com.google.testdata.v1.stub;
 
 import com.google.api.core.ApiFunction;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
@@ -107,6 +108,8 @@ public class DeprecatedServiceStubSettings extends StubSettings<DeprecatedServic
   }
 
   /** Returns the default service endpoint. */
+  @ObsoleteApi(
+      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
   public static String getDefaultEndpoint() {
     return "localhost:7469";
   }

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/DeprecatedServiceStubSettings.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/DeprecatedServiceStubSettings.golden
@@ -108,8 +108,7 @@ public class DeprecatedServiceStubSettings extends StubSettings<DeprecatedServic
   }
 
   /** Returns the default service endpoint. */
-  @ObsoleteApi(
-      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
+  @ObsoleteApi("Use getEndpoint() instead")
   public static String getDefaultEndpoint() {
     return "localhost:7469";
   }

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/EchoStubSettings.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/EchoStubSettings.golden
@@ -6,6 +6,7 @@ import static com.google.showcase.v1beta1.EchoClient.SimplePagedExpandPagedRespo
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.BetaApi;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
@@ -291,6 +292,8 @@ public class EchoStubSettings extends StubSettings<EchoStubSettings> {
   }
 
   /** Returns the default service endpoint. */
+  @ObsoleteApi(
+      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
   public static String getDefaultEndpoint() {
     return "localhost:7469";
   }

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/EchoStubSettings.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/EchoStubSettings.golden
@@ -292,8 +292,7 @@ public class EchoStubSettings extends StubSettings<EchoStubSettings> {
   }
 
   /** Returns the default service endpoint. */
-  @ObsoleteApi(
-      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
+  @ObsoleteApi("Use getEndpoint() instead")
   public static String getDefaultEndpoint() {
     return "localhost:7469";
   }

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/LoggingServiceV2StubSettings.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/LoggingServiceV2StubSettings.golden
@@ -7,6 +7,7 @@ import static com.google.logging.v2.LoggingServiceV2Client.ListMonitoredResource
 import com.google.api.MonitoredResourceDescriptor;
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.batching.BatchingSettings;
 import com.google.api.gax.batching.FlowControlSettings;
 import com.google.api.gax.batching.FlowController;
@@ -433,6 +434,8 @@ public class LoggingServiceV2StubSettings extends StubSettings<LoggingServiceV2S
   }
 
   /** Returns the default service endpoint. */
+  @ObsoleteApi(
+      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
   public static String getDefaultEndpoint() {
     return "logging.googleapis.com:443";
   }

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/LoggingServiceV2StubSettings.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/LoggingServiceV2StubSettings.golden
@@ -434,8 +434,7 @@ public class LoggingServiceV2StubSettings extends StubSettings<LoggingServiceV2S
   }
 
   /** Returns the default service endpoint. */
-  @ObsoleteApi(
-      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
+  @ObsoleteApi("Use getEndpoint() instead")
   public static String getDefaultEndpoint() {
     return "logging.googleapis.com:443";
   }

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/PublisherStubSettings.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/PublisherStubSettings.golden
@@ -443,8 +443,7 @@ public class PublisherStubSettings extends StubSettings<PublisherStubSettings> {
   }
 
   /** Returns the default service endpoint. */
-  @ObsoleteApi(
-      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
+  @ObsoleteApi("Use getEndpoint() instead")
   public static String getDefaultEndpoint() {
     return "pubsub.googleapis.com:443";
   }

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/PublisherStubSettings.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/PublisherStubSettings.golden
@@ -6,6 +6,7 @@ import static com.google.pubsub.v1.PublisherClient.ListTopicsPagedResponse;
 
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.batching.BatchingSettings;
 import com.google.api.gax.batching.FlowControlSettings;
 import com.google.api.gax.batching.FlowController;
@@ -442,6 +443,8 @@ public class PublisherStubSettings extends StubSettings<PublisherStubSettings> {
   }
 
   /** Returns the default service endpoint. */
+  @ObsoleteApi(
+      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
   public static String getDefaultEndpoint() {
     return "pubsub.googleapis.com:443";
   }

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoStubSettings.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoStubSettings.golden
@@ -308,8 +308,7 @@ public class EchoStubSettings extends StubSettings<EchoStubSettings> {
   }
 
   /** Returns the default service endpoint. */
-  @ObsoleteApi(
-      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
+  @ObsoleteApi("Use getEndpoint() instead")
   public static String getDefaultEndpoint() {
     return "localhost:7469";
   }

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoStubSettings.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoStubSettings.golden
@@ -6,6 +6,7 @@ import static com.google.showcase.grpcrest.v1beta1.EchoClient.SimplePagedExpandP
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.BetaApi;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
@@ -307,6 +308,8 @@ public class EchoStubSettings extends StubSettings<EchoStubSettings> {
   }
 
   /** Returns the default service endpoint. */
+  @ObsoleteApi(
+      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
   public static String getDefaultEndpoint() {
     return "localhost:7469";
   }

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/WickedStubSettings.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/WickedStubSettings.golden
@@ -106,8 +106,7 @@ public class WickedStubSettings extends StubSettings<WickedStubSettings> {
   }
 
   /** Returns the default service endpoint. */
-  @ObsoleteApi(
-      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
+  @ObsoleteApi("Use getEndpoint() instead")
   public static String getDefaultEndpoint() {
     return "localhost:7469";
   }

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/WickedStubSettings.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/WickedStubSettings.golden
@@ -2,6 +2,7 @@ package com.google.showcase.v1beta1.stub;
 
 import com.google.api.core.ApiFunction;
 import com.google.api.core.BetaApi;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
@@ -105,6 +106,8 @@ public class WickedStubSettings extends StubSettings<WickedStubSettings> {
   }
 
   /** Returns the default service endpoint. */
+  @ObsoleteApi(
+      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
   public static String getDefaultEndpoint() {
     return "localhost:7469";
   }

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/ComplianceStubSettings.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/ComplianceStubSettings.golden
@@ -2,6 +2,7 @@ package com.google.showcase.v1beta1.stub;
 
 import com.google.api.core.ApiFunction;
 import com.google.api.core.BetaApi;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
@@ -137,6 +138,8 @@ public class ComplianceStubSettings extends StubSettings<ComplianceStubSettings>
   }
 
   /** Returns the default service endpoint. */
+  @ObsoleteApi(
+      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
   public static String getDefaultEndpoint() {
     return "localhost:7469";
   }

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/ComplianceStubSettings.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/ComplianceStubSettings.golden
@@ -138,8 +138,7 @@ public class ComplianceStubSettings extends StubSettings<ComplianceStubSettings>
   }
 
   /** Returns the default service endpoint. */
-  @ObsoleteApi(
-      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
+  @ObsoleteApi("Use getEndpoint() instead")
   public static String getDefaultEndpoint() {
     return "localhost:7469";
   }

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonApiVersionTestingStubSettings.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonApiVersionTestingStubSettings.golden
@@ -92,8 +92,7 @@ public class EchoWithVersionStubSettings extends StubSettings<EchoWithVersionStu
   }
 
   /** Returns the default service endpoint. */
-  @ObsoleteApi(
-      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
+  @ObsoleteApi("Use getEndpoint() instead")
   public static String getDefaultEndpoint() {
     return "localhost:7469";
   }

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonApiVersionTestingStubSettings.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonApiVersionTestingStubSettings.golden
@@ -1,6 +1,7 @@
 package com.google.api.version.test.stub;
 
 import com.google.api.core.ApiFunction;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
@@ -91,6 +92,8 @@ public class EchoWithVersionStubSettings extends StubSettings<EchoWithVersionStu
   }
 
   /** Returns the default service endpoint. */
+  @ObsoleteApi(
+      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
   public static String getDefaultEndpoint() {
     return "localhost:7469";
   }

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/ComplianceStubSettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/ComplianceStubSettings.java
@@ -280,8 +280,7 @@ public class ComplianceStubSettings extends StubSettings<ComplianceStubSettings>
   }
 
   /** Returns the default service endpoint. */
-  @ObsoleteApi(
-      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
+  @ObsoleteApi("Use getEndpoint() instead")
   public static String getDefaultEndpoint() {
     return "localhost:7469";
   }

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/ComplianceStubSettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/ComplianceStubSettings.java
@@ -21,6 +21,7 @@ import static com.google.showcase.v1beta1.ComplianceClient.ListLocationsPagedRes
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.BetaApi;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
@@ -279,6 +280,8 @@ public class ComplianceStubSettings extends StubSettings<ComplianceStubSettings>
   }
 
   /** Returns the default service endpoint. */
+  @ObsoleteApi(
+      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
   public static String getDefaultEndpoint() {
     return "localhost:7469";
   }

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/EchoStubSettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/EchoStubSettings.java
@@ -23,6 +23,7 @@ import static com.google.showcase.v1beta1.EchoClient.PagedExpandPagedResponse;
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.BetaApi;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
@@ -438,6 +439,8 @@ public class EchoStubSettings extends StubSettings<EchoStubSettings> {
   }
 
   /** Returns the default service endpoint. */
+  @ObsoleteApi(
+      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
   public static String getDefaultEndpoint() {
     return "localhost:7469";
   }

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/EchoStubSettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/EchoStubSettings.java
@@ -439,8 +439,7 @@ public class EchoStubSettings extends StubSettings<EchoStubSettings> {
   }
 
   /** Returns the default service endpoint. */
-  @ObsoleteApi(
-      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
+  @ObsoleteApi("Use getEndpoint() instead")
   public static String getDefaultEndpoint() {
     return "localhost:7469";
   }

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/IdentityStubSettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/IdentityStubSettings.java
@@ -310,8 +310,7 @@ public class IdentityStubSettings extends StubSettings<IdentityStubSettings> {
   }
 
   /** Returns the default service endpoint. */
-  @ObsoleteApi(
-      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
+  @ObsoleteApi("Use getEndpoint() instead")
   public static String getDefaultEndpoint() {
     return "localhost:7469";
   }

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/IdentityStubSettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/IdentityStubSettings.java
@@ -22,6 +22,7 @@ import static com.google.showcase.v1beta1.IdentityClient.ListUsersPagedResponse;
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.BetaApi;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
@@ -309,6 +310,8 @@ public class IdentityStubSettings extends StubSettings<IdentityStubSettings> {
   }
 
   /** Returns the default service endpoint. */
+  @ObsoleteApi(
+      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
   public static String getDefaultEndpoint() {
     return "localhost:7469";
   }

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/MessagingStubSettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/MessagingStubSettings.java
@@ -23,6 +23,7 @@ import static com.google.showcase.v1beta1.MessagingClient.ListRoomsPagedResponse
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.BetaApi;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
@@ -451,6 +452,8 @@ public class MessagingStubSettings extends StubSettings<MessagingStubSettings> {
   }
 
   /** Returns the default service endpoint. */
+  @ObsoleteApi(
+      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
   public static String getDefaultEndpoint() {
     return "localhost:7469";
   }

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/MessagingStubSettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/MessagingStubSettings.java
@@ -452,8 +452,7 @@ public class MessagingStubSettings extends StubSettings<MessagingStubSettings> {
   }
 
   /** Returns the default service endpoint. */
-  @ObsoleteApi(
-      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
+  @ObsoleteApi("Use getEndpoint() instead")
   public static String getDefaultEndpoint() {
     return "localhost:7469";
   }

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/SequenceServiceStubSettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/SequenceServiceStubSettings.java
@@ -275,8 +275,7 @@ public class SequenceServiceStubSettings extends StubSettings<SequenceServiceStu
   }
 
   /** Returns the default service endpoint. */
-  @ObsoleteApi(
-      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
+  @ObsoleteApi("Use getEndpoint() instead")
   public static String getDefaultEndpoint() {
     return "localhost:7469";
   }

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/SequenceServiceStubSettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/SequenceServiceStubSettings.java
@@ -21,6 +21,7 @@ import static com.google.showcase.v1beta1.SequenceServiceClient.ListLocationsPag
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.BetaApi;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
@@ -274,6 +275,8 @@ public class SequenceServiceStubSettings extends StubSettings<SequenceServiceStu
   }
 
   /** Returns the default service endpoint. */
+  @ObsoleteApi(
+      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
   public static String getDefaultEndpoint() {
     return "localhost:7469";
   }

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/TestingStubSettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/TestingStubSettings.java
@@ -392,8 +392,7 @@ public class TestingStubSettings extends StubSettings<TestingStubSettings> {
   }
 
   /** Returns the default service endpoint. */
-  @ObsoleteApi(
-      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
+  @ObsoleteApi("Use getEndpoint() instead")
   public static String getDefaultEndpoint() {
     return "localhost:7469";
   }

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/TestingStubSettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/TestingStubSettings.java
@@ -23,6 +23,7 @@ import static com.google.showcase.v1beta1.TestingClient.ListTestsPagedResponse;
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.BetaApi;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
@@ -391,6 +392,8 @@ public class TestingStubSettings extends StubSettings<TestingStubSettings> {
   }
 
   /** Returns the default service endpoint. */
+  @ObsoleteApi(
+      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
   public static String getDefaultEndpoint() {
     return "localhost:7469";
   }

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/ConnectionServiceStubSettings.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/ConnectionServiceStubSettings.java
@@ -21,6 +21,7 @@ import static com.google.cloud.apigeeconnect.v1.ConnectionServiceClient.ListConn
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.BetaApi;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
@@ -194,6 +195,8 @@ public class ConnectionServiceStubSettings extends StubSettings<ConnectionServic
   }
 
   /** Returns the default service endpoint. */
+  @ObsoleteApi(
+      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
   public static String getDefaultEndpoint() {
     return "apigeeconnect.googleapis.com:443";
   }

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/ConnectionServiceStubSettings.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/ConnectionServiceStubSettings.java
@@ -195,8 +195,7 @@ public class ConnectionServiceStubSettings extends StubSettings<ConnectionServic
   }
 
   /** Returns the default service endpoint. */
-  @ObsoleteApi(
-      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
+  @ObsoleteApi("Use getEndpoint() instead")
   public static String getDefaultEndpoint() {
     return "apigeeconnect.googleapis.com:443";
   }

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/TetherStubSettings.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/TetherStubSettings.java
@@ -17,6 +17,7 @@
 package com.google.cloud.apigeeconnect.v1.stub;
 
 import com.google.api.core.ApiFunction;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
@@ -113,6 +114,8 @@ public class TetherStubSettings extends StubSettings<TetherStubSettings> {
   }
 
   /** Returns the default service endpoint. */
+  @ObsoleteApi(
+      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
   public static String getDefaultEndpoint() {
     return "apigeeconnect.googleapis.com:443";
   }

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/TetherStubSettings.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/TetherStubSettings.java
@@ -114,8 +114,7 @@ public class TetherStubSettings extends StubSettings<TetherStubSettings> {
   }
 
   /** Returns the default service endpoint. */
-  @ObsoleteApi(
-      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
+  @ObsoleteApi("Use getEndpoint() instead")
   public static String getDefaultEndpoint() {
     return "apigeeconnect.googleapis.com:443";
   }

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/AssetServiceStubSettings.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/AssetServiceStubSettings.java
@@ -24,6 +24,7 @@ import static com.google.cloud.asset.v1.AssetServiceClient.SearchAllResourcesPag
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.BetaApi;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
@@ -583,6 +584,8 @@ public class AssetServiceStubSettings extends StubSettings<AssetServiceStubSetti
   }
 
   /** Returns the default service endpoint. */
+  @ObsoleteApi(
+      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
   public static String getDefaultEndpoint() {
     return "cloudasset.googleapis.com:443";
   }

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/AssetServiceStubSettings.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/AssetServiceStubSettings.java
@@ -584,8 +584,7 @@ public class AssetServiceStubSettings extends StubSettings<AssetServiceStubSetti
   }
 
   /** Returns the default service endpoint. */
-  @ObsoleteApi(
-      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
+  @ObsoleteApi("Use getEndpoint() instead")
   public static String getDefaultEndpoint() {
     return "cloudasset.googleapis.com:443";
   }

--- a/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/stub/BigtableStubSettings.java
+++ b/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/stub/BigtableStubSettings.java
@@ -17,6 +17,7 @@
 package com.google.cloud.bigtable.data.v2.stub;
 
 import com.google.api.core.ApiFunction;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
@@ -177,6 +178,8 @@ public class BigtableStubSettings extends StubSettings<BigtableStubSettings> {
   }
 
   /** Returns the default service endpoint. */
+  @ObsoleteApi(
+      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
   public static String getDefaultEndpoint() {
     return "bigtable.googleapis.com:443";
   }

--- a/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/stub/BigtableStubSettings.java
+++ b/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/stub/BigtableStubSettings.java
@@ -178,8 +178,7 @@ public class BigtableStubSettings extends StubSettings<BigtableStubSettings> {
   }
 
   /** Returns the default service endpoint. */
-  @ObsoleteApi(
-      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
+  @ObsoleteApi("Use getEndpoint() instead")
   public static String getDefaultEndpoint() {
     return "bigtable.googleapis.com:443";
   }

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/AddressesStubSettings.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/AddressesStubSettings.java
@@ -21,6 +21,7 @@ import static com.google.cloud.compute.v1small.AddressesClient.ListPagedResponse
 
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
@@ -300,6 +301,8 @@ public class AddressesStubSettings extends StubSettings<AddressesStubSettings> {
   }
 
   /** Returns the default service endpoint. */
+  @ObsoleteApi(
+      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
   public static String getDefaultEndpoint() {
     return "compute.googleapis.com:443";
   }

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/AddressesStubSettings.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/AddressesStubSettings.java
@@ -301,8 +301,7 @@ public class AddressesStubSettings extends StubSettings<AddressesStubSettings> {
   }
 
   /** Returns the default service endpoint. */
-  @ObsoleteApi(
-      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
+  @ObsoleteApi("Use getEndpoint() instead")
   public static String getDefaultEndpoint() {
     return "compute.googleapis.com:443";
   }

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/RegionOperationsStubSettings.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/RegionOperationsStubSettings.java
@@ -17,6 +17,7 @@
 package com.google.cloud.compute.v1small.stub;
 
 import com.google.api.core.ApiFunction;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
@@ -125,6 +126,8 @@ public class RegionOperationsStubSettings extends StubSettings<RegionOperationsS
   }
 
   /** Returns the default service endpoint. */
+  @ObsoleteApi(
+      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
   public static String getDefaultEndpoint() {
     return "compute.googleapis.com:443";
   }

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/RegionOperationsStubSettings.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/RegionOperationsStubSettings.java
@@ -126,8 +126,7 @@ public class RegionOperationsStubSettings extends StubSettings<RegionOperationsS
   }
 
   /** Returns the default service endpoint. */
-  @ObsoleteApi(
-      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
+  @ObsoleteApi("Use getEndpoint() instead")
   public static String getDefaultEndpoint() {
     return "compute.googleapis.com:443";
   }

--- a/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/IamCredentialsStubSettings.java
+++ b/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/IamCredentialsStubSettings.java
@@ -153,8 +153,7 @@ public class IamCredentialsStubSettings extends StubSettings<IamCredentialsStubS
   }
 
   /** Returns the default service endpoint. */
-  @ObsoleteApi(
-      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
+  @ObsoleteApi("Use getEndpoint() instead")
   public static String getDefaultEndpoint() {
     return "iamcredentials.googleapis.com:443";
   }

--- a/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/IamCredentialsStubSettings.java
+++ b/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/IamCredentialsStubSettings.java
@@ -18,6 +18,7 @@ package com.google.cloud.iam.credentials.v1.stub;
 
 import com.google.api.core.ApiFunction;
 import com.google.api.core.BetaApi;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
@@ -152,6 +153,8 @@ public class IamCredentialsStubSettings extends StubSettings<IamCredentialsStubS
   }
 
   /** Returns the default service endpoint. */
+  @ObsoleteApi(
+      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
   public static String getDefaultEndpoint() {
     return "iamcredentials.googleapis.com:443";
   }

--- a/test/integration/goldens/iam/src/com/google/iam/v1/stub/IAMPolicyStubSettings.java
+++ b/test/integration/goldens/iam/src/com/google/iam/v1/stub/IAMPolicyStubSettings.java
@@ -131,8 +131,7 @@ public class IAMPolicyStubSettings extends StubSettings<IAMPolicyStubSettings> {
   }
 
   /** Returns the default service endpoint. */
-  @ObsoleteApi(
-      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
+  @ObsoleteApi("Use getEndpoint() instead")
   public static String getDefaultEndpoint() {
     return "iam-meta-api.googleapis.com:443";
   }

--- a/test/integration/goldens/iam/src/com/google/iam/v1/stub/IAMPolicyStubSettings.java
+++ b/test/integration/goldens/iam/src/com/google/iam/v1/stub/IAMPolicyStubSettings.java
@@ -17,6 +17,7 @@
 package com.google.iam.v1.stub;
 
 import com.google.api.core.ApiFunction;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
@@ -130,6 +131,8 @@ public class IAMPolicyStubSettings extends StubSettings<IAMPolicyStubSettings> {
   }
 
   /** Returns the default service endpoint. */
+  @ObsoleteApi(
+      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
   public static String getDefaultEndpoint() {
     return "iam-meta-api.googleapis.com:443";
   }

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/stub/KeyManagementServiceStubSettings.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/stub/KeyManagementServiceStubSettings.java
@@ -651,8 +651,7 @@ public class KeyManagementServiceStubSettings
   }
 
   /** Returns the default service endpoint. */
-  @ObsoleteApi(
-      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
+  @ObsoleteApi("Use getEndpoint() instead")
   public static String getDefaultEndpoint() {
     return "cloudkms.googleapis.com:443";
   }

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/stub/KeyManagementServiceStubSettings.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/stub/KeyManagementServiceStubSettings.java
@@ -24,6 +24,7 @@ import static com.google.cloud.kms.v1.KeyManagementServiceClient.ListLocationsPa
 
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
@@ -650,6 +651,8 @@ public class KeyManagementServiceStubSettings
   }
 
   /** Returns the default service endpoint. */
+  @ObsoleteApi(
+      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
   public static String getDefaultEndpoint() {
     return "cloudkms.googleapis.com:443";
   }

--- a/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/LibraryServiceStubSettings.java
+++ b/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/LibraryServiceStubSettings.java
@@ -319,8 +319,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
   }
 
   /** Returns the default service endpoint. */
-  @ObsoleteApi(
-      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
+  @ObsoleteApi("Use getEndpoint() instead")
   public static String getDefaultEndpoint() {
     return "library-example.googleapis.com:443";
   }

--- a/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/LibraryServiceStubSettings.java
+++ b/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/LibraryServiceStubSettings.java
@@ -22,6 +22,7 @@ import static com.google.cloud.example.library.v1.LibraryServiceClient.ListShelv
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.BetaApi;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
@@ -318,6 +319,8 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
   }
 
   /** Returns the default service endpoint. */
+  @ObsoleteApi(
+      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
   public static String getDefaultEndpoint() {
     return "library-example.googleapis.com:443";
   }

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/ConfigServiceV2StubSettings.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/ConfigServiceV2StubSettings.java
@@ -23,6 +23,7 @@ import static com.google.cloud.logging.v2.ConfigClient.ListViewsPagedResponse;
 
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
@@ -558,6 +559,8 @@ public class ConfigServiceV2StubSettings extends StubSettings<ConfigServiceV2Stu
   }
 
   /** Returns the default service endpoint. */
+  @ObsoleteApi(
+      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
   public static String getDefaultEndpoint() {
     return "logging.googleapis.com:443";
   }

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/ConfigServiceV2StubSettings.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/ConfigServiceV2StubSettings.java
@@ -559,8 +559,7 @@ public class ConfigServiceV2StubSettings extends StubSettings<ConfigServiceV2Stu
   }
 
   /** Returns the default service endpoint. */
-  @ObsoleteApi(
-      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
+  @ObsoleteApi("Use getEndpoint() instead")
   public static String getDefaultEndpoint() {
     return "logging.googleapis.com:443";
   }

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/LoggingServiceV2StubSettings.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/LoggingServiceV2StubSettings.java
@@ -23,6 +23,7 @@ import static com.google.cloud.logging.v2.LoggingClient.ListMonitoredResourceDes
 import com.google.api.MonitoredResourceDescriptor;
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.batching.BatchingSettings;
 import com.google.api.gax.batching.FlowControlSettings;
 import com.google.api.gax.batching.FlowController;
@@ -449,6 +450,8 @@ public class LoggingServiceV2StubSettings extends StubSettings<LoggingServiceV2S
   }
 
   /** Returns the default service endpoint. */
+  @ObsoleteApi(
+      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
   public static String getDefaultEndpoint() {
     return "logging.googleapis.com:443";
   }

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/LoggingServiceV2StubSettings.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/LoggingServiceV2StubSettings.java
@@ -450,8 +450,7 @@ public class LoggingServiceV2StubSettings extends StubSettings<LoggingServiceV2S
   }
 
   /** Returns the default service endpoint. */
-  @ObsoleteApi(
-      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
+  @ObsoleteApi("Use getEndpoint() instead")
   public static String getDefaultEndpoint() {
     return "logging.googleapis.com:443";
   }

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/MetricsServiceV2StubSettings.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/MetricsServiceV2StubSettings.java
@@ -20,6 +20,7 @@ import static com.google.cloud.logging.v2.MetricsClient.ListLogMetricsPagedRespo
 
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
@@ -217,6 +218,8 @@ public class MetricsServiceV2StubSettings extends StubSettings<MetricsServiceV2S
   }
 
   /** Returns the default service endpoint. */
+  @ObsoleteApi(
+      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
   public static String getDefaultEndpoint() {
     return "logging.googleapis.com:443";
   }

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/MetricsServiceV2StubSettings.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/MetricsServiceV2StubSettings.java
@@ -218,8 +218,7 @@ public class MetricsServiceV2StubSettings extends StubSettings<MetricsServiceV2S
   }
 
   /** Returns the default service endpoint. */
-  @ObsoleteApi(
-      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
+  @ObsoleteApi("Use getEndpoint() instead")
   public static String getDefaultEndpoint() {
     return "logging.googleapis.com:443";
   }

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/PublisherStubSettings.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/PublisherStubSettings.java
@@ -484,8 +484,7 @@ public class PublisherStubSettings extends StubSettings<PublisherStubSettings> {
   }
 
   /** Returns the default service endpoint. */
-  @ObsoleteApi(
-      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
+  @ObsoleteApi("Use getEndpoint() instead")
   public static String getDefaultEndpoint() {
     return "pubsub.googleapis.com:443";
   }

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/PublisherStubSettings.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/PublisherStubSettings.java
@@ -22,6 +22,7 @@ import static com.google.cloud.pubsub.v1.TopicAdminClient.ListTopicsPagedRespons
 
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.batching.BatchingSettings;
 import com.google.api.gax.batching.FlowControlSettings;
 import com.google.api.gax.batching.FlowController;
@@ -483,6 +484,8 @@ public class PublisherStubSettings extends StubSettings<PublisherStubSettings> {
   }
 
   /** Returns the default service endpoint. */
+  @ObsoleteApi(
+      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
   public static String getDefaultEndpoint() {
     return "pubsub.googleapis.com:443";
   }

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/SchemaServiceStubSettings.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/SchemaServiceStubSettings.java
@@ -343,8 +343,7 @@ public class SchemaServiceStubSettings extends StubSettings<SchemaServiceStubSet
   }
 
   /** Returns the default service endpoint. */
-  @ObsoleteApi(
-      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
+  @ObsoleteApi("Use getEndpoint() instead")
   public static String getDefaultEndpoint() {
     return "pubsub.googleapis.com:443";
   }

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/SchemaServiceStubSettings.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/SchemaServiceStubSettings.java
@@ -21,6 +21,7 @@ import static com.google.cloud.pubsub.v1.SchemaServiceClient.ListSchemasPagedRes
 
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
@@ -342,6 +343,8 @@ public class SchemaServiceStubSettings extends StubSettings<SchemaServiceStubSet
   }
 
   /** Returns the default service endpoint. */
+  @ObsoleteApi(
+      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
   public static String getDefaultEndpoint() {
     return "pubsub.googleapis.com:443";
   }

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/SubscriberStubSettings.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/SubscriberStubSettings.java
@@ -389,8 +389,7 @@ public class SubscriberStubSettings extends StubSettings<SubscriberStubSettings>
   }
 
   /** Returns the default service endpoint. */
-  @ObsoleteApi(
-      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
+  @ObsoleteApi("Use getEndpoint() instead")
   public static String getDefaultEndpoint() {
     return "pubsub.googleapis.com:443";
   }

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/SubscriberStubSettings.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/SubscriberStubSettings.java
@@ -21,6 +21,7 @@ import static com.google.cloud.pubsub.v1.SubscriptionAdminClient.ListSubscriptio
 
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
@@ -388,6 +389,8 @@ public class SubscriberStubSettings extends StubSettings<SubscriberStubSettings>
   }
 
   /** Returns the default service endpoint. */
+  @ObsoleteApi(
+      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
   public static String getDefaultEndpoint() {
     return "pubsub.googleapis.com:443";
   }

--- a/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/CloudRedisStubSettings.java
+++ b/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/CloudRedisStubSettings.java
@@ -336,8 +336,7 @@ public class CloudRedisStubSettings extends StubSettings<CloudRedisStubSettings>
   }
 
   /** Returns the default service endpoint. */
-  @ObsoleteApi(
-      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
+  @ObsoleteApi("Use getEndpoint() instead")
   public static String getDefaultEndpoint() {
     return "redis.googleapis.com:443";
   }

--- a/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/CloudRedisStubSettings.java
+++ b/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/CloudRedisStubSettings.java
@@ -21,6 +21,7 @@ import static com.google.cloud.redis.v1beta1.CloudRedisClient.ListInstancesPaged
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.BetaApi;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
@@ -335,6 +336,8 @@ public class CloudRedisStubSettings extends StubSettings<CloudRedisStubSettings>
   }
 
   /** Returns the default service endpoint. */
+  @ObsoleteApi(
+      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
   public static String getDefaultEndpoint() {
     return "redis.googleapis.com:443";
   }

--- a/test/integration/goldens/storage/src/com/google/storage/v2/stub/StorageStubSettings.java
+++ b/test/integration/goldens/storage/src/com/google/storage/v2/stub/StorageStubSettings.java
@@ -601,8 +601,7 @@ public class StorageStubSettings extends StubSettings<StorageStubSettings> {
   }
 
   /** Returns the default service endpoint. */
-  @ObsoleteApi(
-      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
+  @ObsoleteApi("Use getEndpoint() instead")
   public static String getDefaultEndpoint() {
     return "storage.googleapis.com:443";
   }

--- a/test/integration/goldens/storage/src/com/google/storage/v2/stub/StorageStubSettings.java
+++ b/test/integration/goldens/storage/src/com/google/storage/v2/stub/StorageStubSettings.java
@@ -23,6 +23,7 @@ import static com.google.storage.v2.StorageClient.ListObjectsPagedResponse;
 
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
@@ -600,6 +601,8 @@ public class StorageStubSettings extends StubSettings<StorageStubSettings> {
   }
 
   /** Returns the default service endpoint. */
+  @ObsoleteApi(
+      "See https://github.com/googleapis/sdk-platform-java/issues/2346 for more information")
   public static String getDefaultEndpoint() {
     return "storage.googleapis.com:443";
   }


### PR DESCRIPTION
Client libraries no longer always use the default endpoint. The resolved endpoint will be determined by the EndpointContext and used by the client.