### PR TITLE
chore: fix renovate bot configs for java-shared-config updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -64,7 +64,7 @@
         "^.cloudbuild/*"
       ],
       "matchStrings": [
-        "_JAVA_SHARED_CONFIG_VERSION: \"(?<currentValue>.+?)\""
+        "  _JAVA_SHARED_CONFIG_VERSION: '(?<currentValue>.+?)'"
       ],
       "depNameTemplate": "com.google.cloud:google-cloud-shared-config",
       "datasourceTemplate": "maven"
@@ -103,7 +103,8 @@
         "^com.google.cloud:google-cloud-shared-config"
       ],
       "semanticCommitType": "build",
-      "semanticCommitScope": "deps"
+      "semanticCommitScope": "deps",
+      "enabled": true
     },
     {
       "matchPackagePatterns": [


### PR DESCRIPTION
Fixes https://github.com/googleapis/sdk-platform-java/issues/2511. Verified with https://github.com/mpeddada1/forking-renovate-repro/pull/15

The Dependency Dashboard logs were shows the status of java-shared-config as being `skipReason:disabled`. Explicitly setting `enabled` to `true` resolves this issue. 

```
{
            "datasource": "maven",
            "depName": "com.google.cloud:google-cloud-shared-config",
            "currentValue": "1.7.1",
            "fileReplacePosition": 873,
            "registryUrls": [
              "https://repo.maven.apache.org/maven2",
              "https://maven-central.storage-download.googleapis.com/maven2",
              "https://repo1.maven.org/maven2",
              "https://maven-central.storage-download.googleapis.com/maven2/"
            ],
            "depType": "parent-root",
            "updates": [],
            "packageName": "com.google.cloud:google-cloud-shared-config",
            "skipReason": "disabled"
          },
```