### PR TITLE
fix: ignore comment in BUILD

### DIFF
--- a/library_generation/model/gapic_inputs.py
+++ b/library_generation/model/gapic_inputs.py
@@ -36,7 +36,7 @@ comment_pattern = r"^\s*\#+"
 pattern_to_proto = {
     r"//google/cloud:common_resources_proto": "google/cloud/common_resources.proto",
     r"//google/cloud/location:location_proto": "google/cloud/location/locations.proto",
-    r"//google/iam/v1:iam_policy_proto": "google/iam/v1/iam_policy.proto"
+    r"//google/iam/v1:iam_policy_proto": "google/iam/v1/iam_policy.proto",
 }
 transport_pattern = r"transport = \"(.*?)\""
 rest_pattern = r"rest_numeric_enums = True"

--- a/library_generation/test/resources/misc/BUILD_comment_common_resources.bazel
+++ b/library_generation/test/resources/misc/BUILD_comment_common_resources.bazel
@@ -1,0 +1,5 @@
+proto_library_with_info(
+  deps = [
+    #"//google/cloud:common_resources_proto",
+  ]
+)

--- a/library_generation/test/resources/misc/BUILD_comment_iam_policy.bazel
+++ b/library_generation/test/resources/misc/BUILD_comment_iam_policy.bazel
@@ -1,0 +1,5 @@
+proto_library_with_info(
+  deps = [
+    # "//google/iam/v1:iam_policy_proto",
+  ]
+)

--- a/library_generation/test/resources/misc/BUILD_comment_locations.bazel
+++ b/library_generation/test/resources/misc/BUILD_comment_locations.bazel
@@ -1,0 +1,5 @@
+proto_library_with_info(
+  deps = [
+    # "//google/cloud/location:location_proto",
+  ]
+)

--- a/library_generation/test/resources/misc/BUILD_common_resources.bazel
+++ b/library_generation/test/resources/misc/BUILD_common_resources.bazel
@@ -1,0 +1,5 @@
+proto_library_with_info(
+  deps = [
+    "//google/cloud:common_resources_proto",
+  ]
+)

--- a/library_generation/test/resources/misc/BUILD_iam_locations.bazel
+++ b/library_generation/test/resources/misc/BUILD_iam_locations.bazel
@@ -1,6 +1,6 @@
 proto_library_with_info(
   deps = [
-    "//google/iam/v1:iam_policy_proto",
     "//google/cloud/location:location_proto",
+    "//google/iam/v1:iam_policy_proto",
   ]
 )

--- a/library_generation/test/resources/misc/BUILD_iam_locations.bazel
+++ b/library_generation/test/resources/misc/BUILD_iam_locations.bazel
@@ -1,5 +1,3 @@
-# this file is only used in testing `get_gapic_additional_protos_from_BUILD` in utilities.sh
-
 proto_library_with_info(
   deps = [
     "//google/iam/v1:iam_policy_proto",

--- a/library_generation/test/resources/misc/BUILD_iam_policy.bazel
+++ b/library_generation/test/resources/misc/BUILD_iam_policy.bazel
@@ -1,0 +1,5 @@
+proto_library_with_info(
+  deps = [
+    "//google/iam/v1:iam_policy_proto",
+  ]
+)

--- a/library_generation/test/resources/misc/BUILD_locations.bazel
+++ b/library_generation/test/resources/misc/BUILD_locations.bazel
@@ -1,0 +1,5 @@
+proto_library_with_info(
+  deps = [
+    "//google/cloud/location:location_proto",
+  ]
+)

--- a/library_generation/test/resources/misc/BUILD_no_additional_protos.bazel
+++ b/library_generation/test/resources/misc/BUILD_no_additional_protos.bazel
@@ -1,0 +1,4 @@
+proto_library_with_info(
+  deps = [
+  ]
+)

--- a/library_generation/test/resources/search_additional_protos/BUILD_common_resources.bazel
+++ b/library_generation/test/resources/search_additional_protos/BUILD_common_resources.bazel
@@ -1,6 +1,0 @@
-# this file is only used in testing `get_gapic_additional_protos_from_BUILD` in utilities.sh
-
-proto_library_with_info(
-  deps = [
-  ]
-)

--- a/library_generation/test/resources/search_additional_protos/BUILD_iam_policy.bazel
+++ b/library_generation/test/resources/search_additional_protos/BUILD_iam_policy.bazel
@@ -1,7 +1,0 @@
-# this file is only used in testing `get_gapic_additional_protos_from_BUILD` in utilities.sh
-
-proto_library_with_info(
-  deps = [
-    "//google/iam/v1:iam_policy_proto",
-  ]
-)

--- a/library_generation/test/resources/search_additional_protos/BUILD_locations.bazel
+++ b/library_generation/test/resources/search_additional_protos/BUILD_locations.bazel
@@ -1,7 +1,0 @@
-# this file is only used in testing `get_gapic_additional_protos_from_BUILD` in utilities.sh
-
-proto_library_with_info(
-  deps = [
-    "//google/cloud/location:location_proto",
-  ]
-)

--- a/library_generation/test/unit_tests.py
+++ b/library_generation/test/unit_tests.py
@@ -214,44 +214,25 @@ class UtilitiesTest(unittest.TestCase):
         self.assertEqual("google/cloud/asset/v1p5beta1", gapics[3].proto_path)
         self.assertEqual("google/cloud/asset/v1p7beta1", gapics[4].proto_path)
 
-    def test_gapic_inputs_parse_add_protos_no_additions(self):
-        parsed = parse_build_file(build_file, "", "BUILD_no_additional_protos.bazel")
-        self.assertEqual(" ", parsed.additional_protos)
-
-    def test_gapic_inputs_parse_add_protos_common_resources(self):
-        parsed = parse_build_file(build_file, "", "BUILD_common_resources.bazel")
+    @parameterized.expand(
+        [
+            ("BUILD_no_additional_protos.bazel", " "),
+            ("BUILD_common_resources.bazel", "  google/cloud/common_resources.proto"),
+            ("BUILD_comment_common_resources.bazel", " "),
+            ("BUILD_locations.bazel", "  google/cloud/location/locations.proto"),
+            ("BUILD_comment_locations.bazel", " "),
+            ("BUILD_iam_policy.bazel", "  google/iam/v1/iam_policy.proto"),
+            ("BUILD_comment_iam_policy.bazel", " "),
+            (
+                "BUILD_iam_locations.bazel",
+                "  google/cloud/location/locations.proto google/iam/v1/iam_policy.proto",
+            ),
+        ]
+    )
+    def test_gapic_inputs_parse_additional_protos(self, build_name, expected):
+        parsed = parse_build_file(build_file, "", build_name)
         self.assertEqual(
-            "  google/cloud/common_resources.proto", parsed.additional_protos
-        )
-
-    def test_gapic_inputs_parse_add_protos_common_resources_comment_out(self):
-        parsed = parse_build_file(
-            build_file, "", "BUILD_comment_common_resources.bazel"
-        )
-        self.assertEqual(" ", parsed.additional_protos)
-
-    def test_gapic_inputs_parse_add_protos_location(self):
-        parsed = parse_build_file(build_file, "", "BUILD_locations.bazel")
-        self.assertEqual(
-            "  google/cloud/location/locations.proto", parsed.additional_protos
-        )
-
-    def test_gapic_inputs_parse_add_protos_location_comment_out(self):
-        parsed = parse_build_file(build_file, "", "BUILD_comment_locations.bazel")
-        self.assertEqual(" ", parsed.additional_protos)
-
-    def test_gapic_inputs_parse_add_protos_iam(self):
-        parsed = parse_build_file(build_file, "", "BUILD_iam_policy.bazel")
-        self.assertEqual("  google/iam/v1/iam_policy.proto", parsed.additional_protos)
-
-    def test_gapic_inputs_parse_add_protos_iam_comment_out(self):
-        parsed = parse_build_file(build_file, "", "BUILD_comment_iam_policy.bazel")
-        self.assertEqual(" ", parsed.additional_protos)
-
-    def test_gapic_inputs_parse_add_protos_iam_locations(self):
-        parsed = parse_build_file(build_file, "", "BUILD_iam_locations.bazel")
-        self.assertEqual(
-            "  google/cloud/location/locations.proto google/iam/v1/iam_policy.proto",
+            expected,
             parsed.additional_protos,
         )
 

--- a/library_generation/test/unit_tests.py
+++ b/library_generation/test/unit_tests.py
@@ -214,6 +214,47 @@ class UtilitiesTest(unittest.TestCase):
         self.assertEqual("google/cloud/asset/v1p5beta1", gapics[3].proto_path)
         self.assertEqual("google/cloud/asset/v1p7beta1", gapics[4].proto_path)
 
+    def test_gapic_inputs_parse_add_protos_no_additions(self):
+        parsed = parse_build_file(build_file, "", "BUILD_no_additional_protos.bazel")
+        self.assertEqual(" ", parsed.additional_protos)
+
+    def test_gapic_inputs_parse_add_protos_common_resources(self):
+        parsed = parse_build_file(build_file, "", "BUILD_common_resources.bazel")
+        self.assertEqual(
+            "  google/cloud/common_resources.proto", parsed.additional_protos
+        )
+
+    def test_gapic_inputs_parse_add_protos_common_resources_comment_out(self):
+        parsed = parse_build_file(
+            build_file, "", "BUILD_comment_common_resources.bazel"
+        )
+        self.assertEqual(" ", parsed.additional_protos)
+
+    def test_gapic_inputs_parse_add_protos_location(self):
+        parsed = parse_build_file(build_file, "", "BUILD_locations.bazel")
+        self.assertEqual(
+            "  google/cloud/location/locations.proto", parsed.additional_protos
+        )
+
+    def test_gapic_inputs_parse_add_protos_location_comment_out(self):
+        parsed = parse_build_file(build_file, "", "BUILD_comment_locations.bazel")
+        self.assertEqual(" ", parsed.additional_protos)
+
+    def test_gapic_inputs_parse_add_protos_iam(self):
+        parsed = parse_build_file(build_file, "", "BUILD_iam_policy.bazel")
+        self.assertEqual("  google/iam/v1/iam_policy.proto", parsed.additional_protos)
+
+    def test_gapic_inputs_parse_add_protos_iam_comment_out(self):
+        parsed = parse_build_file(build_file, "", "BUILD_comment_iam_policy.bazel")
+        self.assertEqual(" ", parsed.additional_protos)
+
+    def test_gapic_inputs_parse_add_protos_iam_locations(self):
+        parsed = parse_build_file(build_file, "", "BUILD_iam_locations.bazel")
+        self.assertEqual(
+            "  google/cloud/location/locations.proto google/iam/v1/iam_policy.proto",
+            parsed.additional_protos,
+        )
+
     def test_gapic_inputs_parse_grpc_only_succeeds(self):
         parsed = parse_build_file(build_file, "", "BUILD_grpc.bazel")
         self.assertEqual("grpc", parsed.transport)


### PR DESCRIPTION
In this PR:
- Ignore comment (leading with `#`) when parsing BUILD.bazel
- Add unit tests

Context: There's a [BUILD](https://github.com/googleapis/googleapis/blob/master/google/cloud/resourcemanager/v3/BUILD.bazel#L52C10-L52C50) in googleapis has common_resources.proto comment out. We need to adjust the regex pattern to adjust this case.