### PR TITLE
chore: fix release-please-config json extra files parameter

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,24 @@
   "group-pull-request-title-pattern": "chore(${branch}): release ${version}",
   "packages": {
     ".": {
-      "extra-files": ["WORKSPACE", ".cloudbuild/cloudbuild.yaml", ".cloudbuild/cloudbuild-test-a.yaml", ".cloudbuild/cloudbuild-test-b.yaml"]
+      "extra-files": [
+        "WORKSPACE",
+        {
+          "type": "yaml",
+          "path": ".cloudbuild/cloudbuild.yaml",
+          "jsonpath": "$.substitutions._SHARED_DEPENDENCIES_VERSION"
+        },
+        {
+          "type": "yaml",
+          "path": ".cloudbuild/cloudbuild-test-a.yaml",
+          "jsonpath": "$.substitutions._SHARED_DEPENDENCIES_VERSION"
+        },
+        {
+          "type": "yaml",
+          "path": ".cloudbuild/cloudbuild-test-b.yaml",
+          "jsonpath": "$.substitutions._SHARED_DEPENDENCIES_VERSION"
+        }
+      ]
     }
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,7 @@
   "group-pull-request-title-pattern": "chore(${branch}): release ${version}",
   "packages": {
     ".": {
-      "extraFiles": ["WORKSPACE"]
+      "extra-files": ["WORKSPACE", ".cloudbuild/cloudbuild.yaml", ".cloudbuild/cloudbuild-test-a.yaml", ".cloudbuild/cloudbuild-test-b.yaml"]
     }
   }
 }


### PR DESCRIPTION
For https://github.com/googleapis/sdk-platform-java/issues/2338 and https://github.com/googleapis/sdk-platform-java/pull/2339

Adjusting parameter format to follow https://github.com/googleapis/release-please/blob/main/docs/customizing.md#updating-arbitrary-files 

Example of `extra-files` usage: https://github.com/googleapis/java-cloud-bom/blob/17c18f1ec0c92ba51a77ab8e9f3c6189412ecea2/release-please-config.json#L8