### PR TITLE
fix: Use ServiceName + MethodName as the regex for Otel

### DIFF
--- a/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallableFactory.java
+++ b/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallableFactory.java
@@ -52,10 +52,8 @@ import javax.annotation.Nonnull;
 
 /** Class with utility methods to create http/json-based direct callables. */
 public class HttpJsonCallableFactory {
-  // Used to extract service and method name from a grpc MethodDescriptor.
-  // fullMethodName has the format: service.resource.action
-  // For example: compute.instances.addAccessConfig
-  private static final Pattern FULL_METHOD_NAME_REGEX = Pattern.compile("^(.+)\\.(.+)$");
+  // Used to extract service and method name from a HttpJson MethodDescriptor.
+  private static final Pattern FULL_METHOD_NAME_REGEX = Pattern.compile("^.*?([^./]+)/([^./]+)$");
 
   private HttpJsonCallableFactory() {}
 


### PR DESCRIPTION
Fixes: https://github.com/googleapis/sdk-platform-java/issues/2502

Use a consistent Regex matching pattern for both gRPC and HttpJson. Copy the pattern used for gRPC into HttpJson.

Looking at the Method Descriptor for HttpJson (Compute as an example), the full method name does not match `service.resource.action`: https://github.com/googleapis/google-cloud-java/blob/1f9e63224424327a08e3663985773546b3f7808b/java-compute/google-cloud-compute/src/main/java/com/google/cloud/compute/v1/stub/HttpJsonBackendServicesStub.java#L85

It seems to match `ServiceName/MethodName`.