### PR TITLE
chore: add `jq` to hermetic build image definition

### DIFF
--- a/.cloudbuild/library_generation/library_generation.Dockerfile
+++ b/.cloudbuild/library_generation/library_generation.Dockerfile
@@ -17,7 +17,7 @@ FROM gcr.io/cloud-devrel-public-resources/python
 
 # install tools
 RUN apt-get update && apt-get install -y \
-	unzip openjdk-17-jdk rsync maven \
+	unzip openjdk-17-jdk rsync maven jq \
 	&& apt-get clean
 
 COPY library_generation /src


### PR DESCRIPTION
From https://github.com/diegomarquezp/google-cloud-java/actions/runs/8178920720/job/22363860250

```
+ /usr/local/lib/python3.11/site-packages/library_generation/owlbot/bin/write_clirr_ignore.sh /usr/local/lib/python3.11/site-packages/library_generation
/workspace/google-cloud-java/java-datastore/proto-google-cloud-datastore-v1 /workspace/google-cloud-java/java-datastore
/workspace/google-cloud-java/java-datastore/proto-google-cloud-datastore-v1/src/main/java /workspace/google-cloud-java/java-datastore/proto-google-cloud-datastore-v1 /workspace/google-cloud-java/java-datastore
/usr/local/lib/python3.11/site-packages/library_generation/owlbot/bin/write_clirr_ignore.sh: line 29: jq: command not found
Library postprocessing failed
Error: Process completed with exit code 1.
```

This PR adds jq to the docker image

## Cause
`write_clirr_ignore` only acts on the repo whenever there is no clirr_ignored_differences found. This occurs when generating a new library from scratch, and we've only testing against existing libraries (i.e. we didn't reach this call to `jq` in any of our previous testing).

https://github.com/googleapis/sdk-platform-java/blob/92e91bc0d91a2619a87abf9b072229a3ab3f4d91/library_generation/owlbot/bin/write_clirr_ignore.sh#L24-L29