### PR TITLE
chore: fix workflow of create additional release tags

### DIFF
--- a/.github/workflows/create_additional_release_tag.yaml
+++ b/.github/workflows/create_additional_release_tag.yaml
@@ -39,5 +39,7 @@ jobs:
         # update the version.
         CHECK_LATEST_TAG="unmanaged-dependencies-check-latest"
         git tag ${CHECK_LATEST_TAG}
-        git push origin -f ${CHECK_LATEST_TAG}
+        # delete the tag in remote repo and push again.
+        git push --delete origin ${CHECK_LATEST_TAG}
+        git push origin ${CHECK_LATEST_TAG}
 


### PR DESCRIPTION
In this PR:
- Try to delete the `unmanaged-dependencies-check-latest` tag in remote repository and push it again.

The workflow of creating additional tags failed after the release:
```
fatal: tag 'unmanaged-dependencies-check-latest' already exists
```
Full log: https://github.com/googleapis/sdk-platform-java/actions/runs/7579063722/job/20642665504