### PR TITLE
fix: remove unnecessary slf4j and AbstractGoogleClientRequest native image configs

### DIFF
--- a/gax-java/gax/src/main/resources/META-INF/native-image/com.google.api/gax/native-image.properties
+++ b/gax-java/gax/src/main/resources/META-INF/native-image/com.google.api/gax/native-image.properties
@@ -1,8 +1,6 @@
 Args = --enable-url-protocols=https,http \
 --initialize-at-build-time=org.conscrypt,\
-  org.slf4j.LoggerFactory,\
   org.junit.platform.engine.TestTag \
---initialize-at-run-time=com.google.api.client.googleapis.services.AbstractGoogleClientRequest$ApiClientVersion \
   --features=com.google.api.gax.nativeimage.OpenCensusFeature,\
   com.google.api.gax.nativeimage.GoogleJsonClientFeature \
   --add-modules=jdk.httpserver


### PR DESCRIPTION
For https://github.com/googleapis/sdk-platform-java/issues/2600

Background for removing these to configs:

(1) Build time initialization of SLF4J's LoggerFactory class
The configuration was added in https://github.com/googleapis/java-core/pull/685 to address the following failure in java-bigquerystorage:
```
Error: Classes that should be initialized at run time got initialized during image building:
 org.slf4j.LoggerFactory was unintentionally initialized at build time. To see why org.slf4j.LoggerFactory got initialized use --trace-class-initialization=org.slf4j.LoggerFactory
```
However, since this [change](https://github.com/googleapis/sdk-platform-java/pull/1290) to initialize netty 4 at run-time, this configuration has no longer been needed. Verified locally that running ` mvn clean test -Dtest=com.google.cloud.bigquery.storage.v1beta2.it.ITBigQueryStorageTest -Pnative -Dsurefire.failIfNoSpecifiedTests=false` in java-bigquerystorage without the build-time initialization of `org.slf4j.LoggerFactory` doesn't result in the failure documented above. 

(2) Run time initialization of `AbstractGoogleClientRequest$ApiClientVersion`

The second change addresses the concern in https://github.com/googleapis/sdk-platform-java/issues/2600#issuecomment-2017820878: `Another item I'm not sure is really needed. This only makes sense if types initialized at build time create instances of ApiClientVersion, but I don't see how that'd be the case`. 

This configurations was added in 2021 (https://github.com/GoogleCloudPlatform/native-image-support-java/pull/83) when [Substitute annotation](https://docs.oracle.com/en/graalvm/jdk/21/sdk/com/oracle/svm/core/annotate/Substitute.html) was used to customize headers. As the name suggests, this feature is used to substitute in existing classes/methods with new classes/methods at native image generation. There have been a [few known cases ](https://github.com/oracle/graal/issues/2936) in the past with build time initializations of target classes in substitutions which may have required the configuration.  However, in https://github.com/googleapis/gax-java/pull/1678, the use of Substitutions was removed and as shown by this [experiment](https://github.com/mpeddada1/avoid-substitutions) the chosen alternative approach to modify the headers worked as expected without needing an explicit run time initialization of `AbstractGoogleClientRequest$ApiClientVersion`. 

This PR removes the obsolete configuration. 



