### PR TITLE
chore: suppress download progress

### DIFF
--- a/library_generation/owlbot/bin/entrypoint.sh
+++ b/library_generation/owlbot/bin/entrypoint.sh
@@ -86,7 +86,7 @@ echo "...done"
 
 # ensure formatting on all .java files in the repository
 echo "Reformatting source..."
-mvn fmt:format
+mvn fmt:format -V --batch-mode --no-transfer-progress
 echo "...done"
 
 


### PR DESCRIPTION
In this PR:
- Suppress logs of download progress when running `fmt` plugin.