### PR TITLE
fix: remove duplicated calls to AutoValue builders

### DIFF
--- a/gax-java/gax-grpc/src/test/java/com/google/api/gax/grpc/TimeoutTest.java
+++ b/gax-java/gax-grpc/src/test/java/com/google/api/gax/grpc/TimeoutTest.java
@@ -199,7 +199,6 @@ public class TimeoutTest {
             .setMaxAttempts(1)
             .setJittered(true)
             .setRpcTimeoutMultiplier(1.0)
-            .setRpcTimeoutMultiplier(1.0)
             .build();
     CallOptions callOptionsUsed =
         setupUnaryCallable(retrySettings, emptyRetryCodes, defaultCallContext);
@@ -314,7 +313,6 @@ public class TimeoutTest {
             .setMaxRetryDelay(Duration.ZERO)
             .setMaxAttempts(1)
             .setJittered(true)
-            .setRpcTimeoutMultiplier(1.0)
             .setRpcTimeoutMultiplier(1.0)
             .build();
     CallOptions callOptionsUsed =


### PR DESCRIPTION
This change removes duplicate calls to setters in `gax-java/gax-grpc/src/test/java/com/google/api/gax/grpc/TimeoutTest.java`.

Fixes #2635 ☕️