### PR TITLE
feat: Add shopping and chat common protos.

### DIFF
--- a/java-common-protos/.OwlBot.yaml
+++ b/java-common-protos/.OwlBot.yaml
@@ -33,13 +33,13 @@ deep-copy-regex:
   dest: "/owl-bot-staging/java-common-protos/v1/proto-google-common-protos/src"
 
 # For shopping common protos
-- source: "google/shopping/merchant/reports/v1beta/google-cloud-merchant-reports-v1beta-java"
+- source: "/google/shopping/merchant/reports/v1beta/google-cloud-merchant-reports-v1beta-java"
   dest: "/owl-bot-staging/java-common-protos/v1/proto-google-common-protos/src"
 
 # It is only used once in https://github.com/googleapis/googleapis/blob/master/google/chat/v1/BUILD.bazel#L47,
 # and technically not a common proto, maybe a violation of AIP-215 if it is not.
 # However, it's better to put it here so that we don't have to manually add it to BUILD.bazel file and hermetic build scripts.
-- source: "google/apps/card/v1/google-apps-card-v1-java/proto-google-apps-card-v1-java"
+- source: "/google/apps/card/v1/google-apps-card-v1-java/proto-google-apps-card-v1-java"
   dest: "/owl-bot-staging/java-common-protos/v1/proto-google-common-protos/src"
 
 - source: "/google/logging/type/google-logging-type-java/proto-google-logging-type-java/src"

--- a/java-common-protos/.OwlBot.yaml
+++ b/java-common-protos/.OwlBot.yaml
@@ -28,7 +28,18 @@ deep-copy-regex:
 - source: "/google/cloud/audit/google-cloud-audit-java/proto-google-cloud-audit-java/src"
   dest: "/owl-bot-staging/java-common-protos/v1/proto-google-common-protos/src"
 
+# For geo common protos
 - source: "/google/geo/type/google-geo-type-java/proto-google-geo-type-java/src"
+  dest: "/owl-bot-staging/java-common-protos/v1/proto-google-common-protos/src"
+
+# For shopping common protos
+- source: "google/shopping/merchant/reports/v1beta/google-cloud-merchant-reports-v1beta-java"
+  dest: "/owl-bot-staging/java-common-protos/v1/proto-google-common-protos/src"
+
+# It is only used once in https://github.com/googleapis/googleapis/blob/master/google/chat/v1/BUILD.bazel#L47,
+# and technically not a common proto, maybe a violation of AIP-215 if it is not.
+# However, it's better to put it here so that we don't have to manually add it to BUILD.bazel file and hermetic build scripts.
+- source: "google/apps/card/v1/google-apps-card-v1-java/proto-google-apps-card-v1-java"
   dest: "/owl-bot-staging/java-common-protos/v1/proto-google-common-protos/src"
 
 - source: "/google/logging/type/google-logging-type-java/proto-google-logging-type-java/src"


### PR DESCRIPTION
This PR adds shopping and chat common protos. 

Once this is released and made it into google-cloud-java, we need to remove the corresponding modules in google-cloud-java, otherwise there would be compilation errors regarding duplicated classes. e.g. This [folder](https://github.com/googleapis/google-cloud-java/tree/main/java-shopping-merchant-reports/proto-google-shopping-merchant-reports-v1beta/src/main/java/com/google/shopping/type) need to be removed.

In addition, hardcoded proto references in https://github.com/googleapis/sdk-platform-java/pull/2414 in hermetic build scripts need to be removed as well.

Fixes #2018