### PR TITLE
chore: shared-deps third party's parent is generator-pom-parent

### DIFF
--- a/gapic-generator-java-pom-parent/pom.xml
+++ b/gapic-generator-java-pom-parent/pom.xml
@@ -36,6 +36,7 @@
     <maven.compiler.release>8</maven.compiler.release>
     <errorprone.version>2.26.1</errorprone.version>
     <j2objc-annotations.version>3.0.0</j2objc-annotations.version>
+    <threetenbp.version>1.6.8</threetenbp.version>
   </properties>
 
   <developers>

--- a/gax-java/pom.xml
+++ b/gax-java/pom.xml
@@ -62,7 +62,7 @@
       <dependency>
         <groupId>org.threeten</groupId>
         <artifactId>threetenbp</artifactId>
-        <version>1.6.8</version>
+        <version>${threetenbp.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.findbugs</groupId>

--- a/java-shared-dependencies/third-party-dependencies/pom.xml
+++ b/java-shared-dependencies/third-party-dependencies/pom.xml
@@ -13,19 +13,17 @@
   </description>
 
   <parent>
-    <groupId>com.google.cloud</groupId>
-    <artifactId>google-cloud-shared-config</artifactId>
-    <version>1.7.7</version>
-    <relativePath />
+    <groupId>com.google.api</groupId>
+    <artifactId>gapic-generator-java-pom-parent</artifactId>
+    <version>2.38.2-SNAPSHOT</version><!-- {x-version-update:gapic-generator-java:current} -->
+    <relativePath>../../gapic-generator-java-pom-parent</relativePath>
   </parent>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <site.installationModule>${project.artifactId}</site.installationModule>
 
-    <threeten.version>1.6.8</threeten.version>
     <threeten-extra.version>1.8.0</threeten-extra.version>
-    <javax.annotations.version>1.3.2</javax.annotations.version>
     <animal-sniffer.version>1.23</animal-sniffer.version>
     <opencensus.version>0.31.1</opencensus.version>
     <findbugs.version>3.0.2</findbugs.version>
@@ -37,9 +35,8 @@
     <!-- ensure checker-qual version matches what Guava uses -->
     <checker-qual.version>3.42.0</checker-qual.version>
     <perfmark-api.version>0.27.0</perfmark-api.version>
-    <google.cloud.opentelemetry.version>0.28.0</google.cloud.opentelemetry.version>
     <j2objc-annotations.version>3.0.0</j2objc-annotations.version>
-    <opentelemetry.version>1.36.0</opentelemetry.version>
+    <google.cloud.opentelemetry.version>0.28.0</google.cloud.opentelemetry.version>
     <opentelemetry-grpc-instrumentation.version>2.1.0-alpha</opentelemetry-grpc-instrumentation.version>
     <flogger.version>0.8</flogger.version>
     <arrow.version>15.0.2</arrow.version>
@@ -75,7 +72,7 @@
       <dependency>
         <groupId>org.threeten</groupId>
         <artifactId>threetenbp</artifactId>
-        <version>${threeten.version}</version>
+        <version>${threetenbp.version}</version>
       </dependency>
       <dependency>
         <groupId>org.threeten</groupId>
@@ -85,7 +82,7 @@
       <dependency>
         <groupId>javax.annotation</groupId>
         <artifactId>javax.annotation-api</artifactId>
-        <version>${javax.annotations.version}</version>
+        <version>${javax.annotation-api.version}</version>
         <scope>compile</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
Following Tomo's suggestion in https://github.com/googleapis/sdk-platform-java/pull/2602#issuecomment-2062138924

Shared-Dep's third_party parent is gapic-generator-java-pom-parent. threetenbp's + otel version is defined in gapic-generator-java-pom-parent