### PR TITLE
fix: add main to `generate_repo.py`

### DIFF
--- a/library_generation/generate_repo.py
+++ b/library_generation/generate_repo.py
@@ -155,3 +155,7 @@ def get_target_libraries(
         for library in config.libraries
         if library.get_library_name() in target_libraries
     ]
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
In todays's nightly generation job ([log](https://github.com/googleapis/google-cloud-java/actions/runs/8457767424/job/23170489394)), no actual generation is done.

I think this is because `main` method has been removed by #2598.