### PR TITLE
chore: do not generate pr description if two commits are same

### DIFF
--- a/library_generation/generate_pr_description.py
+++ b/library_generation/generate_pr_description.py
@@ -79,6 +79,9 @@ def generate_pr_descriptions(
     The pull request description will be generated into
     description_path/pr_description.txt.
 
+    If baseline_commit is the same as googleapis commit in the given generation
+    config, no pr_description.txt will be generated.
+
     :param config: a GenerationConfig object. The googleapis commit in this
     configuration is the latest commit, inclusively, from which the commit
     message is considered.
@@ -90,6 +93,9 @@ def generate_pr_descriptions(
     :param repo_url: the GitHub repository from which retrieves the commit
     history.
     """
+    if baseline_commit == config.googleapis_commitish:
+        return
+
     paths = config.get_proto_path_to_library_name()
     description = get_commit_messages(
         repo_url=repo_url,
@@ -126,6 +132,8 @@ def get_commit_messages(
     :param paths: a mapping from file paths to library_name.
     :param is_monorepo: whether to generate commit messages in a monorepo.
     :return: commit messages.
+    :raise ValueError: if current_commit is older than or equal to
+    baseline_commit.
     """
     tmp_dir = "/tmp/repo"
     shutil.rmtree(tmp_dir, ignore_errors=True)

--- a/library_generation/test/generate_pr_description_unit_tests.py
+++ b/library_generation/test/generate_pr_description_unit_tests.py
@@ -11,9 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 import unittest
 
-from library_generation.generate_pr_description import get_commit_messages
+from library_generation.generate_pr_description import (
+    get_commit_messages,
+    generate_pr_descriptions,
+)
+from library_generation.model.generation_config import GenerationConfig
 
 
 class GeneratePrDescriptionTest(unittest.TestCase):
@@ -47,3 +52,23 @@ class GeneratePrDescriptionTest(unittest.TestCase):
             {},
             True,
         )
+
+    def test_generate_pr_description_with_same_googleapis_commits(self):
+        commit_sha = "36441693dddaf0ed73951ad3a15c215a332756aa"
+        cwd = os.getcwd()
+        generate_pr_descriptions(
+            config=GenerationConfig(
+                gapic_generator_version="",
+                googleapis_commitish=commit_sha,
+                libraries_bom_version="",
+                owlbot_cli_image="",
+                synthtool_commitish="",
+                template_excludes=[],
+                grpc_version="",
+                protobuf_version="",
+                libraries=[],
+            ),
+            baseline_commit=commit_sha,
+            description_path=cwd,
+        )
+        self.assertFalse(os.path.isfile(f"{cwd}/pr_description.txt"))


### PR DESCRIPTION
In this PR:
- Do not generate pr_description.txt if googleapis commit is the same in baseline config and current config.