### PR TITLE
chore: do not include optional dependencies in unmanaged dependency c…

### DIFF
--- a/java-shared-dependencies/unmanaged-dependency-check/src/main/java/com/google/cloud/UnmanagedDependencyCheck.java
+++ b/java-shared-dependencies/unmanaged-dependency-check/src/main/java/com/google/cloud/UnmanagedDependencyCheck.java
@@ -74,7 +74,7 @@ public class UnmanagedDependencyCheck {
       throws InvalidVersionSpecificationException {
     Set<String> res = new HashSet<>();
     new ClassPathBuilder()
-        .resolve(bom.getManagedDependencies(), true, DependencyMediation.MAVEN)
+        .resolve(bom.getManagedDependencies(), false, DependencyMediation.MAVEN)
         .getClassPath()
         .forEach(
             classPath -> {

--- a/java-shared-dependencies/unmanaged-dependency-check/src/test/java/com/google/cloud/UnmanagedDependencyCheckTest.java
+++ b/java-shared-dependencies/unmanaged-dependency-check/src/test/java/com/google/cloud/UnmanagedDependencyCheckTest.java
@@ -13,7 +13,7 @@ public class UnmanagedDependencyCheckTest {
   @Test
   public void getUnmanagedDependencyFromSamePomTest()
       throws MavenRepositoryException, InvalidVersionSpecificationException {
-    String sharedDependenciesBom = "src/test/resources/shared-dependency-3.18.0-pom.xml";
+    String sharedDependenciesBom = "src/test/resources/shared-dependency-pom.xml";
     List<String> unManagedDependencies =
         UnmanagedDependencyCheck.getUnmanagedDependencies(sharedDependenciesBom, sharedDependenciesBom);
     assertTrue(unManagedDependencies.isEmpty());
@@ -24,7 +24,7 @@ public class UnmanagedDependencyCheckTest {
       throws MavenRepositoryException, InvalidVersionSpecificationException {
     List<String> unManagedDependencies =
         UnmanagedDependencyCheck.getUnmanagedDependencies(
-            "src/test/resources/shared-dependency-3.18.0-pom.xml",
+            "src/test/resources/shared-dependency-pom.xml",
             "src/test/resources/google-internal-artifact-test-case-pom.xml");
     assertTrue(unManagedDependencies.isEmpty());
   }
@@ -34,7 +34,7 @@ public class UnmanagedDependencyCheckTest {
       throws MavenRepositoryException, InvalidVersionSpecificationException {
     List<String> unManagedDependencies =
         UnmanagedDependencyCheck.getUnmanagedDependencies(
-            "src/test/resources/shared-dependency-3.18.0-pom.xml", "src/test/resources/transitive-dependency-pom.xml");
+            "src/test/resources/shared-dependency-pom.xml", "src/test/resources/transitive-dependency-pom.xml");
     assertThat(unManagedDependencies)
         .containsAtLeastElementsIn(ImmutableList.of("com.h2database:h2"));
     // test dependency should be ignored.

--- a/java-shared-dependencies/unmanaged-dependency-check/src/test/resources/google-internal-artifact-test-case-pom.xml
+++ b/java-shared-dependencies/unmanaged-dependency-check/src/test/resources/google-internal-artifact-test-case-pom.xml
@@ -55,6 +55,13 @@
           <scope>import</scope>
           <type>pom</type>
         </dependency>
+        <dependency>
+          <groupId>com.google.cloud</groupId>
+          <artifactId>gapic-libraries-bom</artifactId>
+          <version>1.27.0</version>
+          <scope>import</scope>
+          <type>pom</type>
+        </dependency>
       </dependencies>
     </dependencyManagement>
 

--- a/java-shared-dependencies/unmanaged-dependency-check/src/test/resources/google-internal-artifact-test-case-pom.xml
+++ b/java-shared-dependencies/unmanaged-dependency-check/src/test/resources/google-internal-artifact-test-case-pom.xml
@@ -36,7 +36,7 @@
         <dependency>
           <groupId>com.google.cloud</groupId>
           <artifactId>google-cloud-datastore-bom</artifactId>
-          <version>2.17.4</version>
+          <version>2.18.1</version>
           <scope>import</scope>
           <type>pom</type>
         </dependency>
@@ -44,21 +44,14 @@
         <dependency>
           <groupId>com.google.cloud</groupId>
           <artifactId>google-cloud-firestore-bom</artifactId>
-          <version>3.15.2</version>
+          <version>3.16.0</version>
           <scope>import</scope>
           <type>pom</type>
         </dependency>
         <dependency>
           <groupId>com.google.cloud</groupId>
           <artifactId>google-cloud-bigtable-bom</artifactId>
-          <version>2.29.0</version>
-          <scope>import</scope>
-          <type>pom</type>
-        </dependency>
-        <dependency>
-          <groupId>com.google.cloud</groupId>
-          <artifactId>gapic-libraries-bom</artifactId>
-          <version>1.23.0</version>
+          <version>2.31.0</version>
           <scope>import</scope>
           <type>pom</type>
         </dependency>

--- a/java-shared-dependencies/unmanaged-dependency-check/src/test/resources/local-install.sh
+++ b/java-shared-dependencies/unmanaged-dependency-check/src/test/resources/local-install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-mvn install -f shared-dependency--pom.xml
+mvn install -f shared-dependency-pom.xml
 mvn install -f gax-example-pom.xml
 mvn install -f nested-dependency-pom.xml
 mvn install -f transitive-dependency-pom.xml

--- a/java-shared-dependencies/unmanaged-dependency-check/src/test/resources/local-install.sh
+++ b/java-shared-dependencies/unmanaged-dependency-check/src/test/resources/local-install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-mvn install -f shared-dependency-3.18.0-pom.xml
+mvn install -f shared-dependency--pom.xml
 mvn install -f gax-example-pom.xml
 mvn install -f nested-dependency-pom.xml
 mvn install -f transitive-dependency-pom.xml

--- a/java-shared-dependencies/unmanaged-dependency-check/src/test/resources/shared-dependency-pom.xml
+++ b/java-shared-dependencies/unmanaged-dependency-check/src/test/resources/shared-dependency-pom.xml
@@ -1,43 +1,20 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>com.google.cloud</groupId>
-  <artifactId>google-cloud-shared-dependencies</artifactId>
+  <groupId>com.example</groupId>
+  <artifactId>google-cloud-shared-dependencies-test</artifactId>
   <packaging>pom</packaging>
-  <version>3.22.0</version>
-  <modules>
-    <module>first-party-dependencies</module>
-    <module>third-party-dependencies</module>
-  </modules>
+  <version>0.0.1-SNAPSHOT</version>
   <name>Google Cloud Shared Dependencies</name>
   <description>
-    Shared build configuration for Google Cloud Java libraries.
+    Shared build configuration for Google Cloud Java libraries in Tests.
   </description>
-
-  <parent>
-    <groupId>com.google.api</groupId>
-    <artifactId>gapic-generator-java-pom-parent</artifactId>
-    <version>2.32.0</version>
-    <relativePath>../gapic-generator-java-pom-parent</relativePath>
-  </parent>
-
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <site.installationModule>${project.artifactId}</site.installationModule>
-  </properties>
 
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>com.google.cloud</groupId>
-        <artifactId>first-party-dependencies</artifactId>
-        <version>3.22.0</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.google.cloud</groupId>
-        <artifactId>third-party-dependencies</artifactId>
+        <artifactId>google-cloud-shared-dependencies</artifactId>
         <version>3.22.0</version>
         <type>pom</type>
         <scope>import</scope>

--- a/java-shared-dependencies/unmanaged-dependency-check/src/test/resources/shared-dependency-pom.xml
+++ b/java-shared-dependencies/unmanaged-dependency-check/src/test/resources/shared-dependency-pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-shared-dependencies</artifactId>
   <packaging>pom</packaging>
-  <version>3.18.0</version>
+  <version>3.22.0</version>
   <modules>
     <module>first-party-dependencies</module>
     <module>third-party-dependencies</module>

--- a/java-shared-dependencies/unmanaged-dependency-check/src/test/resources/shared-dependency-pom.xml
+++ b/java-shared-dependencies/unmanaged-dependency-check/src/test/resources/shared-dependency-pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>com.google.api</groupId>
     <artifactId>gapic-generator-java-pom-parent</artifactId>
-    <version>2.28.0</version>
+    <version>2.32.0</version>
     <relativePath>../gapic-generator-java-pom-parent</relativePath>
   </parent>
 
@@ -31,14 +31,14 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>first-party-dependencies</artifactId>
-        <version>3.18.0</version>
+        <version>3.22.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>third-party-dependencies</artifactId>
-        <version>3.18.0</version>
+        <version>3.22.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
In this PR:
- Do not include optional dependencies in target BOM.
- Update the unit test to verify newer version of java-bigtable BOM, from which exposed this issue.

Context: the unmanaged dependency check failed on java-bigtable even though no dependency is added (example [PR](https://github.com/googleapis/java-bigtable/pull/2063)). 

The dependencies pointed out by the check is mockito-core and its dependencies (check [log](https://github.com/googleapis/java-bigtable/actions/runs/7612524813/job/20738234669?pr=2063)), which is used in testing and should not be reported by the check.