### PR TITLE
chore: remove `google/shopping/type/types.proto` when generating shopping APIs

### DIFF
--- a/library_generation/generate_library.sh
+++ b/library_generation/generate_library.sh
@@ -175,12 +175,6 @@ case "${proto_path}" in
     removed_proto="google/rpc/http.proto"
     proto_files="${proto_files//${removed_proto}/}"
     ;;
-  "google/shopping"*)
-    # this proto is included in //google/shopping/css/v1:google-cloud-shopping-css-v1-java
-    # and //google/shopping/merchant/inventories/v1beta:google-cloud-merchant-inventories-v1beta-java
-    # and //google/shopping/merchant/reports/v1beta:google-cloud-merchant-reports-v1beta-java
-    proto_files="${proto_files} google/shopping/type/types.proto"
-    ;;
 esac
 # download gapic-generator-java, protobuf and grpc plugin.
 download_tools "${gapic_generator_version}" "${protobuf_version}" "${grpc_version}" "${os_architecture}"
@@ -284,8 +278,7 @@ case "${proto_path}" in
 esac
 # copy proto files to proto-*/src/main/proto
 for proto_src in ${proto_files}; do
-  if [[ "${proto_src}" == "google/cloud/common/operation_metadata.proto" ]] ||
-     [[ "${proto_src}" == "google/shopping/type/types.proto" ]]; then
+  if [[ "${proto_src}" == "google/cloud/common/operation_metadata.proto" ]]; then
     continue
   fi
   mkdir -p "${temp_destination_path}/proto-${folder_name}/src/main/proto"


### PR DESCRIPTION
After #2553 is merged, we do not need to add `google/shopping/type/types.proto` in `generate_library.sh` as a special case.