### PR TITLE
chore: disable renovate for protobuf dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -143,7 +143,8 @@
       "matchPackagePatterns": [
         "^com.google.protobuf"
       ],
-      "groupName": "Protobuf dependencies"
+      "groupName": "Protobuf dependencies",
+      "enabled": false
     },
     {
       "matchPackagePatterns": [


### PR DESCRIPTION
Same as #2618, will revert when Beam is released.
current version is v3.25.3 updated in https://github.com/googleapis/sdk-platform-java/pull/2491