### PR TITLE
fix: Endpoint resolution uses user set endpoint from ClientSettings

### DIFF
--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
@@ -165,7 +165,7 @@ public abstract class ClientContext {
         EndpointContext.newBuilder()
             .setServiceName(settings.getServiceName())
             .setUniverseDomain(settings.getUniverseDomain())
-            .setClientSettingsEndpoint(settings.getClientEndpoint())
+            .setClientSettingsEndpoint(settings.getUserSetEndpoint())
             .setTransportChannelProviderEndpoint(
                 settings.getTransportChannelProvider().getEndpoint())
             .setMtlsEndpoint(settings.getMtlsEndpoint())

--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
@@ -165,7 +165,7 @@ public abstract class ClientContext {
         EndpointContext.newBuilder()
             .setServiceName(settings.getServiceName())
             .setUniverseDomain(settings.getUniverseDomain())
-            .setClientSettingsEndpoint(settings.getEndpoint())
+            .setClientSettingsEndpoint(settings.getClientEndpoint())
             .setTransportChannelProviderEndpoint(
                 settings.getTransportChannelProvider().getEndpoint())
             .setMtlsEndpoint(settings.getMtlsEndpoint())

--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
@@ -157,6 +157,17 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
     return endpoint;
   }
 
+  /**
+   * This is an internal api meant to either return the user set endpoint or null. The difference
+   * between this method and {@link #getEndpoint()}} is that {@link #getEndpoint()} is reimplemented
+   * by the child class and will return the default service endpoint if the user did not set an
+   * endpoint (does not return null).
+   */
+  @InternalApi
+  String getClientEndpoint() {
+    return endpoint;
+  }
+
   public final String getMtlsEndpoint() {
     return mtlsEndpoint;
   }

--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
@@ -164,7 +164,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
    * endpoint (does not return null).
    */
   @InternalApi
-  String getClientEndpoint() {
+  String getUserSetEndpoint() {
     return endpoint;
   }
 


### PR DESCRIPTION
Add new Internal method `getUserSetEndpoint()` that returns the user set endpoint from ClientSettings or null otherwise.

This is used as part of endpoint resolution to determine the proper endpoint.