### PR TITLE
fix: adjust release-please configs for cloudbuild yaml updates

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,24 +5,7 @@
   "group-pull-request-title-pattern": "chore(${branch}): release ${version}",
   "packages": {
     ".": {
-      "extra-files": [
-        "WORKSPACE",
-        {
-          "type": "yaml",
-          "path": ".cloudbuild/cloudbuild.yaml",
-          "jsonpath": "$.substitutions._SHARED_DEPENDENCIES_VERSION"
-        },
-        {
-          "type": "yaml",
-          "path": ".cloudbuild/cloudbuild-test-a.yaml",
-          "jsonpath": "$.substitutions._SHARED_DEPENDENCIES_VERSION"
-        },
-        {
-          "type": "yaml",
-          "path": ".cloudbuild/cloudbuild-test-b.yaml",
-          "jsonpath": "$.substitutions._SHARED_DEPENDENCIES_VERSION"
-        }
-      ]
+      "extra-files": ["WORKSPACE", ".cloudbuild/cloudbuild.yaml", ".cloudbuild/cloudbuild-test-a.yaml", ".cloudbuild/cloudbuild-test-b.yaml"]
     }
   }
 }


### PR DESCRIPTION
Following the `Update arbitrary yaml file` strategy is resulting in release-please making unexpected changes to the cloudbuild yaml files. See #2350.  

Modifying release-please configs to follow `Update arbitrary file` strategy combined with inline annotations as described in https://github.com/googleapis/release-please/blob/main/docs/customizing.md#updating-arbitrary-files: 
![Screenshot 2024-01-09 at 1 19 08 PM](https://github.com/googleapis/sdk-platform-java/assets/66699525/80250a9f-bb61-404d-b3e3-2913f99745ac)
