### PR TITLE
chore: modify pr description

### DIFF
--- a/library_generation/generate_pr_description.py
+++ b/library_generation/generate_pr_description.py
@@ -23,6 +23,7 @@ from library_generation.utilities import find_versioned_proto_path
 from library_generation.utils.commit_message_formatter import format_commit_message
 from library_generation.utilities import get_file_paths
 from library_generation.utils.commit_message_formatter import wrap_nested_commit
+from library_generation.utils.commit_message_formatter import wrap_override_commit
 
 
 @click.group(invoke_without_command=False)
@@ -175,7 +176,11 @@ def __combine_commit_messages(
             f"[googleapis/googleapis@{short_sha}](https://github.com/googleapis/googleapis/commit/{commit.hexsha})"
         )
 
-    messages.extend(format_commit_message(commits=commits, is_monorepo=is_monorepo))
+    messages.extend(
+        wrap_override_commit(
+            format_commit_message(commits=commits, is_monorepo=is_monorepo)
+        )
+    )
 
     return "\n".join(messages)
 

--- a/library_generation/test/resources/integration/google-cloud-java/pr-description-golden.txt
+++ b/library_generation/test/resources/integration/google-cloud-java/pr-description-golden.txt
@@ -6,6 +6,7 @@ Qualified commits are:
 [googleapis/googleapis@0733fdb](https://github.com/googleapis/googleapis/commit/0733fdb5f745192f9f3c95f8d08039286567cbcc)
 [googleapis/googleapis@9e35c62](https://github.com/googleapis/googleapis/commit/9e35c620157d7b11cb5b2e5d0249c5caaee824f3)
 [googleapis/googleapis@36dedd0](https://github.com/googleapis/googleapis/commit/36dedd0d9020c19d1c8259003c2fe9656ada7471)
+BEGIN_COMMIT_OVERRIDE
 BEGIN_NESTED_COMMIT
 docs: [cloudcontrolspartner] update documentation URL
 
@@ -50,3 +51,4 @@ feat: [cloudcontrolspartner] added CloudControlsPartner API
 PiperOrigin-RevId: 606720708
 
 END_NESTED_COMMIT
+END_COMMIT_OVERRIDE

--- a/library_generation/test/resources/integration/java-bigtable/pr-description-golden.txt
+++ b/library_generation/test/resources/integration/java-bigtable/pr-description-golden.txt
@@ -2,6 +2,7 @@ This pull request is generated with proto changes between googleapis commit 6790
 Qualified commits are:
 [googleapis/googleapis@fbcfef0](https://github.com/googleapis/googleapis/commit/fbcfef09510b842774530989889ed1584a8b5acb)
 [googleapis/googleapis@63d2a60](https://github.com/googleapis/googleapis/commit/63d2a60056ad5b156c05c7fb13138fc886c3b739)
+BEGIN_COMMIT_OVERRIDE
 BEGIN_NESTED_COMMIT
 fix: extend timeouts for deleting snapshots, backups and tables
 
@@ -14,3 +15,4 @@ chore: update retry settings for backup rpcs
 PiperOrigin-RevId: 605367937
 
 END_NESTED_COMMIT
+END_COMMIT_OVERRIDE

--- a/library_generation/test/utils/commit_message_formatter_unit_tests.py
+++ b/library_generation/test/utils/commit_message_formatter_unit_tests.py
@@ -16,6 +16,7 @@ from unittest.mock import patch
 
 from library_generation.utils.commit_message_formatter import format_commit_message
 from library_generation.utils.commit_message_formatter import wrap_nested_commit
+from library_generation.utils.commit_message_formatter import wrap_override_commit
 
 
 class CommitMessageFormatterTest(unittest.TestCase):
@@ -113,4 +114,16 @@ class CommitMessageFormatterTest(unittest.TestCase):
                 "END_NESTED_COMMIT",
             ],
             wrap_nested_commit(messages),
+        )
+
+    def test_wrap_override_commit_success(self):
+        messages = ["a commit message", "another message"]
+        self.assertEqual(
+            [
+                "BEGIN_COMMIT_OVERRIDE",
+                "a commit message",
+                "another message",
+                "END_COMMIT_OVERRIDE",
+            ],
+            wrap_override_commit(messages),
         )

--- a/library_generation/utils/commit_message_formatter.py
+++ b/library_generation/utils/commit_message_formatter.py
@@ -62,3 +62,16 @@ def wrap_nested_commit(messages: List[str]) -> List[str]:
     result.extend(messages)
     result.append("END_NESTED_COMMIT")
     return result
+
+
+def wrap_override_commit(messages: List[str]) -> List[str]:
+    """
+    Wrap message between `BEGIN_COMMIT_OVERRIDE` and `END_COMMIT_OVERRIDE`.
+
+    :param messages: a (multi-line) commit message, one line per item.
+    :return: wrapped messages.
+    """
+    result = ["BEGIN_COMMIT_OVERRIDE"]
+    result.extend(messages)
+    result.append("END_COMMIT_OVERRIDE")
+    return result


### PR DESCRIPTION
In this PR:
- Wrap commit message with `BEGIN_COMMIT_OVERRIDE` and `BEGIN_COMMIT_OVERRIDE`.

Context: we found out that the commit messages in https://github.com/googleapis/google-cloud-java/pull/10529 didn't appear in the release notes. @chingor13 pointed out that we should wrap commit messages with `BEGIN_COMMIT_OVERRIDE` and `BEGIN_COMMIT_OVERRIDE` so that release-please can pick them up from a merged PR.