### PR TITLE
chore: update dev guide to get version of gapic-showcase to install.

### DIFF
--- a/showcase/README.md
+++ b/showcase/README.md
@@ -18,7 +18,7 @@ update to a compatible client version in `./WORKSPACE`.
 ```shell
 # Install the showcase server version defined in gapic-showcase/pom.xml
 cd showcase
-go install github.com/googleapis/gapic-showcase/cmd/gapic-showcase@v"$(cd gapic-showcase;mvn help:evaluate -Dexpression=gapic-showcase.version -q -DforceStdout)"
+go install github.com/googleapis/gapic-showcase/cmd/gapic-showcase@v"$(cd gapic-showcase;mvn help:evaluate -Dexpression=gapic-showcase.version -q -DforceStdout |sed 's/\x1b\[[0-9;]*m//g')"
 PATH=$PATH:`go env GOPATH`/bin
 gapic-showcase --help
 > Root command of gapic-showcase


### PR DESCRIPTION
This addition removes the trailing ANSI escape sequence (`\x1b[0m`) on the returned version.
This regex `\x1b\[[0-9;]*m` matches ANSI escape sequences.