### PR TITLE
chore: fix workflow to create additional tags

### DIFF
--- a/.github/workflows/create_additional_release_tag.yaml
+++ b/.github/workflows/create_additional_release_tag.yaml
@@ -38,6 +38,8 @@ jobs:
         # Use fixed tag so that checks in handwritten libraries do not need to
         # update the version.
         CHECK_LATEST_TAG="unmanaged-dependencies-check-latest"
+        # delete and create the tag locally.
+        git tag --delete ${CHECK_LATEST_TAG}
         git tag ${CHECK_LATEST_TAG}
         # delete the tag in remote repo and push again.
         git push --delete origin ${CHECK_LATEST_TAG}


### PR DESCRIPTION
The workflow to create additional tags when releasing is failing: https://github.com/googleapis/sdk-platform-java/actions/runs/7893005878/job/21540707818.

Delete the local tag before creating one.