### PR TITLE
test: increase timeout testCancelOuterFutureAfterStart to 60s

### DIFF
--- a/gax-java/gax/src/test/java/com/google/api/gax/retrying/ScheduledRetryingExecutorTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/retrying/ScheduledRetryingExecutorTest.java
@@ -48,7 +48,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-
 import org.junit.After;
 import org.junit.Test;
 import org.mockito.Mockito;

--- a/gax-java/gax/src/test/java/com/google/api/gax/retrying/ScheduledRetryingExecutorTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/retrying/ScheduledRetryingExecutorTest.java
@@ -48,6 +48,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+
 import org.junit.After;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -262,11 +263,11 @@ public class ScheduledRetryingExecutorTest extends AbstractRetryingExecutorTest 
             .setInitialRetryDelay(Duration.ofMillis(25L))
             .setMaxRetryDelay(Duration.ofMillis(1000L))
             .setRetryDelayMultiplier(4.0)
-            .setTotalTimeout(Duration.ofMillis(2000L))
+            .setTotalTimeout(Duration.ofMillis(60000L))
             // Set this test to not use jitter as the randomized retry delay (RRD) may introduce
             // flaky results. For example, if every RRD value is calculated to be a small value
             // (i.e. 2ms), four retries would result a "SUCCESS" result after 8ms, far below
-            // both the sleep value (150ms) and timeout (2000ms). This could potentially result
+            // both the sleep value (150ms) and timeout (60000ms). This could potentially result
             // in the future.cancel() returning false as you can't cancel a future that has
             // already succeeded. The possibility of having each of the four retries produce a
             // tiny RRD value is small, but not impossible.


### PR DESCRIPTION
Fixes https://github.com/googleapis/sdk-platform-java/issues/1962.

The test was written under a bad assumption that the main thread
(the thread running the test) calls `future.cancel` always before the
callable finishes in 2 second. In reality, there's no guarantee
that CPU executes the main thread in a timely manner.
(This possibility is actually already written in the source code
comment)

Increasing the timeout value from 2 seconds to 60 seconds will
drastically reduce the likelihood of the failure.
