### PR TITLE
chore: remove unmanaged-dependencies-check-latest tag

### DIFF
--- a/.github/workflows/create_additional_release_tag.yaml
+++ b/.github/workflows/create_additional_release_tag.yaml
@@ -34,12 +34,3 @@ jobs:
           git tag $TAG_NAME
           git push origin $TAG_NAME
         done
-        # Generate a tag for unmanaged dependencies check.
-        # Use fixed tag so that checks in handwritten libraries do not need to
-        # update the version.
-        CHECK_LATEST_TAG="unmanaged-dependencies-check-latest"
-        git tag ${CHECK_LATEST_TAG}
-        # delete the tag in remote repo and push again.
-        git push --delete origin ${CHECK_LATEST_TAG}
-        git push origin ${CHECK_LATEST_TAG}
-


### PR DESCRIPTION
In this PR:
- Do not create `unmanaged-dependencies-check-latest` tag in a release. The tag is not deleted in remote branch so downstream repositories can still use it.

We decided to use shared dependencies tag (for example, `google-cloud-shared-dependencies/v1.2.3`) in unmanaged dependencies, so this tag is no longer needed.