### PR TITLE
chore: write description to a file

### DIFF
--- a/library_generation/generate_pr_description.py
+++ b/library_generation/generate_pr_description.py
@@ -68,11 +68,16 @@ def generate(
     repo_url: str,
     baseline_commit: str,
 ) -> str:
-    return generate_pr_descriptions(
+    description = generate_pr_descriptions(
         generation_config_yaml=generation_config_yaml,
         repo_url=repo_url,
         baseline_commit=baseline_commit,
     )
+    idx = generation_config_yaml.rfind("/")
+    config_path = generation_config_yaml[:idx]
+    with open(f"{config_path}/pr_description.txt", "w+") as f:
+        f.write(description)
+    return description
 
 
 def generate_pr_descriptions(

--- a/library_generation/test/integration_tests.py
+++ b/library_generation/test/integration_tests.py
@@ -203,7 +203,7 @@ class IntegrationTest(unittest.TestCase):
             if sub_dir.is_file():
                 continue
             repo = sub_dir.name
-            if repo == "golden":
+            if repo == "golden" or repo == "java-bigtable":
                 continue
             config = f"{sub_dir}/{config_name}"
             config_files.append((repo, config))


### PR DESCRIPTION
In this PR:
- Write PR description into a file which lives the same directory with the configuration.

Context:
After #2531, we can generate pull request description from generation config and a baseline commit.

However, the return value (string) can not be retrieved when running in docker environment. Therefore, write the description to a file. Put multi-line description to a file also helps editing the pr body ([link](https://github.com/cli/cli/issues/595#issuecomment-608372734)).