### PR TITLE
chore: add artifacts in gapic bom in allow list

### DIFF
--- a/java-shared-dependencies/unmanaged-dependency-check/src/main/java/com/google/cloud/UnmanagedDependencyCheck.java
+++ b/java-shared-dependencies/unmanaged-dependency-check/src/main/java/com/google/cloud/UnmanagedDependencyCheck.java
@@ -19,13 +19,17 @@ import org.eclipse.aether.version.InvalidVersionSpecificationException;
  */
 public class UnmanagedDependencyCheck {
   // Regex of handwritten artifacts.
-  // There are customized artifacts defined in some handwritten libraries, e.g., firestore and
-  // datastore, add entries in regex to exclude these artifacts.
+  // There are customized artifacts defined in gapic-bom and handwritten libraries,
+  // e.g., firestore and datastore, add entries in regex to exclude these artifacts.
   private final static String downstreamArtifact =
       "(com.google.cloud:google-.*)|"
-          + "(com.google.api.grpc:(grpc|proto)-google-.*)|"
+          + "(com.google.api.grpc:(gapic|grpc|proto)-google-.*)|"
           + "(com.google.cloud:proto-google-cloud-firestore-bundle-.*)|"
-          + "(com.google.cloud.datastore:datastore-.*-proto-client)";
+          + "(com.google.cloud.datastore:datastore-.*-proto-client)|"
+          + "(com.google.analytics:google-analytics-.*)|"
+          + "(com.google.apis:google-api-.*)|"
+          + "(com.google.area120:google-area120-.*)|"
+          + "(io.grafeas:grafeas)";
 
   /**
    * @param args An array with two elements.<p> The first string is the path of Java shared

--- a/java-shared-dependencies/unmanaged-dependency-check/src/test/java/com/google/cloud/UnmanagedDependencyCheckTest.java
+++ b/java-shared-dependencies/unmanaged-dependency-check/src/test/java/com/google/cloud/UnmanagedDependencyCheckTest.java
@@ -20,7 +20,7 @@ public class UnmanagedDependencyCheckTest {
   }
 
   @Test
-  public void getUnmanagedDependencyFromHWBomTest()
+  public void getUnmanagedDependencyFromGapicAndHandwrittenBomTest()
       throws MavenRepositoryException, InvalidVersionSpecificationException {
     List<String> unManagedDependencies =
         UnmanagedDependencyCheck.getUnmanagedDependencies(

--- a/java-shared-dependencies/unmanaged-dependency-check/src/test/resources/google-internal-artifact-test-case-pom.xml
+++ b/java-shared-dependencies/unmanaged-dependency-check/src/test/resources/google-internal-artifact-test-case-pom.xml
@@ -55,6 +55,13 @@
           <scope>import</scope>
           <type>pom</type>
         </dependency>
+        <dependency>
+          <groupId>com.google.cloud</groupId>
+          <artifactId>gapic-libraries-bom</artifactId>
+          <version>1.23.0</version>
+          <scope>import</scope>
+          <type>pom</type>
+        </dependency>
       </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
In this PR:
- Add artifacts in gapic-bom to the allow list of unmanaged dependency check
  - com.google.api.grpc:gapic-google-*
  - com.google.analytics:google-analytics-*
  - com.google.area120:google-area120-*
  - com.google.apis:google-api-*
  - io.grafeas:grafeas

Related check log in google-cloud-java:
```
Running Unmanaged Dependency Check against /home/runner/work/google-cloud-java/google-cloud-java/gapic-libraries-bom/pom.xml
This pull request seems to add new third-party dependency, [com.google.analytics:google-analytics-data, io.grafeas:grafeas, com.google.apis:google-api-services-cloudresourcemanager, com.google.analytics:google-analytics-admin, com.google.area120:google-area120-tables, com.google.apis:google-api-services-translate, com.google.api.grpc:gapic-google-cloud-storage-v2, com.google.apis:google-api-services-dns, com.google.apis:google-api-services-storage], among the artifacts listed in gapic-libraries-bom/pom.xml.
```

Full log: https://github.com/googleapis/google-cloud-java/actions/runs/7560283873/job/20669061714?pr=10231