### PR TITLE
chore: remove generator in PR description

### DIFF
--- a/library_generation/generate_pr_description.py
+++ b/library_generation/generate_pr_description.py
@@ -92,7 +92,6 @@ def generate_pr_descriptions(
         latest_commit=config.googleapis_commitish,
         baseline_commit=baseline_commit,
         paths=paths,
-        generator_version=config.gapic_generator_version,
         is_monorepo=config.is_monorepo,
     )
 
@@ -102,7 +101,6 @@ def __get_commit_messages(
     latest_commit: str,
     baseline_commit: str,
     paths: Dict[str, str],
-    generator_version: str,
     is_monorepo: bool,
 ) -> str:
     """
@@ -117,7 +115,6 @@ def __get_commit_messages(
     :param baseline_commit: the oldest commit to be considered in
     selecting commit message. This commit should be an ancestor of
     :param paths: a mapping from file paths to library_name.
-    :param generator_version: the version of the generator.
     :param is_monorepo: whether to generate commit messages in a monorepo.
     :return: commit messages.
     """
@@ -140,7 +137,6 @@ def __get_commit_messages(
         latest_commit=latest_commit,
         baseline_commit=baseline_commit,
         commits=qualified_commits,
-        generator_version=generator_version,
         is_monorepo=is_monorepo,
     )
 
@@ -167,7 +163,6 @@ def __combine_commit_messages(
     latest_commit: str,
     baseline_commit: str,
     commits: Dict[Commit, str],
-    generator_version: str,
     is_monorepo: bool,
 ) -> str:
     messages = [
@@ -181,13 +176,6 @@ def __combine_commit_messages(
         )
 
     messages.extend(format_commit_message(commits=commits, is_monorepo=is_monorepo))
-    messages.extend(
-        wrap_nested_commit(
-            [
-                f"feat: Regenerate with the Java code generator (gapic-generator-java) v{generator_version}"
-            ]
-        )
-    )
 
     return "\n".join(messages)
 

--- a/library_generation/test/resources/integration/google-cloud-java/pr-description-golden.txt
+++ b/library_generation/test/resources/integration/google-cloud-java/pr-description-golden.txt
@@ -50,6 +50,3 @@ feat: [cloudcontrolspartner] added CloudControlsPartner API
 PiperOrigin-RevId: 606720708
 
 END_NESTED_COMMIT
-BEGIN_NESTED_COMMIT
-feat: Regenerate with the Java code generator (gapic-generator-java) v2.37.0
-END_NESTED_COMMIT

--- a/library_generation/test/resources/integration/java-bigtable/pr-description-golden.txt
+++ b/library_generation/test/resources/integration/java-bigtable/pr-description-golden.txt
@@ -14,6 +14,3 @@ chore: update retry settings for backup rpcs
 PiperOrigin-RevId: 605367937
 
 END_NESTED_COMMIT
-BEGIN_NESTED_COMMIT
-feat: Regenerate with the Java code generator (gapic-generator-java) v2.35.0
-END_NESTED_COMMIT


### PR DESCRIPTION
In this PR:
- Remove generator version in PR description

We plan to include generator update only when the version is updated, rather than including it in every PR.