### PR TITLE
chore: manually update graalvm docker image tag to 3.26.0

### DIFF
--- a/.cloudbuild/graalvm/cloudbuild-test-a.yaml
+++ b/.cloudbuild/graalvm/cloudbuild-test-a.yaml
@@ -14,7 +14,7 @@
 
 timeout: 7200s # 2 hours
 substitutions:
-  _SHARED_DEPENDENCIES_VERSION: '3.25.1-SNAPSHOT' # {x-version-update:google-cloud-shared-dependencies:current}
+  _SHARED_DEPENDENCIES_VERSION: '3.26.0' # {x-version-update:google-cloud-shared-dependencies:current}
   _JAVA_SHARED_CONFIG_VERSION: '1.7.4'
 
 steps:

--- a/.cloudbuild/graalvm/cloudbuild-test-b.yaml
+++ b/.cloudbuild/graalvm/cloudbuild-test-b.yaml
@@ -14,7 +14,7 @@
 
 timeout: 7200s # 2 hours
 substitutions:
-  _SHARED_DEPENDENCIES_VERSION: '3.25.1-SNAPSHOT' # {x-version-update:google-cloud-shared-dependencies:current}
+  _SHARED_DEPENDENCIES_VERSION: '3.26.0' # {x-version-update:google-cloud-shared-dependencies:current}
   _JAVA_SHARED_CONFIG_VERSION: '1.7.4'
 
 steps:

--- a/.cloudbuild/graalvm/cloudbuild.yaml
+++ b/.cloudbuild/graalvm/cloudbuild.yaml
@@ -14,7 +14,7 @@
 
 timeout: 7200s # 2 hours
 substitutions:
-  _SHARED_DEPENDENCIES_VERSION: '3.25.1-SNAPSHOT' # {x-version-update:google-cloud-shared-dependencies:current}
+  _SHARED_DEPENDENCIES_VERSION: '3.26.0' # {x-version-update:google-cloud-shared-dependencies:current}
   _JAVA_SHARED_CONFIG_VERSION: '1.7.4'
 steps:
   # GraalVM A build


### PR DESCRIPTION
Release-please was unable to update the image tag because the configs weren't up-to-date with the new directory structure (https://github.com/googleapis/sdk-platform-java/pull/2524). Performing a one time update to ensure the docker image tag matches the shared-dependencies version. 