### PR TITLE
chore: change regex in check

### DIFF
--- a/java-shared-dependencies/unmanaged-dependency-check/src/main/java/com/google/cloud/UnmanagedDependencyCheck.java
+++ b/java-shared-dependencies/unmanaged-dependency-check/src/main/java/com/google/cloud/UnmanagedDependencyCheck.java
@@ -19,7 +19,7 @@ import org.eclipse.aether.version.InvalidVersionSpecificationException;
  */
 public class UnmanagedDependencyCheck {
   // regex of handwritten artifacts
-  private final static String downstreamArtifact = "(com.google.cloud:google-cloud-.*)|(com.google.api.grpc:(grpc|proto)-google-cloud-.*)";
+  private final static String downstreamArtifact = "(com.google.cloud:google-.*)|(com.google.api.grpc:(grpc|proto)-google-.*)";
 
 
   /**


### PR DESCRIPTION
In this PR:
- change regex in unmanaged dependency check. The check failed in google-cloud-java so we need to change the regex to allow dependencies like `com.google.cloud:google-xxx` and `com.google.api.grpc:(grpc|proto)-google-xxx`
```
This pull request seems to add new third-party dependency, [com.google.cloud:google-identity-accesscontextmanager, com.google.api.grpc:proto-google-iam-admin-v1, com.google.analytics:google-analytics-data, com.google.api.grpc:proto-google-identity-accesscontextmanager-type, io.grafeas:grafeas, com.google.api.grpc:grpc-google-identity-accesscontextmanager-v1, com.google.api.grpc:grpc-google-analytics-data-v1alpha, com.google.api.grpc:grpc-google-analytics-admin-v1alpha, com.google.api.grpc:proto-google-apps-script-type-protos, com.google.apis:google-api-services-cloudresourcemanager, com.google.api.grpc:proto-google-analytics-admin-v1alpha, com.google.analytics:google-analytics-admin, com.google.api.grpc:proto-google-identity-accesscontextmanager-v1, com.google.cloud:google-iam-policy, com.google.api.grpc:grpc-google-analytics-admin-v1beta, com.google.api.grpc:grpc-google-analytics-data-v1beta, com.google.area120:google-area120-tables, com.google.apis:google-api-services-translate, com.google.api.grpc:proto-google-analytics-data-v1beta, com.google.api.grpc:grpc-google-iam-admin-v1, com.google.api.grpc:gapic-google-cloud-storage-v2, com.google.apis:google-api-services-dns, com.google.api.grpc:grpc-google-area120-tables-v1alpha1, com.google.apis:google-api-services-storage, com.google.cloud:google-iam-admin, com.google.api.grpc:proto-google-analytics-admin-v1beta, com.google.api.grpc:proto-google-devtools-source-protos, com.google.api.grpc:proto-google-analytics-data-v1alpha, com.google.api.grpc:proto-google-area120-tables-v1alpha1], among the artifacts listed in gapic-libraries-bom/pom.xml.
```
Full log: https://github.com/googleapis/google-cloud-java/actions/runs/7560283873/job/20585945957?pr=10231