### PR TITLE
chore: remove ending comma in `owlbot.py`

### DIFF
--- a/library_generation/templates/owlbot.py.j2
+++ b/library_generation/templates/owlbot.py.j2
@@ -23,6 +23,6 @@ for library in s.get_staging_dirs():
 s.remove_staging_dirs()
 {% if should_include_templates %}java.common_templates(monorepo=True, {% if template_excludes %}excludes=[
 {%- for exclude in template_excludes %}
-    "{{ exclude }}",
+    "{{ exclude }}"{% if not loop.last %},{% endif %}
 {%- endfor %}
 ]{% endif %}){% endif %}

--- a/library_generation/test/resources/goldens/owlbot-golden.py
+++ b/library_generation/test/resources/goldens/owlbot-golden.py
@@ -32,5 +32,5 @@ java.common_templates(monorepo=True, excludes=[
     "java.header",
     "license-checks.xml",
     "renovate.json",
-    ".gitignore",
+    ".gitignore"
 ])


### PR DESCRIPTION
In this PR:
- Remove the last comma in the `java.common_templates` method in `owlbot.py`

This will align with `java.common_templates` generated by google-cloud-java's `generation/update_owlbot_postprocessor_config.sh`