### PR TITLE
chore: Update showcase protos

### DIFF
--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/EchoOuterClass.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/EchoOuterClass.java
@@ -158,82 +158,82 @@ public final class EchoOuterClass {
       "ny\"x\n\rExpandRequest\022\017\n\007content\030\001 \001(\t\022!\n\005" +
       "error\030\002 \001(\0132\022.google.rpc.Status\0223\n\020strea" +
       "m_wait_time\030\003 \001(\0132\031.google.protobuf.Dura" +
-      "tion\"R\n\022PagedExpandRequest\022\025\n\007content\030\001 " +
-      "\001(\tB\004\342A\001\002\022\021\n\tpage_size\030\002 \001(\005\022\022\n\npage_tok" +
-      "en\030\003 \001(\t\"Z\n\030PagedExpandLegacyRequest\022\025\n\007" +
-      "content\030\001 \001(\tB\004\342A\001\002\022\023\n\013max_results\030\002 \001(\005" +
-      "\022\022\n\npage_token\030\003 \001(\t\"h\n\023PagedExpandRespo" +
-      "nse\0228\n\tresponses\030\001 \003(\0132%.google.showcase" +
-      ".v1beta1.EchoResponse\022\027\n\017next_page_token" +
-      "\030\002 \001(\t\"(\n\027PagedExpandResponseList\022\r\n\005wor" +
-      "ds\030\001 \003(\t\"\203\002\n\037PagedExpandLegacyMappedResp" +
-      "onse\022`\n\014alphabetized\030\001 \003(\0132J.google.show" +
-      "case.v1beta1.PagedExpandLegacyMappedResp" +
-      "onse.AlphabetizedEntry\022\027\n\017next_page_toke" +
-      "n\030\002 \001(\t\032e\n\021AlphabetizedEntry\022\013\n\003key\030\001 \001(" +
-      "\t\022?\n\005value\030\002 \001(\01320.google.showcase.v1bet" +
-      "a1.PagedExpandResponseList:\0028\001\"\331\001\n\013WaitR" +
-      "equest\022.\n\010end_time\030\001 \001(\0132\032.google.protob" +
-      "uf.TimestampH\000\022(\n\003ttl\030\004 \001(\0132\031.google.pro" +
-      "tobuf.DurationH\000\022#\n\005error\030\002 \001(\0132\022.google" +
-      ".rpc.StatusH\001\0228\n\007success\030\003 \001(\0132%.google." +
-      "showcase.v1beta1.WaitResponseH\001B\005\n\003endB\n" +
-      "\n\010response\"\037\n\014WaitResponse\022\017\n\007content\030\001 " +
-      "\001(\t\"<\n\014WaitMetadata\022,\n\010end_time\030\001 \001(\0132\032." +
-      "google.protobuf.Timestamp\"\255\001\n\014BlockReque" +
-      "st\0221\n\016response_delay\030\001 \001(\0132\031.google.prot" +
-      "obuf.Duration\022#\n\005error\030\002 \001(\0132\022.google.rp" +
-      "c.StatusH\000\0229\n\007success\030\003 \001(\0132&.google.sho" +
-      "wcase.v1beta1.BlockResponseH\000B\n\n\010respons" +
-      "e\" \n\rBlockResponse\022\017\n\007content\030\001 \001(\t*D\n\010S" +
-      "everity\022\017\n\013UNNECESSARY\020\000\022\r\n\tNECESSARY\020\001\022" +
-      "\n\n\006URGENT\020\002\022\014\n\010CRITICAL\020\0032\241\r\n\004Echo\022\224\003\n\004E" +
-      "cho\022$.google.showcase.v1beta1.EchoReques" +
-      "t\032%.google.showcase.v1beta1.EchoResponse" +
-      "\"\276\002\202\323\344\223\002\027\"\022/v1beta1/echo:echo:\001*\212\323\344\223\002\232\002\022" +
-      "\010\n\006header\022\031\n\006header\022\017{routing_id=**}\022+\n\006" +
-      "header\022!{table_name=regions/*/zones/*/**" +
-      "}\022\"\n\006header\022\030{super_id=projects/*}/**\0220\n" +
-      "\006header\022&{table_name=projects/*/instance" +
-      "s/*/**}\0221\n\006header\022\'projects/*/{instance_" +
-      "id=instances/*}/**\022\030\n\014other_header\022\010{baz" +
-      "=**}\022#\n\014other_header\022\023{qux=projects/*}/*" +
-      "*\022\237\001\n\020EchoErrorDetails\0220.google.showcase" +
-      ".v1beta1.EchoErrorDetailsRequest\0321.googl" +
-      "e.showcase.v1beta1.EchoErrorDetailsRespo" +
-      "nse\"&\202\323\344\223\002 \"\033/v1beta1/echo:error-details" +
-      ":\001*\022\212\001\n\006Expand\022&.google.showcase.v1beta1" +
-      ".ExpandRequest\032%.google.showcase.v1beta1" +
-      ".EchoResponse\"/\332A\rcontent,error\202\323\344\223\002\031\"\024/" +
-      "v1beta1/echo:expand:\001*0\001\022z\n\007Collect\022$.go" +
-      "ogle.showcase.v1beta1.EchoRequest\032%.goog" +
-      "le.showcase.v1beta1.EchoResponse\" \202\323\344\223\002\032" +
-      "\"\025/v1beta1/echo:collect:\001*(\001\022W\n\004Chat\022$.g" +
-      "oogle.showcase.v1beta1.EchoRequest\032%.goo" +
-      "gle.showcase.v1beta1.EchoResponse(\0010\001\022\216\001" +
-      "\n\013PagedExpand\022+.google.showcase.v1beta1." +
-      "PagedExpandRequest\032,.google.showcase.v1b" +
-      "eta1.PagedExpandResponse\"$\202\323\344\223\002\036\"\031/v1bet" +
-      "a1/echo:pagedExpand:\001*\022\240\001\n\021PagedExpandLe" +
-      "gacy\0221.google.showcase.v1beta1.PagedExpa" +
-      "ndLegacyRequest\032,.google.showcase.v1beta" +
-      "1.PagedExpandResponse\"*\202\323\344\223\002$\"\037/v1beta1/" +
-      "echo:pagedExpandLegacy:\001*\022\262\001\n\027PagedExpan" +
-      "dLegacyMapped\022+.google.showcase.v1beta1." +
-      "PagedExpandRequest\0328.google.showcase.v1b" +
-      "eta1.PagedExpandLegacyMappedResponse\"0\202\323" +
-      "\344\223\002*\"%/v1beta1/echo:pagedExpandLegacyMap" +
-      "ped:\001*\022\211\001\n\004Wait\022$.google.showcase.v1beta" +
-      "1.WaitRequest\032\035.google.longrunning.Opera" +
-      "tion\"<\312A\034\n\014WaitResponse\022\014WaitMetadata\202\323\344" +
-      "\223\002\027\"\022/v1beta1/echo:wait:\001*\022v\n\005Block\022%.go" +
-      "ogle.showcase.v1beta1.BlockRequest\032&.goo" +
-      "gle.showcase.v1beta1.BlockResponse\"\036\202\323\344\223" +
-      "\002\030\"\023/v1beta1/echo:block:\001*\032\021\312A\016localhost" +
-      ":7469Bq\n\033com.google.showcase.v1beta1P\001Z4" +
-      "github.com/googleapis/gapic-showcase/ser" +
-      "ver/genproto\352\002\031Google::Showcase::V1beta1" +
-      "b\006proto3"
+      "tion\"Q\n\022PagedExpandRequest\022\024\n\007content\030\001 " +
+      "\001(\tB\003\340A\002\022\021\n\tpage_size\030\002 \001(\005\022\022\n\npage_toke" +
+      "n\030\003 \001(\t\"Y\n\030PagedExpandLegacyRequest\022\024\n\007c" +
+      "ontent\030\001 \001(\tB\003\340A\002\022\023\n\013max_results\030\002 \001(\005\022\022" +
+      "\n\npage_token\030\003 \001(\t\"h\n\023PagedExpandRespons" +
+      "e\0228\n\tresponses\030\001 \003(\0132%.google.showcase.v" +
+      "1beta1.EchoResponse\022\027\n\017next_page_token\030\002" +
+      " \001(\t\"(\n\027PagedExpandResponseList\022\r\n\005words" +
+      "\030\001 \003(\t\"\203\002\n\037PagedExpandLegacyMappedRespon" +
+      "se\022`\n\014alphabetized\030\001 \003(\0132J.google.showca" +
+      "se.v1beta1.PagedExpandLegacyMappedRespon" +
+      "se.AlphabetizedEntry\022\027\n\017next_page_token\030" +
+      "\002 \001(\t\032e\n\021AlphabetizedEntry\022\013\n\003key\030\001 \001(\t\022" +
+      "?\n\005value\030\002 \001(\01320.google.showcase.v1beta1" +
+      ".PagedExpandResponseList:\0028\001\"\331\001\n\013WaitReq" +
+      "uest\022.\n\010end_time\030\001 \001(\0132\032.google.protobuf" +
+      ".TimestampH\000\022(\n\003ttl\030\004 \001(\0132\031.google.proto" +
+      "buf.DurationH\000\022#\n\005error\030\002 \001(\0132\022.google.r" +
+      "pc.StatusH\001\0228\n\007success\030\003 \001(\0132%.google.sh" +
+      "owcase.v1beta1.WaitResponseH\001B\005\n\003endB\n\n\010" +
+      "response\"\037\n\014WaitResponse\022\017\n\007content\030\001 \001(" +
+      "\t\"<\n\014WaitMetadata\022,\n\010end_time\030\001 \001(\0132\032.go" +
+      "ogle.protobuf.Timestamp\"\255\001\n\014BlockRequest" +
+      "\0221\n\016response_delay\030\001 \001(\0132\031.google.protob" +
+      "uf.Duration\022#\n\005error\030\002 \001(\0132\022.google.rpc." +
+      "StatusH\000\0229\n\007success\030\003 \001(\0132&.google.showc" +
+      "ase.v1beta1.BlockResponseH\000B\n\n\010response\"" +
+      " \n\rBlockResponse\022\017\n\007content\030\001 \001(\t*D\n\010Sev" +
+      "erity\022\017\n\013UNNECESSARY\020\000\022\r\n\tNECESSARY\020\001\022\n\n" +
+      "\006URGENT\020\002\022\014\n\010CRITICAL\020\0032\241\r\n\004Echo\022\224\003\n\004Ech" +
+      "o\022$.google.showcase.v1beta1.EchoRequest\032" +
+      "%.google.showcase.v1beta1.EchoResponse\"\276" +
+      "\002\202\323\344\223\002\027\"\022/v1beta1/echo:echo:\001*\212\323\344\223\002\232\002\022\010\n" +
+      "\006header\022\031\n\006header\022\017{routing_id=**}\022+\n\006he" +
+      "ader\022!{table_name=regions/*/zones/*/**}\022" +
+      "\"\n\006header\022\030{super_id=projects/*}/**\0220\n\006h" +
+      "eader\022&{table_name=projects/*/instances/" +
+      "*/**}\0221\n\006header\022\'projects/*/{instance_id" +
+      "=instances/*}/**\022\030\n\014other_header\022\010{baz=*" +
+      "*}\022#\n\014other_header\022\023{qux=projects/*}/**\022" +
+      "\237\001\n\020EchoErrorDetails\0220.google.showcase.v" +
+      "1beta1.EchoErrorDetailsRequest\0321.google." +
+      "showcase.v1beta1.EchoErrorDetailsRespons" +
+      "e\"&\202\323\344\223\002 \"\033/v1beta1/echo:error-details:\001" +
+      "*\022\212\001\n\006Expand\022&.google.showcase.v1beta1.E" +
+      "xpandRequest\032%.google.showcase.v1beta1.E" +
+      "choResponse\"/\332A\rcontent,error\202\323\344\223\002\031\"\024/v1" +
+      "beta1/echo:expand:\001*0\001\022z\n\007Collect\022$.goog" +
+      "le.showcase.v1beta1.EchoRequest\032%.google" +
+      ".showcase.v1beta1.EchoResponse\" \202\323\344\223\002\032\"\025" +
+      "/v1beta1/echo:collect:\001*(\001\022W\n\004Chat\022$.goo" +
+      "gle.showcase.v1beta1.EchoRequest\032%.googl" +
+      "e.showcase.v1beta1.EchoResponse(\0010\001\022\216\001\n\013" +
+      "PagedExpand\022+.google.showcase.v1beta1.Pa" +
+      "gedExpandRequest\032,.google.showcase.v1bet" +
+      "a1.PagedExpandResponse\"$\202\323\344\223\002\036\"\031/v1beta1" +
+      "/echo:pagedExpand:\001*\022\240\001\n\021PagedExpandLega" +
+      "cy\0221.google.showcase.v1beta1.PagedExpand" +
+      "LegacyRequest\032,.google.showcase.v1beta1." +
+      "PagedExpandResponse\"*\202\323\344\223\002$\"\037/v1beta1/ec" +
+      "ho:pagedExpandLegacy:\001*\022\262\001\n\027PagedExpandL" +
+      "egacyMapped\022+.google.showcase.v1beta1.Pa" +
+      "gedExpandRequest\0328.google.showcase.v1bet" +
+      "a1.PagedExpandLegacyMappedResponse\"0\202\323\344\223" +
+      "\002*\"%/v1beta1/echo:pagedExpandLegacyMappe" +
+      "d:\001*\022\211\001\n\004Wait\022$.google.showcase.v1beta1." +
+      "WaitRequest\032\035.google.longrunning.Operati" +
+      "on\"<\312A\034\n\014WaitResponse\022\014WaitMetadata\202\323\344\223\002" +
+      "\027\"\022/v1beta1/echo:wait:\001*\022v\n\005Block\022%.goog" +
+      "le.showcase.v1beta1.BlockRequest\032&.googl" +
+      "e.showcase.v1beta1.BlockResponse\"\036\202\323\344\223\002\030" +
+      "\"\023/v1beta1/echo:block:\001*\032\021\312A\016localhost:7" +
+      "469Bq\n\033com.google.showcase.v1beta1P\001Z4gi" +
+      "thub.com/googleapis/gapic-showcase/serve" +
+      "r/genproto\352\002\031Google::Showcase::V1beta1b\006" +
+      "proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/IdentityOuterClass.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/IdentityOuterClass.java
@@ -66,51 +66,51 @@ public final class IdentityOuterClass {
       "\032\031google/api/resource.proto\032\033google/prot" +
       "obuf/empty.proto\032 google/protobuf/field_" +
       "mask.proto\032\037google/protobuf/timestamp.pr" +
-      "oto\"\210\003\n\004User\022\014\n\004name\030\001 \001(\t\022\032\n\014display_na" +
-      "me\030\002 \001(\tB\004\342A\001\002\022\023\n\005email\030\003 \001(\tB\004\342A\001\002\0225\n\013c" +
-      "reate_time\030\004 \001(\0132\032.google.protobuf.Times" +
-      "tampB\004\342A\001\003\0225\n\013update_time\030\005 \001(\0132\032.google" +
-      ".protobuf.TimestampB\004\342A\001\003\022\020\n\003age\030\006 \001(\005H\000" +
-      "\210\001\001\022\030\n\013height_feet\030\007 \001(\001H\001\210\001\001\022\025\n\010nicknam" +
-      "e\030\010 \001(\tH\002\210\001\001\022!\n\024enable_notifications\030\t \001" +
-      "(\010H\003\210\001\001:/\352A,\n\034showcase.googleapis.com/Us" +
-      "er\022\014users/{user}B\006\n\004_ageB\016\n\014_height_feet" +
-      "B\013\n\t_nicknameB\027\n\025_enable_notifications\"@" +
-      "\n\021CreateUserRequest\022+\n\004user\030\001 \001(\0132\035.goog" +
-      "le.showcase.v1beta1.User\"E\n\016GetUserReque" +
-      "st\0223\n\004name\030\001 \001(\tB%\342A\001\002\372A\036\n\034showcase.goog" +
-      "leapis.com/User\"q\n\021UpdateUserRequest\022+\n\004" +
-      "user\030\001 \001(\0132\035.google.showcase.v1beta1.Use" +
-      "r\022/\n\013update_mask\030\002 \001(\0132\032.google.protobuf" +
-      ".FieldMask\"H\n\021DeleteUserRequest\0223\n\004name\030" +
-      "\001 \001(\tB%\342A\001\002\372A\036\n\034showcase.googleapis.com/" +
-      "User\"9\n\020ListUsersRequest\022\021\n\tpage_size\030\001 " +
-      "\001(\005\022\022\n\npage_token\030\002 \001(\t\"Z\n\021ListUsersResp" +
-      "onse\022,\n\005users\030\001 \003(\0132\035.google.showcase.v1" +
-      "beta1.User\022\027\n\017next_page_token\030\002 \001(\t2\212\006\n\010" +
-      "Identity\022\363\001\n\nCreateUser\022*.google.showcas" +
-      "e.v1beta1.CreateUserRequest\032\035.google.sho" +
-      "wcase.v1beta1.User\"\231\001\332A\034user.display_nam" +
-      "e,user.email\332A^user.display_name,user.em" +
-      "ail,user.age,user.nickname,user.enable_n" +
-      "otifications,user.height_feet\202\323\344\223\002\023\"\016/v1" +
-      "beta1/users:\001*\022y\n\007GetUser\022\'.google.showc" +
-      "ase.v1beta1.GetUserRequest\032\035.google.show" +
-      "case.v1beta1.User\"&\332A\004name\202\323\344\223\002\031\022\027/v1bet" +
-      "a1/{name=users/*}\022\203\001\n\nUpdateUser\022*.googl" +
-      "e.showcase.v1beta1.UpdateUserRequest\032\035.g" +
-      "oogle.showcase.v1beta1.User\"*\202\323\344\223\002$2\034/v1" +
-      "beta1/{user.name=users/*}:\004user\022x\n\nDelet" +
-      "eUser\022*.google.showcase.v1beta1.DeleteUs" +
-      "erRequest\032\026.google.protobuf.Empty\"&\332A\004na" +
-      "me\202\323\344\223\002\031*\027/v1beta1/{name=users/*}\022z\n\tLis" +
-      "tUsers\022).google.showcase.v1beta1.ListUse" +
-      "rsRequest\032*.google.showcase.v1beta1.List" +
-      "UsersResponse\"\026\202\323\344\223\002\020\022\016/v1beta1/users\032\021\312" +
-      "A\016localhost:7469Bq\n\033com.google.showcase." +
-      "v1beta1P\001Z4github.com/googleapis/gapic-s" +
-      "howcase/server/genproto\352\002\031Google::Showca" +
-      "se::V1beta1b\006proto3"
+      "oto\"\204\003\n\004User\022\014\n\004name\030\001 \001(\t\022\031\n\014display_na" +
+      "me\030\002 \001(\tB\003\340A\002\022\022\n\005email\030\003 \001(\tB\003\340A\002\0224\n\013cre" +
+      "ate_time\030\004 \001(\0132\032.google.protobuf.Timesta" +
+      "mpB\003\340A\003\0224\n\013update_time\030\005 \001(\0132\032.google.pr" +
+      "otobuf.TimestampB\003\340A\003\022\020\n\003age\030\006 \001(\005H\000\210\001\001\022" +
+      "\030\n\013height_feet\030\007 \001(\001H\001\210\001\001\022\025\n\010nickname\030\010 " +
+      "\001(\tH\002\210\001\001\022!\n\024enable_notifications\030\t \001(\010H\003" +
+      "\210\001\001:/\352A,\n\034showcase.googleapis.com/User\022\014" +
+      "users/{user}B\006\n\004_ageB\016\n\014_height_feetB\013\n\t" +
+      "_nicknameB\027\n\025_enable_notifications\"@\n\021Cr" +
+      "eateUserRequest\022+\n\004user\030\001 \001(\0132\035.google.s" +
+      "howcase.v1beta1.User\"D\n\016GetUserRequest\0222" +
+      "\n\004name\030\001 \001(\tB$\340A\002\372A\036\n\034showcase.googleapi" +
+      "s.com/User\"q\n\021UpdateUserRequest\022+\n\004user\030" +
+      "\001 \001(\0132\035.google.showcase.v1beta1.User\022/\n\013" +
+      "update_mask\030\002 \001(\0132\032.google.protobuf.Fiel" +
+      "dMask\"G\n\021DeleteUserRequest\0222\n\004name\030\001 \001(\t" +
+      "B$\340A\002\372A\036\n\034showcase.googleapis.com/User\"9" +
+      "\n\020ListUsersRequest\022\021\n\tpage_size\030\001 \001(\005\022\022\n" +
+      "\npage_token\030\002 \001(\t\"Z\n\021ListUsersResponse\022," +
+      "\n\005users\030\001 \003(\0132\035.google.showcase.v1beta1." +
+      "User\022\027\n\017next_page_token\030\002 \001(\t2\212\006\n\010Identi" +
+      "ty\022\363\001\n\nCreateUser\022*.google.showcase.v1be" +
+      "ta1.CreateUserRequest\032\035.google.showcase." +
+      "v1beta1.User\"\231\001\332A\034user.display_name,user" +
+      ".email\332A^user.display_name,user.email,us" +
+      "er.age,user.nickname,user.enable_notific" +
+      "ations,user.height_feet\202\323\344\223\002\023\"\016/v1beta1/" +
+      "users:\001*\022y\n\007GetUser\022\'.google.showcase.v1" +
+      "beta1.GetUserRequest\032\035.google.showcase.v" +
+      "1beta1.User\"&\332A\004name\202\323\344\223\002\031\022\027/v1beta1/{na" +
+      "me=users/*}\022\203\001\n\nUpdateUser\022*.google.show" +
+      "case.v1beta1.UpdateUserRequest\032\035.google." +
+      "showcase.v1beta1.User\"*\202\323\344\223\002$2\034/v1beta1/" +
+      "{user.name=users/*}:\004user\022x\n\nDeleteUser\022" +
+      "*.google.showcase.v1beta1.DeleteUserRequ" +
+      "est\032\026.google.protobuf.Empty\"&\332A\004name\202\323\344\223" +
+      "\002\031*\027/v1beta1/{name=users/*}\022z\n\tListUsers" +
+      "\022).google.showcase.v1beta1.ListUsersRequ" +
+      "est\032*.google.showcase.v1beta1.ListUsersR" +
+      "esponse\"\026\202\323\344\223\002\020\022\016/v1beta1/users\032\021\312A\016loca" +
+      "lhost:7469Bq\n\033com.google.showcase.v1beta" +
+      "1P\001Z4github.com/googleapis/gapic-showcas" +
+      "e/server/genproto\352\002\031Google::Showcase::V1" +
+      "beta1b\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/MessagingOuterClass.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/MessagingOuterClass.java
@@ -142,141 +142,140 @@ public final class MessagingOuterClass {
       "grunning/operations.proto\032\033google/protob" +
       "uf/empty.proto\032 google/protobuf/field_ma" +
       "sk.proto\032\037google/protobuf/timestamp.prot" +
-      "o\032\036google/rpc/error_details.proto\"\344\001\n\004Ro" +
-      "om\022\014\n\004name\030\001 \001(\t\022\032\n\014display_name\030\002 \001(\tB\004" +
-      "\342A\001\002\022\023\n\013description\030\003 \001(\t\0225\n\013create_time" +
-      "\030\004 \001(\0132\032.google.protobuf.TimestampB\004\342A\001\003" +
-      "\0225\n\013update_time\030\005 \001(\0132\032.google.protobuf." +
-      "TimestampB\004\342A\001\003:/\352A,\n\034showcase.googleapi" +
-      "s.com/Room\022\014rooms/{room}\"@\n\021CreateRoomRe" +
-      "quest\022+\n\004room\030\001 \001(\0132\035.google.showcase.v1" +
-      "beta1.Room\"E\n\016GetRoomRequest\0223\n\004name\030\001 \001" +
-      "(\tB%\342A\001\002\372A\036\n\034showcase.googleapis.com/Roo" +
-      "m\"q\n\021UpdateRoomRequest\022+\n\004room\030\001 \001(\0132\035.g" +
-      "oogle.showcase.v1beta1.Room\022/\n\013update_ma" +
-      "sk\030\002 \001(\0132\032.google.protobuf.FieldMask\"H\n\021" +
-      "DeleteRoomRequest\0223\n\004name\030\001 \001(\tB%\342A\001\002\372A\036" +
-      "\n\034showcase.googleapis.com/Room\"9\n\020ListRo" +
-      "omsRequest\022\021\n\tpage_size\030\001 \001(\005\022\022\n\npage_to" +
-      "ken\030\002 \001(\t\"Z\n\021ListRoomsResponse\022,\n\005rooms\030" +
-      "\001 \003(\0132\035.google.showcase.v1beta1.Room\022\027\n\017" +
-      "next_page_token\030\002 \001(\t\"\371\003\n\005Blurb\022\014\n\004name\030" +
-      "\001 \001(\t\0223\n\004user\030\002 \001(\tB%\342A\001\002\372A\036\n\034showcase.g" +
-      "oogleapis.com/User\022\016\n\004text\030\003 \001(\tH\000\022\017\n\005im" +
-      "age\030\004 \001(\014H\000\0225\n\013create_time\030\005 \001(\0132\032.googl" +
-      "e.protobuf.TimestampB\004\342A\001\003\0225\n\013update_tim" +
-      "e\030\006 \001(\0132\032.google.protobuf.TimestampB\004\342A\001" +
-      "\003\022\030\n\016legacy_room_id\030\007 \001(\tH\001\022\030\n\016legacy_us" +
-      "er_id\030\010 \001(\tH\001:\321\001\352A\315\001\n\035showcase.googleapi" +
-      "s.com/Blurb\0228users/{user}/profile/blurbs" +
-      "/legacy/{legacy_user}~{blurb}\022#users/{us" +
-      "er}/profile/blurbs/{blurb}\022\033rooms/{room}" +
-      "/blurbs/{blurb}\0220rooms/{room}/blurbs/leg" +
-      "acy/{legacy_room}.{blurb}B\t\n\007contentB\013\n\t" +
-      "legacy_id\"{\n\022CreateBlurbRequest\0226\n\006paren" +
-      "t\030\001 \001(\tB&\342A\001\002\372A\037\022\035showcase.googleapis.co" +
-      "m/Blurb\022-\n\005blurb\030\002 \001(\0132\036.google.showcase" +
-      ".v1beta1.Blurb\"G\n\017GetBlurbRequest\0224\n\004nam" +
-      "e\030\001 \001(\tB&\342A\001\002\372A\037\n\035showcase.googleapis.co" +
-      "m/Blurb\"t\n\022UpdateBlurbRequest\022-\n\005blurb\030\001" +
-      " \001(\0132\036.google.showcase.v1beta1.Blurb\022/\n\013" +
-      "update_mask\030\002 \001(\0132\032.google.protobuf.Fiel" +
-      "dMask\"J\n\022DeleteBlurbRequest\0224\n\004name\030\001 \001(" +
-      "\tB&\342A\001\002\372A\037\n\035showcase.googleapis.com/Blur" +
-      "b\"r\n\021ListBlurbsRequest\0226\n\006parent\030\001 \001(\tB&" +
-      "\342A\001\002\372A\037\022\035showcase.googleapis.com/Blurb\022\021" +
-      "\n\tpage_size\030\002 \001(\005\022\022\n\npage_token\030\003 \001(\t\"]\n" +
-      "\022ListBlurbsResponse\022.\n\006blurbs\030\001 \003(\0132\036.go" +
-      "ogle.showcase.v1beta1.Blurb\022\027\n\017next_page" +
-      "_token\030\002 \001(\t\"\205\001\n\023SearchBlurbsRequest\022\023\n\005" +
-      "query\030\001 \001(\tB\004\342A\001\002\0222\n\006parent\030\002 \001(\tB\"\372A\037\022\035" +
-      "showcase.googleapis.com/Blurb\022\021\n\tpage_si" +
-      "ze\030\003 \001(\005\022\022\n\npage_token\030\004 \001(\t\"A\n\024SearchBl" +
-      "urbsMetadata\022)\n\nretry_info\030\001 \001(\0132\025.googl" +
-      "e.rpc.RetryInfo\"_\n\024SearchBlurbsResponse\022" +
-      ".\n\006blurbs\030\001 \003(\0132\036.google.showcase.v1beta" +
-      "1.Blurb\022\027\n\017next_page_token\030\002 \001(\t\"\202\001\n\023Str" +
-      "eamBlurbsRequest\0224\n\004name\030\001 \001(\tB&\342A\001\002\372A\037\022" +
-      "\035showcase.googleapis.com/Blurb\0225\n\013expire" +
-      "_time\030\002 \001(\0132\032.google.protobuf.TimestampB" +
-      "\004\342A\001\002\"\321\001\n\024StreamBlurbsResponse\022-\n\005blurb\030" +
-      "\001 \001(\0132\036.google.showcase.v1beta1.Blurb\022D\n" +
-      "\006action\030\002 \001(\01624.google.showcase.v1beta1." +
-      "StreamBlurbsResponse.Action\"D\n\006Action\022\026\n" +
-      "\022ACTION_UNSPECIFIED\020\000\022\n\n\006CREATE\020\001\022\n\n\006UPD" +
-      "ATE\020\002\022\n\n\006DELETE\020\003\"#\n\022SendBlurbsResponse\022" +
-      "\r\n\005names\030\001 \003(\t\"\332\001\n\016ConnectRequest\022G\n\006con" +
-      "fig\030\001 \001(\01325.google.showcase.v1beta1.Conn" +
-      "ectRequest.ConnectConfigH\000\022/\n\005blurb\030\002 \001(" +
-      "\0132\036.google.showcase.v1beta1.BlurbH\000\032C\n\rC" +
-      "onnectConfig\0222\n\006parent\030\001 \001(\tB\"\372A\037\022\035showc" +
-      "ase.googleapis.com/BlurbB\t\n\007request2\264\023\n\t" +
-      "Messaging\022\227\001\n\nCreateRoom\022*.google.showca" +
-      "se.v1beta1.CreateRoomRequest\032\035.google.sh" +
-      "owcase.v1beta1.Room\">\332A\"room.display_nam" +
-      "e,room.description\202\323\344\223\002\023\"\016/v1beta1/rooms" +
-      ":\001*\022y\n\007GetRoom\022\'.google.showcase.v1beta1" +
-      ".GetRoomRequest\032\035.google.showcase.v1beta" +
-      "1.Room\"&\332A\004name\202\323\344\223\002\031\022\027/v1beta1/{name=ro" +
-      "oms/*}\022\203\001\n\nUpdateRoom\022*.google.showcase." +
-      "v1beta1.UpdateRoomRequest\032\035.google.showc" +
-      "ase.v1beta1.Room\"*\202\323\344\223\002$2\034/v1beta1/{room" +
-      ".name=rooms/*}:\004room\022x\n\nDeleteRoom\022*.goo" +
-      "gle.showcase.v1beta1.DeleteRoomRequest\032\026" +
-      ".google.protobuf.Empty\"&\332A\004name\202\323\344\223\002\031*\027/" +
-      "v1beta1/{name=rooms/*}\022z\n\tListRooms\022).go" +
-      "ogle.showcase.v1beta1.ListRoomsRequest\032*" +
-      ".google.showcase.v1beta1.ListRoomsRespon" +
-      "se\"\026\202\323\344\223\002\020\022\016/v1beta1/rooms\022\366\001\n\013CreateBlu" +
-      "rb\022+.google.showcase.v1beta1.CreateBlurb" +
-      "Request\032\036.google.showcase.v1beta1.Blurb\"" +
-      "\231\001\332A\034parent,blurb.user,blurb.text\332A\035pare" +
-      "nt,blurb.user,blurb.image\202\323\344\223\002T\" /v1beta" +
-      "1/{parent=rooms/*}/blurbs:\001*Z-\"(/v1beta1" +
-      "/{parent=users/*/profile}/blurbs:\001*\022\261\001\n\010" +
-      "GetBlurb\022(.google.showcase.v1beta1.GetBl" +
-      "urbRequest\032\036.google.showcase.v1beta1.Blu" +
-      "rb\"[\332A\004name\202\323\344\223\002N\022 /v1beta1/{name=rooms/" +
-      "*/blurbs/*}Z*\022(/v1beta1/{name=users/*/pr" +
-      "ofile/blurbs/*}\022\312\001\n\013UpdateBlurb\022+.google" +
-      ".showcase.v1beta1.UpdateBlurbRequest\032\036.g" +
-      "oogle.showcase.v1beta1.Blurb\"n\202\323\344\223\002h2&/v" +
-      "1beta1/{blurb.name=rooms/*/blurbs/*}:\005bl" +
-      "urbZ72./v1beta1/{blurb.name=users/*/prof" +
-      "ile/blurbs/*}:\005blurb\022\257\001\n\013DeleteBlurb\022+.g" +
-      "oogle.showcase.v1beta1.DeleteBlurbReques" +
-      "t\032\026.google.protobuf.Empty\"[\332A\004name\202\323\344\223\002N" +
-      "* /v1beta1/{name=rooms/*/blurbs/*}Z**(/v" +
-      "1beta1/{name=users/*/profile/blurbs/*}\022\304" +
-      "\001\n\nListBlurbs\022*.google.showcase.v1beta1." +
-      "ListBlurbsRequest\032+.google.showcase.v1be" +
-      "ta1.ListBlurbsResponse\"]\332A\006parent\202\323\344\223\002N\022" +
-      " /v1beta1/{parent=rooms/*}/blurbsZ*\022(/v1" +
-      "beta1/{parent=users/*/profile}/blurbs\022\201\002" +
-      "\n\014SearchBlurbs\022,.google.showcase.v1beta1" +
-      ".SearchBlurbsRequest\032\035.google.longrunnin" +
-      "g.Operation\"\243\001\312A,\n\024SearchBlurbsResponse\022" +
-      "\024SearchBlurbsMetadata\332A\014parent,query\202\323\344\223" +
-      "\002_\"\'/v1beta1/{parent=rooms/*}/blurbs:sea" +
-      "rch:\001*Z1\"//v1beta1/{parent=users/*/profi" +
-      "le}/blurbs:search\022\323\001\n\014StreamBlurbs\022,.goo" +
-      "gle.showcase.v1beta1.StreamBlurbsRequest" +
-      "\032-.google.showcase.v1beta1.StreamBlurbsR" +
-      "esponse\"d\202\323\344\223\002^\"%/v1beta1/{name=rooms/*}" +
-      "/blurbs:stream:\001*Z2\"-/v1beta1/{name=user" +
-      "s/*/profile}/blurbs:stream:\001*0\001\022\316\001\n\nSend" +
-      "Blurbs\022+.google.showcase.v1beta1.CreateB" +
-      "lurbRequest\032+.google.showcase.v1beta1.Se" +
-      "ndBlurbsResponse\"d\202\323\344\223\002^\"%/v1beta1/{pare" +
-      "nt=rooms/*}/blurbs:send:\001*Z2\"-/v1beta1/{" +
-      "parent=users/*/profile}/blurbs:send:\001*(\001" +
-      "\022e\n\007Connect\022\'.google.showcase.v1beta1.Co" +
-      "nnectRequest\032-.google.showcase.v1beta1.S" +
-      "treamBlurbsResponse(\0010\001\032\021\312A\016localhost:74" +
-      "69Bq\n\033com.google.showcase.v1beta1P\001Z4git" +
-      "hub.com/googleapis/gapic-showcase/server" +
-      "/genproto\352\002\031Google::Showcase::V1beta1b\006p" +
-      "roto3"
+      "o\032\036google/rpc/error_details.proto\"\341\001\n\004Ro" +
+      "om\022\014\n\004name\030\001 \001(\t\022\031\n\014display_name\030\002 \001(\tB\003" +
+      "\340A\002\022\023\n\013description\030\003 \001(\t\0224\n\013create_time\030" +
+      "\004 \001(\0132\032.google.protobuf.TimestampB\003\340A\003\0224" +
+      "\n\013update_time\030\005 \001(\0132\032.google.protobuf.Ti" +
+      "mestampB\003\340A\003:/\352A,\n\034showcase.googleapis.c" +
+      "om/Room\022\014rooms/{room}\"@\n\021CreateRoomReque" +
+      "st\022+\n\004room\030\001 \001(\0132\035.google.showcase.v1bet" +
+      "a1.Room\"D\n\016GetRoomRequest\0222\n\004name\030\001 \001(\tB" +
+      "$\340A\002\372A\036\n\034showcase.googleapis.com/Room\"q\n" +
+      "\021UpdateRoomRequest\022+\n\004room\030\001 \001(\0132\035.googl" +
+      "e.showcase.v1beta1.Room\022/\n\013update_mask\030\002" +
+      " \001(\0132\032.google.protobuf.FieldMask\"G\n\021Dele" +
+      "teRoomRequest\0222\n\004name\030\001 \001(\tB$\340A\002\372A\036\n\034sho" +
+      "wcase.googleapis.com/Room\"9\n\020ListRoomsRe" +
+      "quest\022\021\n\tpage_size\030\001 \001(\005\022\022\n\npage_token\030\002" +
+      " \001(\t\"Z\n\021ListRoomsResponse\022,\n\005rooms\030\001 \003(\013" +
+      "2\035.google.showcase.v1beta1.Room\022\027\n\017next_" +
+      "page_token\030\002 \001(\t\"\366\003\n\005Blurb\022\014\n\004name\030\001 \001(\t" +
+      "\0222\n\004user\030\002 \001(\tB$\340A\002\372A\036\n\034showcase.googlea" +
+      "pis.com/User\022\016\n\004text\030\003 \001(\tH\000\022\017\n\005image\030\004 " +
+      "\001(\014H\000\0224\n\013create_time\030\005 \001(\0132\032.google.prot" +
+      "obuf.TimestampB\003\340A\003\0224\n\013update_time\030\006 \001(\013" +
+      "2\032.google.protobuf.TimestampB\003\340A\003\022\030\n\016leg" +
+      "acy_room_id\030\007 \001(\tH\001\022\030\n\016legacy_user_id\030\010 " +
+      "\001(\tH\001:\321\001\352A\315\001\n\035showcase.googleapis.com/Bl" +
+      "urb\0228users/{user}/profile/blurbs/legacy/" +
+      "{legacy_user}~{blurb}\022#users/{user}/prof" +
+      "ile/blurbs/{blurb}\022\033rooms/{room}/blurbs/" +
+      "{blurb}\0220rooms/{room}/blurbs/legacy/{leg" +
+      "acy_room}.{blurb}B\t\n\007contentB\013\n\tlegacy_i" +
+      "d\"z\n\022CreateBlurbRequest\0225\n\006parent\030\001 \001(\tB" +
+      "%\340A\002\372A\037\022\035showcase.googleapis.com/Blurb\022-" +
+      "\n\005blurb\030\002 \001(\0132\036.google.showcase.v1beta1." +
+      "Blurb\"F\n\017GetBlurbRequest\0223\n\004name\030\001 \001(\tB%" +
+      "\340A\002\372A\037\n\035showcase.googleapis.com/Blurb\"t\n" +
+      "\022UpdateBlurbRequest\022-\n\005blurb\030\001 \001(\0132\036.goo" +
+      "gle.showcase.v1beta1.Blurb\022/\n\013update_mas" +
+      "k\030\002 \001(\0132\032.google.protobuf.FieldMask\"I\n\022D" +
+      "eleteBlurbRequest\0223\n\004name\030\001 \001(\tB%\340A\002\372A\037\n" +
+      "\035showcase.googleapis.com/Blurb\"q\n\021ListBl" +
+      "urbsRequest\0225\n\006parent\030\001 \001(\tB%\340A\002\372A\037\022\035sho" +
+      "wcase.googleapis.com/Blurb\022\021\n\tpage_size\030" +
+      "\002 \001(\005\022\022\n\npage_token\030\003 \001(\t\"]\n\022ListBlurbsR" +
+      "esponse\022.\n\006blurbs\030\001 \003(\0132\036.google.showcas" +
+      "e.v1beta1.Blurb\022\027\n\017next_page_token\030\002 \001(\t" +
+      "\"\204\001\n\023SearchBlurbsRequest\022\022\n\005query\030\001 \001(\tB" +
+      "\003\340A\002\0222\n\006parent\030\002 \001(\tB\"\372A\037\022\035showcase.goog" +
+      "leapis.com/Blurb\022\021\n\tpage_size\030\003 \001(\005\022\022\n\np" +
+      "age_token\030\004 \001(\t\"A\n\024SearchBlurbsMetadata\022" +
+      ")\n\nretry_info\030\001 \001(\0132\025.google.rpc.RetryIn" +
+      "fo\"_\n\024SearchBlurbsResponse\022.\n\006blurbs\030\001 \003" +
+      "(\0132\036.google.showcase.v1beta1.Blurb\022\027\n\017ne" +
+      "xt_page_token\030\002 \001(\t\"\200\001\n\023StreamBlurbsRequ" +
+      "est\0223\n\004name\030\001 \001(\tB%\340A\002\372A\037\022\035showcase.goog" +
+      "leapis.com/Blurb\0224\n\013expire_time\030\002 \001(\0132\032." +
+      "google.protobuf.TimestampB\003\340A\002\"\321\001\n\024Strea" +
+      "mBlurbsResponse\022-\n\005blurb\030\001 \001(\0132\036.google." +
+      "showcase.v1beta1.Blurb\022D\n\006action\030\002 \001(\01624" +
+      ".google.showcase.v1beta1.StreamBlurbsRes" +
+      "ponse.Action\"D\n\006Action\022\026\n\022ACTION_UNSPECI" +
+      "FIED\020\000\022\n\n\006CREATE\020\001\022\n\n\006UPDATE\020\002\022\n\n\006DELETE" +
+      "\020\003\"#\n\022SendBlurbsResponse\022\r\n\005names\030\001 \003(\t\"" +
+      "\332\001\n\016ConnectRequest\022G\n\006config\030\001 \001(\01325.goo" +
+      "gle.showcase.v1beta1.ConnectRequest.Conn" +
+      "ectConfigH\000\022/\n\005blurb\030\002 \001(\0132\036.google.show" +
+      "case.v1beta1.BlurbH\000\032C\n\rConnectConfig\0222\n" +
+      "\006parent\030\001 \001(\tB\"\372A\037\022\035showcase.googleapis." +
+      "com/BlurbB\t\n\007request2\264\023\n\tMessaging\022\227\001\n\nC" +
+      "reateRoom\022*.google.showcase.v1beta1.Crea" +
+      "teRoomRequest\032\035.google.showcase.v1beta1." +
+      "Room\">\332A\"room.display_name,room.descript" +
+      "ion\202\323\344\223\002\023\"\016/v1beta1/rooms:\001*\022y\n\007GetRoom\022" +
+      "\'.google.showcase.v1beta1.GetRoomRequest" +
+      "\032\035.google.showcase.v1beta1.Room\"&\332A\004name" +
+      "\202\323\344\223\002\031\022\027/v1beta1/{name=rooms/*}\022\203\001\n\nUpda" +
+      "teRoom\022*.google.showcase.v1beta1.UpdateR" +
+      "oomRequest\032\035.google.showcase.v1beta1.Roo" +
+      "m\"*\202\323\344\223\002$2\034/v1beta1/{room.name=rooms/*}:" +
+      "\004room\022x\n\nDeleteRoom\022*.google.showcase.v1" +
+      "beta1.DeleteRoomRequest\032\026.google.protobu" +
+      "f.Empty\"&\332A\004name\202\323\344\223\002\031*\027/v1beta1/{name=r" +
+      "ooms/*}\022z\n\tListRooms\022).google.showcase.v" +
+      "1beta1.ListRoomsRequest\032*.google.showcas" +
+      "e.v1beta1.ListRoomsResponse\"\026\202\323\344\223\002\020\022\016/v1" +
+      "beta1/rooms\022\366\001\n\013CreateBlurb\022+.google.sho" +
+      "wcase.v1beta1.CreateBlurbRequest\032\036.googl" +
+      "e.showcase.v1beta1.Blurb\"\231\001\332A\034parent,blu" +
+      "rb.user,blurb.text\332A\035parent,blurb.user,b" +
+      "lurb.image\202\323\344\223\002T\" /v1beta1/{parent=rooms" +
+      "/*}/blurbs:\001*Z-\"(/v1beta1/{parent=users/" +
+      "*/profile}/blurbs:\001*\022\261\001\n\010GetBlurb\022(.goog" +
+      "le.showcase.v1beta1.GetBlurbRequest\032\036.go" +
+      "ogle.showcase.v1beta1.Blurb\"[\332A\004name\202\323\344\223" +
+      "\002N\022 /v1beta1/{name=rooms/*/blurbs/*}Z*\022(" +
+      "/v1beta1/{name=users/*/profile/blurbs/*}" +
+      "\022\312\001\n\013UpdateBlurb\022+.google.showcase.v1bet" +
+      "a1.UpdateBlurbRequest\032\036.google.showcase." +
+      "v1beta1.Blurb\"n\202\323\344\223\002h2&/v1beta1/{blurb.n" +
+      "ame=rooms/*/blurbs/*}:\005blurbZ72./v1beta1" +
+      "/{blurb.name=users/*/profile/blurbs/*}:\005" +
+      "blurb\022\257\001\n\013DeleteBlurb\022+.google.showcase." +
+      "v1beta1.DeleteBlurbRequest\032\026.google.prot" +
+      "obuf.Empty\"[\332A\004name\202\323\344\223\002N* /v1beta1/{nam" +
+      "e=rooms/*/blurbs/*}Z**(/v1beta1/{name=us" +
+      "ers/*/profile/blurbs/*}\022\304\001\n\nListBlurbs\022*" +
+      ".google.showcase.v1beta1.ListBlurbsReque" +
+      "st\032+.google.showcase.v1beta1.ListBlurbsR" +
+      "esponse\"]\332A\006parent\202\323\344\223\002N\022 /v1beta1/{pare" +
+      "nt=rooms/*}/blurbsZ*\022(/v1beta1/{parent=u" +
+      "sers/*/profile}/blurbs\022\201\002\n\014SearchBlurbs\022" +
+      ",.google.showcase.v1beta1.SearchBlurbsRe" +
+      "quest\032\035.google.longrunning.Operation\"\243\001\312" +
+      "A,\n\024SearchBlurbsResponse\022\024SearchBlurbsMe" +
+      "tadata\332A\014parent,query\202\323\344\223\002_\"\'/v1beta1/{p" +
+      "arent=rooms/*}/blurbs:search:\001*Z1\"//v1be" +
+      "ta1/{parent=users/*/profile}/blurbs:sear" +
+      "ch\022\323\001\n\014StreamBlurbs\022,.google.showcase.v1" +
+      "beta1.StreamBlurbsRequest\032-.google.showc" +
+      "ase.v1beta1.StreamBlurbsResponse\"d\202\323\344\223\002^" +
+      "\"%/v1beta1/{name=rooms/*}/blurbs:stream:" +
+      "\001*Z2\"-/v1beta1/{name=users/*/profile}/bl" +
+      "urbs:stream:\001*0\001\022\316\001\n\nSendBlurbs\022+.google" +
+      ".showcase.v1beta1.CreateBlurbRequest\032+.g" +
+      "oogle.showcase.v1beta1.SendBlurbsRespons" +
+      "e\"d\202\323\344\223\002^\"%/v1beta1/{parent=rooms/*}/blu" +
+      "rbs:send:\001*Z2\"-/v1beta1/{parent=users/*/" +
+      "profile}/blurbs:send:\001*(\001\022e\n\007Connect\022\'.g" +
+      "oogle.showcase.v1beta1.ConnectRequest\032-." +
+      "google.showcase.v1beta1.StreamBlurbsResp" +
+      "onse(\0010\001\032\021\312A\016localhost:7469Bq\n\033com.googl" +
+      "e.showcase.v1beta1P\001Z4github.com/googlea" +
+      "pis/gapic-showcase/server/genproto\352\002\031Goo" +
+      "gle::Showcase::V1beta1b\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/SequenceOuterClass.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/SequenceOuterClass.java
@@ -106,92 +106,91 @@ public final class SequenceOuterClass {
       "\032\031google/api/resource.proto\032\036google/prot" +
       "obuf/duration.proto\032\033google/protobuf/emp" +
       "ty.proto\032\037google/protobuf/timestamp.prot" +
-      "o\032\027google/rpc/status.proto\"\364\001\n\010Sequence\022" +
-      "\022\n\004name\030\001 \001(\tB\004\342A\001\003\022=\n\tresponses\030\002 \003(\0132*" +
-      ".google.showcase.v1beta1.Sequence.Respon" +
-      "se\032X\n\010Response\022\"\n\006status\030\001 \001(\0132\022.google." +
+      "o\032\027google/rpc/status.proto\"\363\001\n\010Sequence\022" +
+      "\021\n\004name\030\001 \001(\tB\003\340A\003\022=\n\tresponses\030\002 \003(\0132*." +
+      "google.showcase.v1beta1.Sequence.Respons" +
+      "e\032X\n\010Response\022\"\n\006status\030\001 \001(\0132\022.google.r" +
+      "pc.Status\022(\n\005delay\030\002 \001(\0132\031.google.protob" +
+      "uf.Duration:;\352A8\n showcase.googleapis.co" +
+      "m/Sequence\022\024sequences/{sequence}\"\312\002\n\021Str" +
+      "eamingSequence\022\021\n\004name\030\001 \001(\tB\003\340A\003\022\017\n\007con" +
+      "tent\030\002 \001(\t\022F\n\tresponses\030\003 \003(\01323.google.s" +
+      "howcase.v1beta1.StreamingSequence.Respon" +
+      "se\032p\n\010Response\022\"\n\006status\030\001 \001(\0132\022.google." +
       "rpc.Status\022(\n\005delay\030\002 \001(\0132\031.google.proto" +
-      "buf.Duration:;\352A8\n showcase.googleapis.c" +
-      "om/Sequence\022\024sequences/{sequence}\"\313\002\n\021St" +
-      "reamingSequence\022\022\n\004name\030\001 \001(\tB\004\342A\001\003\022\017\n\007c" +
-      "ontent\030\002 \001(\t\022F\n\tresponses\030\003 \003(\01323.google" +
-      ".showcase.v1beta1.StreamingSequence.Resp" +
-      "onse\032p\n\010Response\022\"\n\006status\030\001 \001(\0132\022.googl" +
-      "e.rpc.Status\022(\n\005delay\030\002 \001(\0132\031.google.pro" +
-      "tobuf.Duration\022\026\n\016response_index\030\003 \001(\005:W" +
-      "\352AT\n)showcase.googleapis.com/StreamingSe" +
-      "quence\022\'streamingSequences/{streaming_se" +
-      "quence}\"\323\003\n\027StreamingSequenceReport\022\022\n\004n" +
-      "ame\030\001 \001(\tB\004\342A\001\003\022J\n\010attempts\030\002 \003(\01328.goog" +
-      "le.showcase.v1beta1.StreamingSequenceRep" +
-      "ort.Attempt\032\340\001\n\007Attempt\022\026\n\016attempt_numbe" +
-      "r\030\001 \001(\005\0224\n\020attempt_deadline\030\002 \001(\0132\032.goog" +
-      "le.protobuf.Timestamp\0221\n\rresponse_time\030\003" +
-      " \001(\0132\032.google.protobuf.Timestamp\0220\n\ratte" +
-      "mpt_delay\030\004 \001(\0132\031.google.protobuf.Durati" +
-      "on\022\"\n\006status\030\005 \001(\0132\022.google.rpc.Status:u" +
-      "\352Ar\n/showcase.googleapis.com/StreamingSe" +
-      "quenceReport\022?streamingSequences/{stream" +
-      "ing_sequence}/streamingSequenceReport\"\234\003" +
-      "\n\016SequenceReport\022\022\n\004name\030\001 \001(\tB\004\342A\001\003\022A\n\010" +
-      "attempts\030\002 \003(\0132/.google.showcase.v1beta1" +
-      ".SequenceReport.Attempt\032\340\001\n\007Attempt\022\026\n\016a" +
-      "ttempt_number\030\001 \001(\005\0224\n\020attempt_deadline\030" +
-      "\002 \001(\0132\032.google.protobuf.Timestamp\0221\n\rres" +
-      "ponse_time\030\003 \001(\0132\032.google.protobuf.Times" +
-      "tamp\0220\n\rattempt_delay\030\004 \001(\0132\031.google.pro" +
-      "tobuf.Duration\022\"\n\006status\030\005 \001(\0132\022.google." +
-      "rpc.Status:P\352AM\n&showcase.googleapis.com" +
-      "/SequenceReport\022#sequences/{sequence}/se" +
-      "quenceReport\"L\n\025CreateSequenceRequest\0223\n" +
-      "\010sequence\030\001 \001(\0132!.google.showcase.v1beta" +
-      "1.Sequence\"h\n\036CreateStreamingSequenceReq" +
-      "uest\022F\n\022streaming_sequence\030\001 \001(\0132*.googl" +
-      "e.showcase.v1beta1.StreamingSequence\"Q\n\026" +
-      "AttemptSequenceRequest\0227\n\004name\030\001 \001(\tB)\342A" +
-      "\001\002\372A\"\n showcase.googleapis.com/Sequence\"" +
-      "\202\001\n\037AttemptStreamingSequenceRequest\022@\n\004n" +
-      "ame\030\001 \001(\tB2\342A\001\002\372A+\n)showcase.googleapis." +
-      "com/StreamingSequence\022\035\n\017last_fail_index" +
-      "\030\002 \001(\005B\004\342A\001\001\"3\n AttemptStreamingSequence" +
-      "Response\022\017\n\007content\030\001 \001(\t\"Y\n\030GetSequence" +
-      "ReportRequest\022=\n\004name\030\001 \001(\tB/\342A\001\002\372A(\n&sh" +
-      "owcase.googleapis.com/SequenceReport\"k\n!" +
-      "GetStreamingSequenceReportRequest\022F\n\004nam" +
-      "e\030\001 \001(\tB8\342A\001\002\372A1\n/showcase.googleapis.co" +
-      "m/StreamingSequenceReport2\360\010\n\017SequenceSe" +
-      "rvice\022\224\001\n\016CreateSequence\022..google.showca" +
-      "se.v1beta1.CreateSequenceRequest\032!.googl" +
-      "e.showcase.v1beta1.Sequence\"/\332A\010sequence" +
-      "\202\323\344\223\002\036\"\022/v1beta1/sequences:\010sequence\022\314\001\n" +
-      "\027CreateStreamingSequence\0227.google.showca" +
-      "se.v1beta1.CreateStreamingSequenceReques" +
-      "t\032*.google.showcase.v1beta1.StreamingSeq" +
-      "uence\"L\332A\022streaming_sequence\202\323\344\223\0021\"\033/v1b" +
-      "eta1/streamingSequences:\022streaming_seque" +
-      "nce\022\252\001\n\021GetSequenceReport\0221.google.showc" +
-      "ase.v1beta1.GetSequenceReportRequest\032\'.g" +
-      "oogle.showcase.v1beta1.SequenceReport\"9\332" +
-      "A\004name\202\323\344\223\002,\022*/v1beta1/{name=sequences/*" +
-      "/sequenceReport}\022\327\001\n\032GetStreamingSequenc" +
-      "eReport\022:.google.showcase.v1beta1.GetStr" +
-      "eamingSequenceReportRequest\0320.google.sho" +
-      "wcase.v1beta1.StreamingSequenceReport\"K\332" +
-      "A\004name\202\323\344\223\002>\022</v1beta1/{name=streamingSe" +
-      "quences/*/streamingSequenceReport}\022\211\001\n\017A" +
-      "ttemptSequence\022/.google.showcase.v1beta1" +
-      ".AttemptSequenceRequest\032\026.google.protobu" +
-      "f.Empty\"-\332A\004name\202\323\344\223\002 \"\033/v1beta1/{name=s" +
-      "equences/*}:\001*\022\320\001\n\030AttemptStreamingSeque" +
-      "nce\0228.google.showcase.v1beta1.AttemptStr" +
-      "eamingSequenceRequest\0329.google.showcase." +
-      "v1beta1.AttemptStreamingSequenceResponse" +
-      "\"=\332A\004name\202\323\344\223\0020\"+/v1beta1/{name=streamin" +
-      "gSequences/*}:stream:\001*0\001\032\021\312A\016localhost:" +
-      "7469Bq\n\033com.google.showcase.v1beta1P\001Z4g" +
-      "ithub.com/googleapis/gapic-showcase/serv" +
-      "er/genproto\352\002\031Google::Showcase::V1beta1b" +
-      "\006proto3"
+      "buf.Duration\022\026\n\016response_index\030\003 \001(\005:W\352A" +
+      "T\n)showcase.googleapis.com/StreamingSequ" +
+      "ence\022\'streamingSequences/{streaming_sequ" +
+      "ence}\"\322\003\n\027StreamingSequenceReport\022\021\n\004nam" +
+      "e\030\001 \001(\tB\003\340A\003\022J\n\010attempts\030\002 \003(\01328.google." +
+      "showcase.v1beta1.StreamingSequenceReport" +
+      ".Attempt\032\340\001\n\007Attempt\022\026\n\016attempt_number\030\001" +
+      " \001(\005\0224\n\020attempt_deadline\030\002 \001(\0132\032.google." +
+      "protobuf.Timestamp\0221\n\rresponse_time\030\003 \001(" +
+      "\0132\032.google.protobuf.Timestamp\0220\n\rattempt" +
+      "_delay\030\004 \001(\0132\031.google.protobuf.Duration\022" +
+      "\"\n\006status\030\005 \001(\0132\022.google.rpc.Status:u\352Ar" +
+      "\n/showcase.googleapis.com/StreamingSeque" +
+      "nceReport\022?streamingSequences/{streaming" +
+      "_sequence}/streamingSequenceReport\"\233\003\n\016S" +
+      "equenceReport\022\021\n\004name\030\001 \001(\tB\003\340A\003\022A\n\010atte" +
+      "mpts\030\002 \003(\0132/.google.showcase.v1beta1.Seq" +
+      "uenceReport.Attempt\032\340\001\n\007Attempt\022\026\n\016attem" +
+      "pt_number\030\001 \001(\005\0224\n\020attempt_deadline\030\002 \001(" +
+      "\0132\032.google.protobuf.Timestamp\0221\n\rrespons" +
+      "e_time\030\003 \001(\0132\032.google.protobuf.Timestamp" +
+      "\0220\n\rattempt_delay\030\004 \001(\0132\031.google.protobu" +
+      "f.Duration\022\"\n\006status\030\005 \001(\0132\022.google.rpc." +
+      "Status:P\352AM\n&showcase.googleapis.com/Seq" +
+      "uenceReport\022#sequences/{sequence}/sequen" +
+      "ceReport\"L\n\025CreateSequenceRequest\0223\n\010seq" +
+      "uence\030\001 \001(\0132!.google.showcase.v1beta1.Se" +
+      "quence\"h\n\036CreateStreamingSequenceRequest" +
+      "\022F\n\022streaming_sequence\030\001 \001(\0132*.google.sh" +
+      "owcase.v1beta1.StreamingSequence\"P\n\026Atte" +
+      "mptSequenceRequest\0226\n\004name\030\001 \001(\tB(\340A\002\372A\"" +
+      "\n showcase.googleapis.com/Sequence\"\200\001\n\037A" +
+      "ttemptStreamingSequenceRequest\022?\n\004name\030\001" +
+      " \001(\tB1\340A\002\372A+\n)showcase.googleapis.com/St" +
+      "reamingSequence\022\034\n\017last_fail_index\030\002 \001(\005" +
+      "B\003\340A\001\"3\n AttemptStreamingSequenceRespons" +
+      "e\022\017\n\007content\030\001 \001(\t\"X\n\030GetSequenceReportR" +
+      "equest\022<\n\004name\030\001 \001(\tB.\340A\002\372A(\n&showcase.g" +
+      "oogleapis.com/SequenceReport\"j\n!GetStrea" +
+      "mingSequenceReportRequest\022E\n\004name\030\001 \001(\tB" +
+      "7\340A\002\372A1\n/showcase.googleapis.com/Streami" +
+      "ngSequenceReport2\360\010\n\017SequenceService\022\224\001\n" +
+      "\016CreateSequence\022..google.showcase.v1beta" +
+      "1.CreateSequenceRequest\032!.google.showcas" +
+      "e.v1beta1.Sequence\"/\332A\010sequence\202\323\344\223\002\036\"\022/" +
+      "v1beta1/sequences:\010sequence\022\314\001\n\027CreateSt" +
+      "reamingSequence\0227.google.showcase.v1beta" +
+      "1.CreateStreamingSequenceRequest\032*.googl" +
+      "e.showcase.v1beta1.StreamingSequence\"L\332A" +
+      "\022streaming_sequence\202\323\344\223\0021\"\033/v1beta1/stre" +
+      "amingSequences:\022streaming_sequence\022\252\001\n\021G" +
+      "etSequenceReport\0221.google.showcase.v1bet" +
+      "a1.GetSequenceReportRequest\032\'.google.sho" +
+      "wcase.v1beta1.SequenceReport\"9\332A\004name\202\323\344" +
+      "\223\002,\022*/v1beta1/{name=sequences/*/sequence" +
+      "Report}\022\327\001\n\032GetStreamingSequenceReport\022:" +
+      ".google.showcase.v1beta1.GetStreamingSeq" +
+      "uenceReportRequest\0320.google.showcase.v1b" +
+      "eta1.StreamingSequenceReport\"K\332A\004name\202\323\344" +
+      "\223\002>\022</v1beta1/{name=streamingSequences/*" +
+      "/streamingSequenceReport}\022\211\001\n\017AttemptSeq" +
+      "uence\022/.google.showcase.v1beta1.AttemptS" +
+      "equenceRequest\032\026.google.protobuf.Empty\"-" +
+      "\332A\004name\202\323\344\223\002 \"\033/v1beta1/{name=sequences/" +
+      "*}:\001*\022\320\001\n\030AttemptStreamingSequence\0228.goo" +
+      "gle.showcase.v1beta1.AttemptStreamingSeq" +
+      "uenceRequest\0329.google.showcase.v1beta1.A" +
+      "ttemptStreamingSequenceResponse\"=\332A\004name" +
+      "\202\323\344\223\0020\"+/v1beta1/{name=streamingSequence" +
+      "s/*}:stream:\001*0\001\032\021\312A\016localhost:7469Bq\n\033c" +
+      "om.google.showcase.v1beta1P\001Z4github.com" +
+      "/googleapis/gapic-showcase/server/genpro" +
+      "to\352\002\031Google::Showcase::V1beta1b\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,


### PR DESCRIPTION
Run the latest invocation of `mvn compile -P update`.

The diffs were in https://github.com/googleapis/sdk-platform-java/pull/2360 and failing the showcase CI jobs.