### PR TITLE
chore: gapic-generator-java noop follow up on hermetic build scripts

### DIFF
--- a/library_generation/generate_composed_library.py
+++ b/library_generation/generate_composed_library.py
@@ -150,8 +150,6 @@ def __construct_effective_arg(
     arguments = list(base_arguments)
     arguments += util.create_argument("proto_path", gapic)
     arguments += [
-        "--proto_only",
-        gapic_inputs.proto_only,
         "--gapic_additional_protos",
         gapic_inputs.additional_protos,
         "--transport",

--- a/library_generation/model/gapic_inputs.py
+++ b/library_generation/model/gapic_inputs.py
@@ -54,7 +54,6 @@ class GapicInputs:
 
     def __init__(
         self,
-        proto_only="true",
         additional_protos="google/cloud/common_resources.proto",
         transport="",
         rest_numeric_enum="",
@@ -63,7 +62,6 @@ class GapicInputs:
         service_yaml="",
         include_samples="true",
     ):
-        self.proto_only = proto_only
         self.additional_protos = additional_protos
         self.transport = transport
         self.rest_numeric_enum = rest_numeric_enum
@@ -112,7 +110,6 @@ def parse(
     service_yaml = __parse_service_yaml(gapic_target[0], versioned_path)
 
     return GapicInputs(
-        proto_only="false",
         additional_protos=additional_protos,
         transport=transport,
         rest_numeric_enum=rest_numeric_enum,

--- a/library_generation/test/resources/integration/google-cloud-java/generation_config.yaml
+++ b/library_generation/test/resources/integration/google-cloud-java/generation_config.yaml
@@ -37,6 +37,7 @@ libraries:
     - proto_path: google/cloud/alloydb/v1beta
 
   - api_shortname: alloydb
+    # this is a proto_only library with which the gapic-generator should no-op
     name_pretty: AlloyDB connectors
     product_documentation: https://cloud.google.com/alloydb/docs
     api_description: AlloyDB is a fully-managed, PostgreSQL-compatible database for

--- a/library_generation/test/utilities_unit_tests.py
+++ b/library_generation/test/utilities_unit_tests.py
@@ -309,16 +309,6 @@ class UtilitiesTest(unittest.TestCase):
         parsed = parse_build_file(build_file, "", "BUILD_rest_numeric_enums_true.bazel")
         self.assertEqual("true", parsed.rest_numeric_enum)
 
-    def test_gapic_inputs_parse_no_gapic_library_returns_proto_only_true(self):
-        # include_samples_empty only has a gradle assembly rule
-        parsed = parse_build_file(build_file, "", "BUILD_include_samples_empty.bazel")
-        self.assertEqual("true", parsed.proto_only)
-
-    def test_gapic_inputs_parse_with_gapic_library_returns_proto_only_false(self):
-        # rest.bazel has a java_gapic_library rule
-        parsed = parse_build_file(build_file, "", "BUILD_rest.bazel")
-        self.assertEqual("false", parsed.proto_only)
-
     def test_gapic_inputs_parse_gapic_yaml_succeeds(self):
         parsed = parse_build_file(
             build_file, "test/versioned/path", "BUILD_gapic_yaml.bazel"


### PR DESCRIPTION
This is a follow up from https://github.com/googleapis/sdk-platform-java/pull/2460

Since GGJ will NOOP when no services are found in the passed `proto_path`s, we remove the `proto_only` flag entirely so we can rely on this new behavior instead.