### PR TITLE
feat: Update Gapic generator and Gax to emit api-versioning via header

### DIFF
--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceStubSettingsClassComposer.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceStubSettingsClassComposer.java
@@ -370,6 +370,16 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
             .setReturnType(returnType)
             .build();
 
+    if (!Strings.isNullOrEmpty(service.apiVersion())) {
+
+      returnExpr =
+          MethodInvocationExpr.builder()
+              .setExprReferenceExpr(returnExpr)
+              .setMethodName("setApiVersionToken")
+              .setArguments(ValueExpr.withValue(StringObjectValue.withValue(service.apiVersion())))
+              .setReturnType(returnType)
+              .build();
+    }
     return MethodDefinition.builder()
         .setScope(ScopeNode.PUBLIC)
         .setIsStatic(true)

--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceStubSettingsClassComposer.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceStubSettingsClassComposer.java
@@ -370,7 +370,7 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
             .setReturnType(returnType)
             .build();
 
-    if (!Strings.isNullOrEmpty(service.apiVersion())) {
+    if (service.hasApiVersion()) {
 
       returnExpr =
           MethodInvocationExpr.builder()

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/ServiceStubSettingsClassComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/ServiceStubSettingsClassComposerTest.java
@@ -54,6 +54,12 @@ public class ServiceStubSettingsClassComposerTest {
             GrpcTestProtoLoader.instance().parseDeprecatedService(),
             "localhost:7469",
             "v1"
+          },
+          {
+            "ApiVersionTestingStubSettings",
+            GrpcTestProtoLoader.instance().parseApiVersionTesting(),
+            "localhost:7469",
+            "v1"
           }
         });
   }

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/ApiVersionTestingStubSettings.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/ApiVersionTestingStubSettings.golden
@@ -1,0 +1,248 @@
+package com.google.api.version.test.stub;
+
+import com.google.api.core.ApiFunction;
+import com.google.api.gax.core.GaxProperties;
+import com.google.api.gax.core.GoogleCredentialsProvider;
+import com.google.api.gax.core.InstantiatingExecutorProvider;
+import com.google.api.gax.grpc.GaxGrpcProperties;
+import com.google.api.gax.grpc.GrpcTransportChannel;
+import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.api.gax.rpc.ApiClientHeaderProvider;
+import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.api.gax.rpc.StubSettings;
+import com.google.api.gax.rpc.TransportChannelProvider;
+import com.google.api.gax.rpc.UnaryCallSettings;
+import com.google.api.version.test.EchoRequest;
+import com.google.api.version.test.EchoResponse;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import java.io.IOException;
+import java.util.List;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS.
+/**
+ * Settings class to configure an instance of {@link EchoWithVersionStub}.
+ *
+ * <p>The default instance has everything set to sensible defaults:
+ *
+ * <ul>
+ *   <li>The default service address (localhost) and default port (7469) are used.
+ *   <li>Credentials are acquired automatically through Application Default Credentials.
+ *   <li>Retries are configured for idempotent methods but not for non-idempotent methods.
+ * </ul>
+ *
+ * <p>The builder of this class is recursive, so contained classes are themselves builders. When
+ * build() is called, the tree of builders is called to create the complete settings object.
+ *
+ * <p>For example, to set the total timeout of echoWithVersionMethod to 30 seconds:
+ *
+ * <pre>{@code
+ * // This snippet has been automatically generated and should be regarded as a code template only.
+ * // It will require modifications to work:
+ * // - It may require correct/in-range values for request initialization.
+ * // - It may require specifying regional endpoints when creating the service client as shown in
+ * // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+ * EchoWithVersionStubSettings.Builder echoWithVersionSettingsBuilder =
+ *     EchoWithVersionStubSettings.newBuilder();
+ * echoWithVersionSettingsBuilder
+ *     .echoWithVersionMethodSettings()
+ *     .setRetrySettings(
+ *         echoWithVersionSettingsBuilder
+ *             .echoWithVersionMethodSettings()
+ *             .getRetrySettings()
+ *             .toBuilder()
+ *             .setTotalTimeout(Duration.ofSeconds(30))
+ *             .build());
+ * EchoWithVersionStubSettings echoWithVersionSettings = echoWithVersionSettingsBuilder.build();
+ * }</pre>
+ */
+@Generated("by gapic-generator-java")
+public class EchoWithVersionStubSettings extends StubSettings<EchoWithVersionStubSettings> {
+  /** The default scopes of the service. */
+  private static final ImmutableList<String> DEFAULT_SERVICE_SCOPES =
+      ImmutableList.<String>builder().add("https://www.googleapis.com/auth/cloud-platform").build();
+
+  private final UnaryCallSettings<EchoRequest, EchoResponse> echoWithVersionMethodSettings;
+
+  /** Returns the object with the settings used for calls to echoWithVersionMethod. */
+  public UnaryCallSettings<EchoRequest, EchoResponse> echoWithVersionMethodSettings() {
+    return echoWithVersionMethodSettings;
+  }
+
+  public EchoWithVersionStub createStub() throws IOException {
+    if (getTransportChannelProvider()
+        .getTransportName()
+        .equals(GrpcTransportChannel.getGrpcTransportName())) {
+      return GrpcEchoWithVersionStub.create(this);
+    }
+    throw new UnsupportedOperationException(
+        String.format(
+            "Transport not supported: %s", getTransportChannelProvider().getTransportName()));
+  }
+
+  /** Returns a builder for the default ExecutorProvider for this service. */
+  public static InstantiatingExecutorProvider.Builder defaultExecutorProviderBuilder() {
+    return InstantiatingExecutorProvider.newBuilder();
+  }
+
+  /** Returns the default service endpoint. */
+  public static String getDefaultEndpoint() {
+    return "localhost:7469";
+  }
+
+  /** Returns the default mTLS service endpoint. */
+  public static String getDefaultMtlsEndpoint() {
+    return "localhost:7469";
+  }
+
+  /** Returns the default service scopes. */
+  public static List<String> getDefaultServiceScopes() {
+    return DEFAULT_SERVICE_SCOPES;
+  }
+
+  /** Returns a builder for the default credentials for this service. */
+  public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder() {
+    return GoogleCredentialsProvider.newBuilder()
+        .setScopesToApply(DEFAULT_SERVICE_SCOPES)
+        .setUseJwtAccessWithScope(true);
+  }
+
+  /** Returns a builder for the default ChannelProvider for this service. */
+  public static InstantiatingGrpcChannelProvider.Builder defaultGrpcTransportProviderBuilder() {
+    return InstantiatingGrpcChannelProvider.newBuilder()
+        .setMaxInboundMessageSize(Integer.MAX_VALUE);
+  }
+
+  public static TransportChannelProvider defaultTransportChannelProvider() {
+    return defaultGrpcTransportProviderBuilder().build();
+  }
+
+  public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder() {
+    return ApiClientHeaderProvider.newBuilder()
+        .setGeneratedLibToken(
+            "gapic", GaxProperties.getLibraryVersion(EchoWithVersionStubSettings.class))
+        .setTransportToken(GaxGrpcProperties.getGrpcTokenName(), GaxGrpcProperties.getGrpcVersion())
+        .setApiVersionToken("fake_version");
+  }
+
+  /** Returns a new builder for this class. */
+  public static Builder newBuilder() {
+    return Builder.createDefault();
+  }
+
+  /** Returns a new builder for this class. */
+  public static Builder newBuilder(ClientContext clientContext) {
+    return new Builder(clientContext);
+  }
+
+  /** Returns a builder containing all the values of this settings class. */
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  protected EchoWithVersionStubSettings(Builder settingsBuilder) throws IOException {
+    super(settingsBuilder);
+
+    echoWithVersionMethodSettings = settingsBuilder.echoWithVersionMethodSettings().build();
+  }
+
+  /** Builder for EchoWithVersionStubSettings. */
+  public static class Builder extends StubSettings.Builder<EchoWithVersionStubSettings, Builder> {
+    private final ImmutableList<UnaryCallSettings.Builder<?, ?>> unaryMethodSettingsBuilders;
+    private final UnaryCallSettings.Builder<EchoRequest, EchoResponse>
+        echoWithVersionMethodSettings;
+    private static final ImmutableMap<String, ImmutableSet<StatusCode.Code>>
+        RETRYABLE_CODE_DEFINITIONS;
+
+    static {
+      ImmutableMap.Builder<String, ImmutableSet<StatusCode.Code>> definitions =
+          ImmutableMap.builder();
+      definitions.put("no_retry_codes", ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));
+      RETRYABLE_CODE_DEFINITIONS = definitions.build();
+    }
+
+    private static final ImmutableMap<String, RetrySettings> RETRY_PARAM_DEFINITIONS;
+
+    static {
+      ImmutableMap.Builder<String, RetrySettings> definitions = ImmutableMap.builder();
+      RetrySettings settings = null;
+      settings = RetrySettings.newBuilder().setRpcTimeoutMultiplier(1.0).build();
+      definitions.put("no_retry_params", settings);
+      RETRY_PARAM_DEFINITIONS = definitions.build();
+    }
+
+    protected Builder() {
+      this(((ClientContext) null));
+    }
+
+    protected Builder(ClientContext clientContext) {
+      super(clientContext);
+
+      echoWithVersionMethodSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      unaryMethodSettingsBuilders =
+          ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(echoWithVersionMethodSettings);
+      initDefaults(this);
+    }
+
+    protected Builder(EchoWithVersionStubSettings settings) {
+      super(settings);
+
+      echoWithVersionMethodSettings = settings.echoWithVersionMethodSettings.toBuilder();
+
+      unaryMethodSettingsBuilders =
+          ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(echoWithVersionMethodSettings);
+    }
+
+    private static Builder createDefault() {
+      Builder builder = new Builder(((ClientContext) null));
+
+      builder.setTransportChannelProvider(defaultTransportChannelProvider());
+      builder.setCredentialsProvider(defaultCredentialsProviderBuilder().build());
+      builder.setInternalHeaderProvider(defaultApiClientHeaderProviderBuilder().build());
+      builder.setMtlsEndpoint(getDefaultMtlsEndpoint());
+      builder.setSwitchToMtlsEndpointAllowed(true);
+
+      return initDefaults(builder);
+    }
+
+    private static Builder initDefaults(Builder builder) {
+      builder
+          .echoWithVersionMethodSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_params"));
+
+      return builder;
+    }
+
+    /**
+     * Applies the given settings updater function to all of the unary API methods in this service.
+     *
+     * <p>Note: This method does not support applying settings to streaming methods.
+     */
+    public Builder applyToAllUnaryMethods(
+        ApiFunction<UnaryCallSettings.Builder<?, ?>, Void> settingsUpdater) {
+      super.applyToAllUnaryMethods(unaryMethodSettingsBuilders, settingsUpdater);
+      return this;
+    }
+
+    public ImmutableList<UnaryCallSettings.Builder<?, ?>> unaryMethodSettingsBuilders() {
+      return unaryMethodSettingsBuilders;
+    }
+
+    /** Returns the builder for the settings used for calls to echoWithVersionMethod. */
+    public UnaryCallSettings.Builder<EchoRequest, EchoResponse> echoWithVersionMethodSettings() {
+      return echoWithVersionMethodSettings;
+    }
+
+    @Override
+    public EchoWithVersionStubSettings build() throws IOException {
+      return new EchoWithVersionStubSettings(this);
+    }
+  }
+}

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/EchoStubSettings.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/EchoStubSettings.golden
@@ -325,8 +325,8 @@ public class EchoStubSettings extends StubSettings<EchoStubSettings> {
   public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder() {
     return ApiClientHeaderProvider.newBuilder()
         .setGeneratedLibToken("gapic", GaxProperties.getLibraryVersion(EchoStubSettings.class))
-        .setTransportToken(GaxGrpcProperties.getGrpcTokenName(), GaxGrpcProperties.getGrpcVersion())
-        .setApiVersionToken("v1_20230601");
+        .setTransportToken(
+            GaxGrpcProperties.getGrpcTokenName(), GaxGrpcProperties.getGrpcVersion());
   }
 
   /** Returns a new builder for this class. */

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/EchoStubSettings.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/EchoStubSettings.golden
@@ -325,8 +325,8 @@ public class EchoStubSettings extends StubSettings<EchoStubSettings> {
   public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder() {
     return ApiClientHeaderProvider.newBuilder()
         .setGeneratedLibToken("gapic", GaxProperties.getLibraryVersion(EchoStubSettings.class))
-        .setTransportToken(
-            GaxGrpcProperties.getGrpcTokenName(), GaxGrpcProperties.getGrpcVersion());
+        .setTransportToken(GaxGrpcProperties.getGrpcTokenName(), GaxGrpcProperties.getGrpcVersion())
+        .setApiVersionToken("v1_20230601");
   }
 
   /** Returns a new builder for this class. */

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/servicesettings/stub/SyncEchoWithVersionMethod.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/servicesettings/stub/SyncEchoWithVersionMethod.golden
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.api.version.test.stub.samples;
+
+// [START goldensample_generated_EchoWithVersionStubSettings_EchoWithVersionMethod_sync]
+import com.google.api.version.test.stub.EchoWithVersionStubSettings;
+import java.time.Duration;
+
+public class SyncEchoWithVersionMethod {
+
+  public static void main(String[] args) throws Exception {
+    syncEchoWithVersionMethod();
+  }
+
+  public static void syncEchoWithVersionMethod() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    EchoWithVersionStubSettings.Builder echoWithVersionSettingsBuilder =
+        EchoWithVersionStubSettings.newBuilder();
+    echoWithVersionSettingsBuilder
+        .echoWithVersionMethodSettings()
+        .setRetrySettings(
+            echoWithVersionSettingsBuilder
+                .echoWithVersionMethodSettings()
+                .getRetrySettings()
+                .toBuilder()
+                .setTotalTimeout(Duration.ofSeconds(30))
+                .build());
+    EchoWithVersionStubSettings echoWithVersionSettings = echoWithVersionSettingsBuilder.build();
+  }
+}
+// [END goldensample_generated_EchoWithVersionStubSettings_EchoWithVersionMethod_sync]

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/ServiceStubSettingsClassComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/ServiceStubSettingsClassComposerTest.java
@@ -23,37 +23,51 @@ import com.google.api.generator.test.framework.GoldenFileWriter;
 import com.google.api.generator.test.protoloader.GrpcRestTestProtoLoader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collection;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+@RunWith(Parameterized.class)
 public class ServiceStubSettingsClassComposerTest {
+  @Parameterized.Parameters
+  public static Collection<Object[]> data() {
+    return Arrays.asList(
+        new Object[][] {
+          {"EchoStubSettings.golden", GrpcRestTestProtoLoader.instance().parseShowcaseEcho()},
+          {"WickedStubSettings.golden", GrpcRestTestProtoLoader.instance().parseShowcaseWicked()}
+        });
+  }
+
+  @Parameterized.Parameter public String goldenFileName;
+
+  @Parameterized.Parameter(1)
+  public GapicContext context;
+
   @Test
   public void generateServiceClasses() {
-    GapicContext context = GrpcRestTestProtoLoader.instance().parseShowcaseEcho();
     Service echoProtoService = context.services().get(0);
     GapicClass clazz =
         ServiceStubSettingsClassComposer.instance().generate(context, echoProtoService);
 
     JavaWriterVisitor visitor = new JavaWriterVisitor();
     clazz.classDefinition().accept(visitor);
-    GoldenFileWriter.saveCodegenToFile(this.getClass(), "EchoStubSettings.golden", visitor.write());
-    Path goldenFilePath =
-        Paths.get(GoldenFileWriter.getGoldenDir(this.getClass()), "EchoStubSettings.golden");
+    GoldenFileWriter.saveCodegenToFile(this.getClass(), goldenFileName, visitor.write());
+    Path goldenFilePath = Paths.get(GoldenFileWriter.getGoldenDir(this.getClass()), goldenFileName);
     Assert.assertCodeEquals(goldenFilePath, visitor.write());
   }
 
   @Test
   public void generateServiceClassesWicked() {
-    GapicContext context = GrpcRestTestProtoLoader.instance().parseShowcaseWicked();
     Service wickedProtoService = context.services().get(0);
     GapicClass clazz =
         ServiceStubSettingsClassComposer.instance().generate(context, wickedProtoService);
 
     JavaWriterVisitor visitor = new JavaWriterVisitor();
     clazz.classDefinition().accept(visitor);
-    GoldenFileWriter.saveCodegenToFile(
-        this.getClass(), "WickedStubSettings.golden", visitor.write());
-    Path goldenFilePath =
-        Paths.get(GoldenFileWriter.getGoldenDir(this.getClass()), "WickedStubSettings.golden");
+    GoldenFileWriter.saveCodegenToFile(this.getClass(), goldenFileName, visitor.write());
+    Path goldenFilePath = Paths.get(GoldenFileWriter.getGoldenDir(this.getClass()), goldenFileName);
     Assert.assertCodeEquals(goldenFilePath, visitor.write());
   }
 }

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/ServiceStubSettingsClassComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/ServiceStubSettingsClassComposerTest.java
@@ -57,17 +57,4 @@ public class ServiceStubSettingsClassComposerTest {
     Path goldenFilePath = Paths.get(GoldenFileWriter.getGoldenDir(this.getClass()), goldenFileName);
     Assert.assertCodeEquals(goldenFilePath, visitor.write());
   }
-
-  @Test
-  public void generateServiceClassesWicked() {
-    Service wickedProtoService = context.services().get(0);
-    GapicClass clazz =
-        ServiceStubSettingsClassComposer.instance().generate(context, wickedProtoService);
-
-    JavaWriterVisitor visitor = new JavaWriterVisitor();
-    clazz.classDefinition().accept(visitor);
-    GoldenFileWriter.saveCodegenToFile(this.getClass(), goldenFileName, visitor.write());
-    Path goldenFilePath = Paths.get(GoldenFileWriter.getGoldenDir(this.getClass()), goldenFileName);
-    Assert.assertCodeEquals(goldenFilePath, visitor.write());
-  }
 }

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoStubSettings.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoStubSettings.golden
@@ -348,8 +348,8 @@ public class EchoStubSettings extends StubSettings<EchoStubSettings> {
   public static ApiClientHeaderProvider.Builder defaultGrpcApiClientHeaderProviderBuilder() {
     return ApiClientHeaderProvider.newBuilder()
         .setGeneratedLibToken("gapic", GaxProperties.getLibraryVersion(EchoStubSettings.class))
-        .setTransportToken(
-            GaxGrpcProperties.getGrpcTokenName(), GaxGrpcProperties.getGrpcVersion());
+        .setTransportToken(GaxGrpcProperties.getGrpcTokenName(), GaxGrpcProperties.getGrpcVersion())
+        .setApiVersionToken("foo_version_for_tests");
   }
 
   public static ApiClientHeaderProvider.Builder defaultHttpJsonApiClientHeaderProviderBuilder() {
@@ -357,7 +357,8 @@ public class EchoStubSettings extends StubSettings<EchoStubSettings> {
         .setGeneratedLibToken("gapic", GaxProperties.getLibraryVersion(EchoStubSettings.class))
         .setTransportToken(
             GaxHttpJsonProperties.getHttpJsonTokenName(),
-            GaxHttpJsonProperties.getHttpJsonVersion());
+            GaxHttpJsonProperties.getHttpJsonVersion())
+        .setApiVersionToken("foo_version_for_tests");
   }
 
   public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder() {

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/ServiceStubSettingsClassComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/ServiceStubSettingsClassComposerTest.java
@@ -36,32 +36,28 @@ public class ServiceStubSettingsClassComposerTest {
   public static Collection<Object[]> data() {
     return Arrays.asList(
         new Object[][] {
-            {
-                "ComplianceStubSettings.golden",
-                RestTestProtoLoader.instance().parseCompliance()
-            },
-            {
-                "HttpJsonEchoStubSettings.golden",
-                RestTestProtoLoader.instance().parseEcho()
-            }
+          {"ComplianceStubSettings.golden", RestTestProtoLoader.instance().parseCompliance()},
+          {
+            "HttpJsonApiVersionTestingStubSettings.golden",
+            RestTestProtoLoader.instance().parseApiVersionTesting()
+          }
         });
   }
+
   @Parameterized.Parameter public String goldenFileName;
 
   @Parameterized.Parameter(1)
   public GapicContext context;
+
   @Test
   public void generateServiceClasses() {
     Service protoService = context.services().get(0);
-    GapicClass clazz =
-        ServiceStubSettingsClassComposer.instance().generate(context, protoService);
+    GapicClass clazz = ServiceStubSettingsClassComposer.instance().generate(context, protoService);
 
     JavaWriterVisitor visitor = new JavaWriterVisitor();
     clazz.classDefinition().accept(visitor);
-    GoldenFileWriter.saveCodegenToFile(
-        this.getClass(), goldenFileName, visitor.write());
-    Path goldenFilePath =
-        Paths.get(GoldenFileWriter.getGoldenDir(this.getClass()), goldenFileName);
+    GoldenFileWriter.saveCodegenToFile(this.getClass(), goldenFileName, visitor.write());
+    Path goldenFilePath = Paths.get(GoldenFileWriter.getGoldenDir(this.getClass()), goldenFileName);
     Assert.assertCodeEquals(goldenFilePath, visitor.write());
   }
 }

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/ServiceStubSettingsClassComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/ServiceStubSettingsClassComposerTest.java
@@ -23,22 +23,45 @@ import com.google.api.generator.test.framework.GoldenFileWriter;
 import com.google.api.generator.test.protoloader.RestTestProtoLoader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collection;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+@RunWith(Parameterized.class)
 public class ServiceStubSettingsClassComposerTest {
+
+  @Parameterized.Parameters
+  public static Collection<Object[]> data() {
+    return Arrays.asList(
+        new Object[][] {
+            {
+                "ComplianceStubSettings.golden",
+                RestTestProtoLoader.instance().parseCompliance()
+            },
+            {
+                "HttpJsonEchoStubSettings.golden",
+                RestTestProtoLoader.instance().parseEcho()
+            }
+        });
+  }
+  @Parameterized.Parameter public String goldenFileName;
+
+  @Parameterized.Parameter(1)
+  public GapicContext context;
   @Test
   public void generateServiceClasses() {
-    GapicContext context = RestTestProtoLoader.instance().parseCompliance();
-    Service echoProtoService = context.services().get(0);
+    Service protoService = context.services().get(0);
     GapicClass clazz =
-        ServiceStubSettingsClassComposer.instance().generate(context, echoProtoService);
+        ServiceStubSettingsClassComposer.instance().generate(context, protoService);
 
     JavaWriterVisitor visitor = new JavaWriterVisitor();
     clazz.classDefinition().accept(visitor);
     GoldenFileWriter.saveCodegenToFile(
-        this.getClass(), "ComplianceStubSettings.golden", visitor.write());
+        this.getClass(), goldenFileName, visitor.write());
     Path goldenFilePath =
-        Paths.get(GoldenFileWriter.getGoldenDir(this.getClass()), "ComplianceStubSettings.golden");
+        Paths.get(GoldenFileWriter.getGoldenDir(this.getClass()), goldenFileName);
     Assert.assertCodeEquals(goldenFilePath, visitor.write());
   }
 }

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonApiVersionTestingStubSettings.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonApiVersionTestingStubSettings.golden
@@ -1,0 +1,250 @@
+package com.google.api.version.test.stub;
+
+import com.google.api.core.ApiFunction;
+import com.google.api.gax.core.GaxProperties;
+import com.google.api.gax.core.GoogleCredentialsProvider;
+import com.google.api.gax.core.InstantiatingExecutorProvider;
+import com.google.api.gax.httpjson.GaxHttpJsonProperties;
+import com.google.api.gax.httpjson.HttpJsonTransportChannel;
+import com.google.api.gax.httpjson.InstantiatingHttpJsonChannelProvider;
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.api.gax.rpc.ApiClientHeaderProvider;
+import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.api.gax.rpc.StubSettings;
+import com.google.api.gax.rpc.TransportChannelProvider;
+import com.google.api.gax.rpc.UnaryCallSettings;
+import com.google.api.version.test.EchoRequest;
+import com.google.api.version.test.EchoResponse;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import java.io.IOException;
+import java.util.List;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS.
+/**
+ * Settings class to configure an instance of {@link EchoWithVersionStub}.
+ *
+ * <p>The default instance has everything set to sensible defaults:
+ *
+ * <ul>
+ *   <li>The default service address (localhost) and default port (7469) are used.
+ *   <li>Credentials are acquired automatically through Application Default Credentials.
+ *   <li>Retries are configured for idempotent methods but not for non-idempotent methods.
+ * </ul>
+ *
+ * <p>The builder of this class is recursive, so contained classes are themselves builders. When
+ * build() is called, the tree of builders is called to create the complete settings object.
+ *
+ * <p>For example, to set the total timeout of echoWithVersionMethod to 30 seconds:
+ *
+ * <pre>{@code
+ * // This snippet has been automatically generated and should be regarded as a code template only.
+ * // It will require modifications to work:
+ * // - It may require correct/in-range values for request initialization.
+ * // - It may require specifying regional endpoints when creating the service client as shown in
+ * // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+ * EchoWithVersionStubSettings.Builder echoWithVersionSettingsBuilder =
+ *     EchoWithVersionStubSettings.newBuilder();
+ * echoWithVersionSettingsBuilder
+ *     .echoWithVersionMethodSettings()
+ *     .setRetrySettings(
+ *         echoWithVersionSettingsBuilder
+ *             .echoWithVersionMethodSettings()
+ *             .getRetrySettings()
+ *             .toBuilder()
+ *             .setTotalTimeout(Duration.ofSeconds(30))
+ *             .build());
+ * EchoWithVersionStubSettings echoWithVersionSettings = echoWithVersionSettingsBuilder.build();
+ * }</pre>
+ */
+@Generated("by gapic-generator-java")
+public class EchoWithVersionStubSettings extends StubSettings<EchoWithVersionStubSettings> {
+  /** The default scopes of the service. */
+  private static final ImmutableList<String> DEFAULT_SERVICE_SCOPES =
+      ImmutableList.<String>builder().add("https://www.googleapis.com/auth/cloud-platform").build();
+
+  private final UnaryCallSettings<EchoRequest, EchoResponse> echoWithVersionMethodSettings;
+
+  /** Returns the object with the settings used for calls to echoWithVersionMethod. */
+  public UnaryCallSettings<EchoRequest, EchoResponse> echoWithVersionMethodSettings() {
+    return echoWithVersionMethodSettings;
+  }
+
+  public EchoWithVersionStub createStub() throws IOException {
+    if (getTransportChannelProvider()
+        .getTransportName()
+        .equals(HttpJsonTransportChannel.getHttpJsonTransportName())) {
+      return HttpJsonEchoWithVersionStub.create(this);
+    }
+    throw new UnsupportedOperationException(
+        String.format(
+            "Transport not supported: %s", getTransportChannelProvider().getTransportName()));
+  }
+
+  /** Returns a builder for the default ExecutorProvider for this service. */
+  public static InstantiatingExecutorProvider.Builder defaultExecutorProviderBuilder() {
+    return InstantiatingExecutorProvider.newBuilder();
+  }
+
+  /** Returns the default service endpoint. */
+  public static String getDefaultEndpoint() {
+    return "localhost:7469";
+  }
+
+  /** Returns the default mTLS service endpoint. */
+  public static String getDefaultMtlsEndpoint() {
+    return "localhost:7469";
+  }
+
+  /** Returns the default service scopes. */
+  public static List<String> getDefaultServiceScopes() {
+    return DEFAULT_SERVICE_SCOPES;
+  }
+
+  /** Returns a builder for the default credentials for this service. */
+  public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder() {
+    return GoogleCredentialsProvider.newBuilder()
+        .setScopesToApply(DEFAULT_SERVICE_SCOPES)
+        .setUseJwtAccessWithScope(true);
+  }
+
+  /** Returns a builder for the default ChannelProvider for this service. */
+  public static InstantiatingHttpJsonChannelProvider.Builder
+      defaultHttpJsonTransportProviderBuilder() {
+    return InstantiatingHttpJsonChannelProvider.newBuilder();
+  }
+
+  public static TransportChannelProvider defaultTransportChannelProvider() {
+    return defaultHttpJsonTransportProviderBuilder().build();
+  }
+
+  public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder() {
+    return ApiClientHeaderProvider.newBuilder()
+        .setGeneratedLibToken(
+            "gapic", GaxProperties.getLibraryVersion(EchoWithVersionStubSettings.class))
+        .setTransportToken(
+            GaxHttpJsonProperties.getHttpJsonTokenName(),
+            GaxHttpJsonProperties.getHttpJsonVersion())
+        .setApiVersionToken("fake_version");
+  }
+
+  /** Returns a new builder for this class. */
+  public static Builder newBuilder() {
+    return Builder.createDefault();
+  }
+
+  /** Returns a new builder for this class. */
+  public static Builder newBuilder(ClientContext clientContext) {
+    return new Builder(clientContext);
+  }
+
+  /** Returns a builder containing all the values of this settings class. */
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  protected EchoWithVersionStubSettings(Builder settingsBuilder) throws IOException {
+    super(settingsBuilder);
+
+    echoWithVersionMethodSettings = settingsBuilder.echoWithVersionMethodSettings().build();
+  }
+
+  /** Builder for EchoWithVersionStubSettings. */
+  public static class Builder extends StubSettings.Builder<EchoWithVersionStubSettings, Builder> {
+    private final ImmutableList<UnaryCallSettings.Builder<?, ?>> unaryMethodSettingsBuilders;
+    private final UnaryCallSettings.Builder<EchoRequest, EchoResponse>
+        echoWithVersionMethodSettings;
+    private static final ImmutableMap<String, ImmutableSet<StatusCode.Code>>
+        RETRYABLE_CODE_DEFINITIONS;
+
+    static {
+      ImmutableMap.Builder<String, ImmutableSet<StatusCode.Code>> definitions =
+          ImmutableMap.builder();
+      definitions.put("no_retry_codes", ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));
+      RETRYABLE_CODE_DEFINITIONS = definitions.build();
+    }
+
+    private static final ImmutableMap<String, RetrySettings> RETRY_PARAM_DEFINITIONS;
+
+    static {
+      ImmutableMap.Builder<String, RetrySettings> definitions = ImmutableMap.builder();
+      RetrySettings settings = null;
+      settings = RetrySettings.newBuilder().setRpcTimeoutMultiplier(1.0).build();
+      definitions.put("no_retry_params", settings);
+      RETRY_PARAM_DEFINITIONS = definitions.build();
+    }
+
+    protected Builder() {
+      this(((ClientContext) null));
+    }
+
+    protected Builder(ClientContext clientContext) {
+      super(clientContext);
+
+      echoWithVersionMethodSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      unaryMethodSettingsBuilders =
+          ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(echoWithVersionMethodSettings);
+      initDefaults(this);
+    }
+
+    protected Builder(EchoWithVersionStubSettings settings) {
+      super(settings);
+
+      echoWithVersionMethodSettings = settings.echoWithVersionMethodSettings.toBuilder();
+
+      unaryMethodSettingsBuilders =
+          ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(echoWithVersionMethodSettings);
+    }
+
+    private static Builder createDefault() {
+      Builder builder = new Builder(((ClientContext) null));
+
+      builder.setTransportChannelProvider(defaultTransportChannelProvider());
+      builder.setCredentialsProvider(defaultCredentialsProviderBuilder().build());
+      builder.setInternalHeaderProvider(defaultApiClientHeaderProviderBuilder().build());
+      builder.setMtlsEndpoint(getDefaultMtlsEndpoint());
+      builder.setSwitchToMtlsEndpointAllowed(true);
+
+      return initDefaults(builder);
+    }
+
+    private static Builder initDefaults(Builder builder) {
+      builder
+          .echoWithVersionMethodSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_params"));
+
+      return builder;
+    }
+
+    /**
+     * Applies the given settings updater function to all of the unary API methods in this service.
+     *
+     * <p>Note: This method does not support applying settings to streaming methods.
+     */
+    public Builder applyToAllUnaryMethods(
+        ApiFunction<UnaryCallSettings.Builder<?, ?>, Void> settingsUpdater) {
+      super.applyToAllUnaryMethods(unaryMethodSettingsBuilders, settingsUpdater);
+      return this;
+    }
+
+    public ImmutableList<UnaryCallSettings.Builder<?, ?>> unaryMethodSettingsBuilders() {
+      return unaryMethodSettingsBuilders;
+    }
+
+    /** Returns the builder for the settings used for calls to echoWithVersionMethod. */
+    public UnaryCallSettings.Builder<EchoRequest, EchoResponse> echoWithVersionMethodSettings() {
+      return echoWithVersionMethodSettings;
+    }
+
+    @Override
+    public EchoWithVersionStubSettings build() throws IOException {
+      return new EchoWithVersionStubSettings(this);
+    }
+  }
+}

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonEchoStubSettings.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonEchoStubSettings.golden
@@ -1,0 +1,636 @@
+package com.google.showcase.v1beta1.stub;
+
+import static com.google.showcase.v1beta1.EchoClient.PagedExpandPagedResponse;
+import static com.google.showcase.v1beta1.EchoClient.SimplePagedExpandPagedResponse;
+
+import com.google.api.core.ApiFunction;
+import com.google.api.core.ApiFuture;
+import com.google.api.core.BetaApi;
+import com.google.api.gax.core.GaxProperties;
+import com.google.api.gax.core.GoogleCredentialsProvider;
+import com.google.api.gax.core.InstantiatingExecutorProvider;
+import com.google.api.gax.httpjson.GaxHttpJsonProperties;
+import com.google.api.gax.httpjson.HttpJsonTransportChannel;
+import com.google.api.gax.httpjson.InstantiatingHttpJsonChannelProvider;
+import com.google.api.gax.httpjson.ProtoOperationTransformers;
+import com.google.api.gax.longrunning.OperationSnapshot;
+import com.google.api.gax.longrunning.OperationTimedPollAlgorithm;
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.api.gax.rpc.ApiClientHeaderProvider;
+import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.OperationCallSettings;
+import com.google.api.gax.rpc.PageContext;
+import com.google.api.gax.rpc.PagedCallSettings;
+import com.google.api.gax.rpc.PagedListDescriptor;
+import com.google.api.gax.rpc.PagedListResponseFactory;
+import com.google.api.gax.rpc.ServerStreamingCallSettings;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.api.gax.rpc.StreamingCallSettings;
+import com.google.api.gax.rpc.StubSettings;
+import com.google.api.gax.rpc.TransportChannelProvider;
+import com.google.api.gax.rpc.UnaryCallSettings;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.longrunning.Operation;
+import com.google.showcase.v1beta1.BlockRequest;
+import com.google.showcase.v1beta1.BlockResponse;
+import com.google.showcase.v1beta1.EchoRequest;
+import com.google.showcase.v1beta1.EchoResponse;
+import com.google.showcase.v1beta1.ExpandRequest;
+import com.google.showcase.v1beta1.Object;
+import com.google.showcase.v1beta1.PagedExpandRequest;
+import com.google.showcase.v1beta1.PagedExpandResponse;
+import com.google.showcase.v1beta1.WaitMetadata;
+import com.google.showcase.v1beta1.WaitRequest;
+import com.google.showcase.v1beta1.WaitResponse;
+import java.io.IOException;
+import java.util.List;
+import javax.annotation.Generated;
+import org.threeten.bp.Duration;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS.
+/**
+ * Settings class to configure an instance of {@link EchoStub}.
+ *
+ * <p>The default instance has everything set to sensible defaults:
+ *
+ * <ul>
+ *   <li>The default service address (localhost) and default port (7469) are used.
+ *   <li>Credentials are acquired automatically through Application Default Credentials.
+ *   <li>Retries are configured for idempotent methods but not for non-idempotent methods.
+ * </ul>
+ *
+ * <p>The builder of this class is recursive, so contained classes are themselves builders. When
+ * build() is called, the tree of builders is called to create the complete settings object.
+ *
+ * <p>For example, to set the total timeout of echo to 30 seconds:
+ *
+ * <pre>{@code
+ * // This snippet has been automatically generated and should be regarded as a code template only.
+ * // It will require modifications to work:
+ * // - It may require correct/in-range values for request initialization.
+ * // - It may require specifying regional endpoints when creating the service client as shown in
+ * // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+ * EchoStubSettings.Builder echoSettingsBuilder = EchoStubSettings.newBuilder();
+ * echoSettingsBuilder
+ *     .echoSettings()
+ *     .setRetrySettings(
+ *         echoSettingsBuilder
+ *             .echoSettings()
+ *             .getRetrySettings()
+ *             .toBuilder()
+ *             .setTotalTimeout(Duration.ofSeconds(30))
+ *             .build());
+ * EchoStubSettings echoSettings = echoSettingsBuilder.build();
+ * }</pre>
+ */
+@BetaApi
+@Generated("by gapic-generator-java")
+public class EchoStubSettings extends StubSettings<EchoStubSettings> {
+  /** The default scopes of the service. */
+  private static final ImmutableList<String> DEFAULT_SERVICE_SCOPES =
+      ImmutableList.<String>builder().add("https://www.googleapis.com/auth/cloud-platform").build();
+
+  private final UnaryCallSettings<EchoRequest, EchoResponse> echoSettings;
+  private final ServerStreamingCallSettings<ExpandRequest, EchoResponse> expandSettings;
+  private final StreamingCallSettings<EchoRequest, EchoResponse> collectSettings;
+  private final StreamingCallSettings<EchoRequest, EchoResponse> chatSettings;
+  private final StreamingCallSettings<EchoRequest, EchoResponse> chatAgainSettings;
+  private final PagedCallSettings<PagedExpandRequest, PagedExpandResponse, PagedExpandPagedResponse>
+      pagedExpandSettings;
+  private final PagedCallSettings<
+          PagedExpandRequest, PagedExpandResponse, SimplePagedExpandPagedResponse>
+      simplePagedExpandSettings;
+  private final UnaryCallSettings<WaitRequest, Operation> waitSettings;
+  private final OperationCallSettings<WaitRequest, WaitResponse, WaitMetadata>
+      waitOperationSettings;
+  private final UnaryCallSettings<BlockRequest, BlockResponse> blockSettings;
+  private final UnaryCallSettings<EchoRequest, Object> collideNameSettings;
+
+  private static final PagedListDescriptor<PagedExpandRequest, PagedExpandResponse, EchoResponse>
+      PAGED_EXPAND_PAGE_STR_DESC =
+          new PagedListDescriptor<PagedExpandRequest, PagedExpandResponse, EchoResponse>() {
+            @Override
+            public String emptyToken() {
+              return "";
+            }
+
+            @Override
+            public PagedExpandRequest injectToken(PagedExpandRequest payload, String token) {
+              return PagedExpandRequest.newBuilder(payload).setPageToken(token).build();
+            }
+
+            @Override
+            public PagedExpandRequest injectPageSize(PagedExpandRequest payload, int pageSize) {
+              return PagedExpandRequest.newBuilder(payload).setPageSize(pageSize).build();
+            }
+
+            @Override
+            public Integer extractPageSize(PagedExpandRequest payload) {
+              return payload.getPageSize();
+            }
+
+            @Override
+            public String extractNextToken(PagedExpandResponse payload) {
+              return payload.getNextPageToken();
+            }
+
+            @Override
+            public Iterable<EchoResponse> extractResources(PagedExpandResponse payload) {
+              return payload.getResponsesList() == null
+                  ? ImmutableList.<EchoResponse>of()
+                  : payload.getResponsesList();
+            }
+          };
+
+  private static final PagedListDescriptor<PagedExpandRequest, PagedExpandResponse, EchoResponse>
+      SIMPLE_PAGED_EXPAND_PAGE_STR_DESC =
+          new PagedListDescriptor<PagedExpandRequest, PagedExpandResponse, EchoResponse>() {
+            @Override
+            public String emptyToken() {
+              return "";
+            }
+
+            @Override
+            public PagedExpandRequest injectToken(PagedExpandRequest payload, String token) {
+              return PagedExpandRequest.newBuilder(payload).setPageToken(token).build();
+            }
+
+            @Override
+            public PagedExpandRequest injectPageSize(PagedExpandRequest payload, int pageSize) {
+              return PagedExpandRequest.newBuilder(payload).setPageSize(pageSize).build();
+            }
+
+            @Override
+            public Integer extractPageSize(PagedExpandRequest payload) {
+              return payload.getPageSize();
+            }
+
+            @Override
+            public String extractNextToken(PagedExpandResponse payload) {
+              return payload.getNextPageToken();
+            }
+
+            @Override
+            public Iterable<EchoResponse> extractResources(PagedExpandResponse payload) {
+              return payload.getResponsesList() == null
+                  ? ImmutableList.<EchoResponse>of()
+                  : payload.getResponsesList();
+            }
+          };
+
+  private static final PagedListResponseFactory<
+          PagedExpandRequest, PagedExpandResponse, PagedExpandPagedResponse>
+      PAGED_EXPAND_PAGE_STR_FACT =
+          new PagedListResponseFactory<
+              PagedExpandRequest, PagedExpandResponse, PagedExpandPagedResponse>() {
+            @Override
+            public ApiFuture<PagedExpandPagedResponse> getFuturePagedResponse(
+                UnaryCallable<PagedExpandRequest, PagedExpandResponse> callable,
+                PagedExpandRequest request,
+                ApiCallContext context,
+                ApiFuture<PagedExpandResponse> futureResponse) {
+              PageContext<PagedExpandRequest, PagedExpandResponse, EchoResponse> pageContext =
+                  PageContext.create(callable, PAGED_EXPAND_PAGE_STR_DESC, request, context);
+              return PagedExpandPagedResponse.createAsync(pageContext, futureResponse);
+            }
+          };
+
+  private static final PagedListResponseFactory<
+          PagedExpandRequest, PagedExpandResponse, SimplePagedExpandPagedResponse>
+      SIMPLE_PAGED_EXPAND_PAGE_STR_FACT =
+          new PagedListResponseFactory<
+              PagedExpandRequest, PagedExpandResponse, SimplePagedExpandPagedResponse>() {
+            @Override
+            public ApiFuture<SimplePagedExpandPagedResponse> getFuturePagedResponse(
+                UnaryCallable<PagedExpandRequest, PagedExpandResponse> callable,
+                PagedExpandRequest request,
+                ApiCallContext context,
+                ApiFuture<PagedExpandResponse> futureResponse) {
+              PageContext<PagedExpandRequest, PagedExpandResponse, EchoResponse> pageContext =
+                  PageContext.create(callable, SIMPLE_PAGED_EXPAND_PAGE_STR_DESC, request, context);
+              return SimplePagedExpandPagedResponse.createAsync(pageContext, futureResponse);
+            }
+          };
+
+  /** Returns the object with the settings used for calls to echo. */
+  public UnaryCallSettings<EchoRequest, EchoResponse> echoSettings() {
+    return echoSettings;
+  }
+
+  /** Returns the object with the settings used for calls to expand. */
+  public ServerStreamingCallSettings<ExpandRequest, EchoResponse> expandSettings() {
+    return expandSettings;
+  }
+
+  /** Returns the object with the settings used for calls to collect. */
+  public StreamingCallSettings<EchoRequest, EchoResponse> collectSettings() {
+    return collectSettings;
+  }
+
+  /** Returns the object with the settings used for calls to chat. */
+  public StreamingCallSettings<EchoRequest, EchoResponse> chatSettings() {
+    return chatSettings;
+  }
+
+  /** Returns the object with the settings used for calls to chatAgain. */
+  public StreamingCallSettings<EchoRequest, EchoResponse> chatAgainSettings() {
+    return chatAgainSettings;
+  }
+
+  /** Returns the object with the settings used for calls to pagedExpand. */
+  public PagedCallSettings<PagedExpandRequest, PagedExpandResponse, PagedExpandPagedResponse>
+      pagedExpandSettings() {
+    return pagedExpandSettings;
+  }
+
+  /** Returns the object with the settings used for calls to simplePagedExpand. */
+  public PagedCallSettings<PagedExpandRequest, PagedExpandResponse, SimplePagedExpandPagedResponse>
+      simplePagedExpandSettings() {
+    return simplePagedExpandSettings;
+  }
+
+  /** Returns the object with the settings used for calls to wait. */
+  public UnaryCallSettings<WaitRequest, Operation> waitSettings() {
+    return waitSettings;
+  }
+
+  /** Returns the object with the settings used for calls to wait. */
+  public OperationCallSettings<WaitRequest, WaitResponse, WaitMetadata> waitOperationSettings() {
+    return waitOperationSettings;
+  }
+
+  /** Returns the object with the settings used for calls to block. */
+  public UnaryCallSettings<BlockRequest, BlockResponse> blockSettings() {
+    return blockSettings;
+  }
+
+  /** Returns the object with the settings used for calls to collideName. */
+  public UnaryCallSettings<EchoRequest, Object> collideNameSettings() {
+    return collideNameSettings;
+  }
+
+  public EchoStub createStub() throws IOException {
+    if (getTransportChannelProvider()
+        .getTransportName()
+        .equals(HttpJsonTransportChannel.getHttpJsonTransportName())) {
+      return HttpJsonEchoStub.create(this);
+    }
+    throw new UnsupportedOperationException(
+        String.format(
+            "Transport not supported: %s", getTransportChannelProvider().getTransportName()));
+  }
+
+  /** Returns a builder for the default ExecutorProvider for this service. */
+  public static InstantiatingExecutorProvider.Builder defaultExecutorProviderBuilder() {
+    return InstantiatingExecutorProvider.newBuilder();
+  }
+
+  /** Returns the default service endpoint. */
+  public static String getDefaultEndpoint() {
+    return "localhost:7469";
+  }
+
+  /** Returns the default mTLS service endpoint. */
+  public static String getDefaultMtlsEndpoint() {
+    return "localhost:7469";
+  }
+
+  /** Returns the default service scopes. */
+  public static List<String> getDefaultServiceScopes() {
+    return DEFAULT_SERVICE_SCOPES;
+  }
+
+  /** Returns a builder for the default credentials for this service. */
+  public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder() {
+    return GoogleCredentialsProvider.newBuilder()
+        .setScopesToApply(DEFAULT_SERVICE_SCOPES)
+        .setUseJwtAccessWithScope(true);
+  }
+
+  /** Returns a builder for the default ChannelProvider for this service. */
+  public static InstantiatingHttpJsonChannelProvider.Builder
+      defaultHttpJsonTransportProviderBuilder() {
+    return InstantiatingHttpJsonChannelProvider.newBuilder();
+  }
+
+  public static TransportChannelProvider defaultTransportChannelProvider() {
+    return defaultHttpJsonTransportProviderBuilder().build();
+  }
+
+  public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder() {
+    return ApiClientHeaderProvider.newBuilder()
+        .setGeneratedLibToken("gapic", GaxProperties.getLibraryVersion(EchoStubSettings.class))
+        .setTransportToken(
+            GaxHttpJsonProperties.getHttpJsonTokenName(),
+            GaxHttpJsonProperties.getHttpJsonVersion())
+        .setApiVersionToken("v1_20230601");
+  }
+
+  /** Returns a new builder for this class. */
+  public static Builder newBuilder() {
+    return Builder.createDefault();
+  }
+
+  /** Returns a new builder for this class. */
+  public static Builder newBuilder(ClientContext clientContext) {
+    return new Builder(clientContext);
+  }
+
+  /** Returns a builder containing all the values of this settings class. */
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  protected EchoStubSettings(Builder settingsBuilder) throws IOException {
+    super(settingsBuilder);
+
+    echoSettings = settingsBuilder.echoSettings().build();
+    expandSettings = settingsBuilder.expandSettings().build();
+    collectSettings = settingsBuilder.collectSettings().build();
+    chatSettings = settingsBuilder.chatSettings().build();
+    chatAgainSettings = settingsBuilder.chatAgainSettings().build();
+    pagedExpandSettings = settingsBuilder.pagedExpandSettings().build();
+    simplePagedExpandSettings = settingsBuilder.simplePagedExpandSettings().build();
+    waitSettings = settingsBuilder.waitSettings().build();
+    waitOperationSettings = settingsBuilder.waitOperationSettings().build();
+    blockSettings = settingsBuilder.blockSettings().build();
+    collideNameSettings = settingsBuilder.collideNameSettings().build();
+  }
+
+  /** Builder for EchoStubSettings. */
+  public static class Builder extends StubSettings.Builder<EchoStubSettings, Builder> {
+    private final ImmutableList<UnaryCallSettings.Builder<?, ?>> unaryMethodSettingsBuilders;
+    private final UnaryCallSettings.Builder<EchoRequest, EchoResponse> echoSettings;
+    private final ServerStreamingCallSettings.Builder<ExpandRequest, EchoResponse> expandSettings;
+    private final StreamingCallSettings.Builder<EchoRequest, EchoResponse> collectSettings;
+    private final StreamingCallSettings.Builder<EchoRequest, EchoResponse> chatSettings;
+    private final StreamingCallSettings.Builder<EchoRequest, EchoResponse> chatAgainSettings;
+    private final PagedCallSettings.Builder<
+            PagedExpandRequest, PagedExpandResponse, PagedExpandPagedResponse>
+        pagedExpandSettings;
+    private final PagedCallSettings.Builder<
+            PagedExpandRequest, PagedExpandResponse, SimplePagedExpandPagedResponse>
+        simplePagedExpandSettings;
+    private final UnaryCallSettings.Builder<WaitRequest, Operation> waitSettings;
+    private final OperationCallSettings.Builder<WaitRequest, WaitResponse, WaitMetadata>
+        waitOperationSettings;
+    private final UnaryCallSettings.Builder<BlockRequest, BlockResponse> blockSettings;
+    private final UnaryCallSettings.Builder<EchoRequest, Object> collideNameSettings;
+    private static final ImmutableMap<String, ImmutableSet<StatusCode.Code>>
+        RETRYABLE_CODE_DEFINITIONS;
+
+    static {
+      ImmutableMap.Builder<String, ImmutableSet<StatusCode.Code>> definitions =
+          ImmutableMap.builder();
+      definitions.put(
+          "retry_policy_1_codes",
+          ImmutableSet.copyOf(
+              Lists.<StatusCode.Code>newArrayList(
+                  StatusCode.Code.UNAVAILABLE, StatusCode.Code.UNKNOWN)));
+      definitions.put(
+          "no_retry_0_codes", ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));
+      RETRYABLE_CODE_DEFINITIONS = definitions.build();
+    }
+
+    private static final ImmutableMap<String, RetrySettings> RETRY_PARAM_DEFINITIONS;
+
+    static {
+      ImmutableMap.Builder<String, RetrySettings> definitions = ImmutableMap.builder();
+      RetrySettings settings = null;
+      settings =
+          RetrySettings.newBuilder()
+              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setRetryDelayMultiplier(2.0)
+              .setMaxRetryDelay(Duration.ofMillis(3000L))
+              .setInitialRpcTimeout(Duration.ofMillis(10000L))
+              .setRpcTimeoutMultiplier(1.0)
+              .setMaxRpcTimeout(Duration.ofMillis(10000L))
+              .setTotalTimeout(Duration.ofMillis(10000L))
+              .build();
+      definitions.put("retry_policy_1_params", settings);
+      settings =
+          RetrySettings.newBuilder()
+              .setInitialRpcTimeout(Duration.ofMillis(5000L))
+              .setRpcTimeoutMultiplier(1.0)
+              .setMaxRpcTimeout(Duration.ofMillis(5000L))
+              .setTotalTimeout(Duration.ofMillis(5000L))
+              .build();
+      definitions.put("no_retry_0_params", settings);
+      RETRY_PARAM_DEFINITIONS = definitions.build();
+    }
+
+    protected Builder() {
+      this(((ClientContext) null));
+    }
+
+    protected Builder(ClientContext clientContext) {
+      super(clientContext);
+
+      echoSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+      expandSettings = ServerStreamingCallSettings.newBuilder();
+      collectSettings = StreamingCallSettings.newBuilder();
+      chatSettings = StreamingCallSettings.newBuilder();
+      chatAgainSettings = StreamingCallSettings.newBuilder();
+      pagedExpandSettings = PagedCallSettings.newBuilder(PAGED_EXPAND_PAGE_STR_FACT);
+      simplePagedExpandSettings = PagedCallSettings.newBuilder(SIMPLE_PAGED_EXPAND_PAGE_STR_FACT);
+      waitSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+      waitOperationSettings = OperationCallSettings.newBuilder();
+      blockSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+      collideNameSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      unaryMethodSettingsBuilders =
+          ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
+              echoSettings,
+              pagedExpandSettings,
+              simplePagedExpandSettings,
+              waitSettings,
+              blockSettings,
+              collideNameSettings);
+      initDefaults(this);
+    }
+
+    protected Builder(EchoStubSettings settings) {
+      super(settings);
+
+      echoSettings = settings.echoSettings.toBuilder();
+      expandSettings = settings.expandSettings.toBuilder();
+      collectSettings = settings.collectSettings.toBuilder();
+      chatSettings = settings.chatSettings.toBuilder();
+      chatAgainSettings = settings.chatAgainSettings.toBuilder();
+      pagedExpandSettings = settings.pagedExpandSettings.toBuilder();
+      simplePagedExpandSettings = settings.simplePagedExpandSettings.toBuilder();
+      waitSettings = settings.waitSettings.toBuilder();
+      waitOperationSettings = settings.waitOperationSettings.toBuilder();
+      blockSettings = settings.blockSettings.toBuilder();
+      collideNameSettings = settings.collideNameSettings.toBuilder();
+
+      unaryMethodSettingsBuilders =
+          ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
+              echoSettings,
+              pagedExpandSettings,
+              simplePagedExpandSettings,
+              waitSettings,
+              blockSettings,
+              collideNameSettings);
+    }
+
+    private static Builder createDefault() {
+      Builder builder = new Builder(((ClientContext) null));
+
+      builder.setTransportChannelProvider(defaultTransportChannelProvider());
+      builder.setCredentialsProvider(defaultCredentialsProviderBuilder().build());
+      builder.setInternalHeaderProvider(defaultApiClientHeaderProviderBuilder().build());
+      builder.setMtlsEndpoint(getDefaultMtlsEndpoint());
+      builder.setSwitchToMtlsEndpointAllowed(true);
+
+      return initDefaults(builder);
+    }
+
+    private static Builder initDefaults(Builder builder) {
+      builder
+          .echoSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("retry_policy_1_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("retry_policy_1_params"));
+
+      builder
+          .expandSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("retry_policy_1_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("retry_policy_1_params"));
+
+      builder
+          .pagedExpandSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("retry_policy_1_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("retry_policy_1_params"));
+
+      builder
+          .simplePagedExpandSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_0_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_0_params"));
+
+      builder
+          .waitSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_0_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_0_params"));
+
+      builder
+          .blockSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_0_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_0_params"));
+
+      builder
+          .collideNameSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_0_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_0_params"));
+
+      builder
+          .waitOperationSettings()
+          .setInitialCallSettings(
+              UnaryCallSettings.<WaitRequest, OperationSnapshot>newUnaryCallSettingsBuilder()
+                  .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_0_codes"))
+                  .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_0_params"))
+                  .build())
+          .setResponseTransformer(
+              ProtoOperationTransformers.ResponseTransformer.create(WaitResponse.class))
+          .setMetadataTransformer(
+              ProtoOperationTransformers.MetadataTransformer.create(WaitMetadata.class))
+          .setPollingAlgorithm(
+              OperationTimedPollAlgorithm.create(
+                  RetrySettings.newBuilder()
+                      .setInitialRetryDelay(Duration.ofMillis(5000L))
+                      .setRetryDelayMultiplier(1.5)
+                      .setMaxRetryDelay(Duration.ofMillis(45000L))
+                      .setInitialRpcTimeout(Duration.ZERO)
+                      .setRpcTimeoutMultiplier(1.0)
+                      .setMaxRpcTimeout(Duration.ZERO)
+                      .setTotalTimeout(Duration.ofMillis(300000L))
+                      .build()));
+
+      return builder;
+    }
+
+    /**
+     * Applies the given settings updater function to all of the unary API methods in this service.
+     *
+     * <p>Note: This method does not support applying settings to streaming methods.
+     */
+    public Builder applyToAllUnaryMethods(
+        ApiFunction<UnaryCallSettings.Builder<?, ?>, Void> settingsUpdater) {
+      super.applyToAllUnaryMethods(unaryMethodSettingsBuilders, settingsUpdater);
+      return this;
+    }
+
+    public ImmutableList<UnaryCallSettings.Builder<?, ?>> unaryMethodSettingsBuilders() {
+      return unaryMethodSettingsBuilders;
+    }
+
+    /** Returns the builder for the settings used for calls to echo. */
+    public UnaryCallSettings.Builder<EchoRequest, EchoResponse> echoSettings() {
+      return echoSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to expand. */
+    public ServerStreamingCallSettings.Builder<ExpandRequest, EchoResponse> expandSettings() {
+      return expandSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to collect. */
+    public StreamingCallSettings.Builder<EchoRequest, EchoResponse> collectSettings() {
+      return collectSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to chat. */
+    public StreamingCallSettings.Builder<EchoRequest, EchoResponse> chatSettings() {
+      return chatSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to chatAgain. */
+    public StreamingCallSettings.Builder<EchoRequest, EchoResponse> chatAgainSettings() {
+      return chatAgainSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to pagedExpand. */
+    public PagedCallSettings.Builder<
+            PagedExpandRequest, PagedExpandResponse, PagedExpandPagedResponse>
+        pagedExpandSettings() {
+      return pagedExpandSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to simplePagedExpand. */
+    public PagedCallSettings.Builder<
+            PagedExpandRequest, PagedExpandResponse, SimplePagedExpandPagedResponse>
+        simplePagedExpandSettings() {
+      return simplePagedExpandSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to wait. */
+    public UnaryCallSettings.Builder<WaitRequest, Operation> waitSettings() {
+      return waitSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to wait. */
+    public OperationCallSettings.Builder<WaitRequest, WaitResponse, WaitMetadata>
+        waitOperationSettings() {
+      return waitOperationSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to block. */
+    public UnaryCallSettings.Builder<BlockRequest, BlockResponse> blockSettings() {
+      return blockSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to collideName. */
+    public UnaryCallSettings.Builder<EchoRequest, Object> collideNameSettings() {
+      return collideNameSettings;
+    }
+
+    @Override
+    public EchoStubSettings build() throws IOException {
+      return new EchoStubSettings(this);
+    }
+  }
+}

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonEchoStubSettings.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonEchoStubSettings.golden
@@ -327,8 +327,7 @@ public class EchoStubSettings extends StubSettings<EchoStubSettings> {
         .setGeneratedLibToken("gapic", GaxProperties.getLibraryVersion(EchoStubSettings.class))
         .setTransportToken(
             GaxHttpJsonProperties.getHttpJsonTokenName(),
-            GaxHttpJsonProperties.getHttpJsonVersion())
-        .setApiVersionToken("v1_20230601");
+            GaxHttpJsonProperties.getHttpJsonVersion());
   }
 
   /** Returns a new builder for this class. */

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/ParserTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/ParserTest.java
@@ -624,6 +624,7 @@ public class ParserTest {
     com.google.api.generator.gapic.model.Service parsedEchoService = services.get(0);
 
     assertEquals("Echo", parsedEchoService.overriddenName());
+    assertEquals("EchoWithVersion", parsedEchoService.overriddenName());
     assertTrue(parsedEchoService.hasApiVersion());
     assertEquals("fake_version", parsedEchoService.apiVersion());
   }

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/ParserTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/ParserTest.java
@@ -623,7 +623,6 @@ public class ParserTest {
             new HashSet<>());
     com.google.api.generator.gapic.model.Service parsedEchoService = services.get(0);
 
-    assertEquals("Echo", parsedEchoService.overriddenName());
     assertEquals("EchoWithVersion", parsedEchoService.overriddenName());
     assertTrue(parsedEchoService.hasApiVersion());
     assertEquals("fake_version", parsedEchoService.apiVersion());

--- a/gapic-generator-java/src/test/java/com/google/api/generator/test/protoloader/TestProtoLoader.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/test/protoloader/TestProtoLoader.java
@@ -28,6 +28,7 @@ import com.google.api.generator.gapic.protoparser.BatchingSettingsConfigParser;
 import com.google.api.generator.gapic.protoparser.Parser;
 import com.google.api.generator.gapic.protoparser.ServiceConfigParser;
 import com.google.api.generator.gapic.protoparser.ServiceYamlParser;
+import com.google.api.version.test.ApiVersionTestingOuterClass;
 import com.google.auto.populate.field.AutoPopulateFieldTestingOuterClass;
 import com.google.bookshop.v1beta1.BookshopProto;
 import com.google.explicit.dynamic.routing.header.ExplicitDynamicRoutingHeaderTestingOuterClass;
@@ -288,6 +289,37 @@ public class TestProtoLoader {
         .setMessages(messageTypes)
         .setResourceNames(resourceNames)
         .setServices(services)
+        .setHelperResourceNames(outputResourceNames)
+        .setTransport(transport)
+        .build();
+  }
+
+  public GapicContext parseApiVersionTesting() {
+    FileDescriptor testingFileDescriptor = ApiVersionTestingOuterClass.getDescriptor();
+    ServiceDescriptor testingService = testingFileDescriptor.getServices().get(0);
+    assertEquals(testingService.getName(), "EchoWithVersion");
+
+    Map<String, Message> messageTypes = Parser.parseMessages(testingFileDescriptor);
+    Map<String, ResourceName> resourceNames = Parser.parseResourceNames(testingFileDescriptor);
+    Set<ResourceName> outputResourceNames = new HashSet<>();
+    List<Service> services =
+        Parser.parseService(
+            testingFileDescriptor,
+            messageTypes,
+            resourceNames,
+            Optional.empty(),
+            outputResourceNames);
+    String jsonFilename = "showcase_grpc_service_config.json";
+    Path jsonPath = Paths.get(testFilesDirectory, jsonFilename);
+    Optional<GapicServiceConfig> configOpt = ServiceConfigParser.parse(jsonPath.toString());
+    assertTrue(configOpt.isPresent());
+    GapicServiceConfig config = configOpt.get();
+
+    return GapicContext.builder()
+        .setMessages(messageTypes)
+        .setResourceNames(resourceNames)
+        .setServices(services)
+        .setServiceConfig(config)
         .setHelperResourceNames(outputResourceNames)
         .setTransport(transport)
         .build();

--- a/gapic-generator-java/src/test/proto/api_version_testing.proto
+++ b/gapic-generator-java/src/test/proto/api_version_testing.proto
@@ -24,7 +24,6 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 import "google/rpc/status.proto";
 
-package google.api.version.test;
 package google.api.version.test.v1;
 
 option java_package = "com.google.api.version.test";

--- a/gapic-generator-java/src/test/proto/api_version_testing.proto
+++ b/gapic-generator-java/src/test/proto/api_version_testing.proto
@@ -25,6 +25,7 @@ import "google/protobuf/timestamp.proto";
 import "google/rpc/status.proto";
 
 package google.api.version.test;
+package google.api.version.test.v1;
 
 option java_package = "com.google.api.version.test";
 option java_multiple_files = true;
@@ -39,7 +40,7 @@ option (google.api.resource_definition) = {
 // to test different scenarios.
 
 // This service is used to test when api_version string is provided.
-service Echo {
+service EchoWithVersion {
   // This service is meant to only run locally on the port 7469 (keypad digits
   // for "show").
   option (google.api.default_host) = "localhost:7469";
@@ -48,7 +49,7 @@ service Echo {
       "https://www.googleapis.com/auth/cloud-platform";
 
   // This method simply echos the request. This method is showcases unary rpcs.
-  rpc Echo(EchoRequest) returns (EchoResponse) {
+  rpc EchoWithVersionMethod(EchoRequest) returns (EchoResponse) {
     option (google.api.http) = {
       post: "/v1beta1/echo:echo"
       body: "*"

--- a/gapic-generator-java/src/test/proto/echo_grpcrest.proto
+++ b/gapic-generator-java/src/test/proto/echo_grpcrest.proto
@@ -47,6 +47,7 @@ service Echo {
   option (google.api.default_host) = "localhost:7469";
   option (google.api.oauth_scopes) =
       "https://www.googleapis.com/auth/cloud-platform";
+  option (google.api.api_version) = "foo_version_for_tests";
 
   // This method simply echos the request. This method is showcases unary rpcs.
   rpc Echo(EchoRequest) returns (EchoResponse) {

--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/ApiClientHeaderProvider.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/ApiClientHeaderProvider.java
@@ -42,6 +42,8 @@ public class ApiClientHeaderProvider implements HeaderProvider, Serializable {
   private static final long serialVersionUID = -8876627296793342119L;
   static final String QUOTA_PROJECT_ID_HEADER_KEY = "x-goog-user-project";
 
+  static final String API_VERSION_HEADER_KEY = "x-goog-api-version";
+
   private final Map<String, String> headers;
 
   protected ApiClientHeaderProvider(Builder builder) {
@@ -68,6 +70,9 @@ public class ApiClientHeaderProvider implements HeaderProvider, Serializable {
       headersBuilder.put(QUOTA_PROJECT_ID_HEADER_KEY, builder.getQuotaProjectIdToken());
     }
 
+    if (builder.getApiVersionToken() != null) {
+      headersBuilder.put(API_VERSION_HEADER_KEY, builder.getApiVersionToken());
+    }
     this.headers = headersBuilder.build();
   }
 
@@ -109,6 +114,8 @@ public class ApiClientHeaderProvider implements HeaderProvider, Serializable {
     private String resourceHeaderKey;
     private String resourceToken;
 
+    private String apiVersionToken;
+
     protected Builder() {
       // Initialize with default values
       apiClientHeaderKey = getDefaultApiClientHeaderKey();
@@ -121,6 +128,8 @@ public class ApiClientHeaderProvider implements HeaderProvider, Serializable {
 
       resourceHeaderKey = getDefaultResourceHeaderKey();
       resourceToken = null;
+
+      apiVersionToken = null;
     }
 
     public String getApiClientHeaderKey() {
@@ -203,6 +212,15 @@ public class ApiClientHeaderProvider implements HeaderProvider, Serializable {
 
     public Builder setResourceToken(String resourceToken) {
       this.resourceToken = resourceToken;
+      return this;
+    }
+
+    public String getApiVersionToken() {
+      return apiVersionToken;
+    }
+
+    public Builder setApiVersionToken(String apiVersionToken) {
+      this.apiVersionToken = apiVersionToken;
       return this;
     }
 

--- a/gax-java/gax/src/test/java/com/google/api/gax/rpc/ApiClientHeaderProviderTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/rpc/ApiClientHeaderProviderTest.java
@@ -40,6 +40,7 @@ public class ApiClientHeaderProviderTest {
 
   private static final String X_GOOG_API_CLIENT = "x-goog-api-client";
   private static final String CLOUD_RESOURCE_PREFIX = "google-cloud-resource-prefix";
+  private static final String API_VERSION_HEADER_KEY = "x-goog-api-version";
 
   @Test
   public void testServiceHeaderDefault() {
@@ -137,5 +138,12 @@ public class ApiClientHeaderProviderTest {
         .matches("^gl-java/.* gccl/1\\.2\\.3 gax/.*$");
     assertThat(provider.getHeaders().get(ApiClientHeaderProvider.QUOTA_PROJECT_ID_HEADER_KEY))
         .matches(quotaProjectHeaderValue);
+  }
+  @Test
+  public void testApiVersionHeader() {
+    ApiClientHeaderProvider provider = ApiClientHeaderProvider.newBuilder()
+        .setApiVersionToken("fake-version-string").build();
+    assertThat(provider.getHeaders().size()).isEqualTo(2);
+    assertThat(provider.getHeaders().get(API_VERSION_HEADER_KEY)).matches("fake-version-string");
   }
 }

--- a/gax-java/gax/src/test/java/com/google/api/gax/rpc/ApiClientHeaderProviderTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/rpc/ApiClientHeaderProviderTest.java
@@ -139,11 +139,16 @@ public class ApiClientHeaderProviderTest {
     assertThat(provider.getHeaders().get(ApiClientHeaderProvider.QUOTA_PROJECT_ID_HEADER_KEY))
         .matches(quotaProjectHeaderValue);
   }
+
   @Test
   public void testApiVersionHeader() {
-    ApiClientHeaderProvider provider = ApiClientHeaderProvider.newBuilder()
-        .setApiVersionToken("fake-version-string").build();
+    ApiClientHeaderProvider provider =
+        ApiClientHeaderProvider.newBuilder().setApiVersionToken("fake-version-string").build();
     assertThat(provider.getHeaders().size()).isEqualTo(2);
     assertThat(provider.getHeaders().get(API_VERSION_HEADER_KEY)).matches("fake-version-string");
+
+    ApiClientHeaderProvider emptyProvider =
+        ApiClientHeaderProvider.newBuilder().setApiVersionToken("").build();
+    assertThat(emptyProvider.getHeaders().get(API_VERSION_HEADER_KEY).isEmpty());
   }
 }

--- a/gax-java/gax/src/test/java/com/google/api/gax/rpc/ApiClientHeaderProviderTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/rpc/ApiClientHeaderProviderTest.java
@@ -40,7 +40,6 @@ public class ApiClientHeaderProviderTest {
 
   private static final String X_GOOG_API_CLIENT = "x-goog-api-client";
   private static final String CLOUD_RESOURCE_PREFIX = "google-cloud-resource-prefix";
-  private static final String API_VERSION_HEADER_KEY = "x-goog-api-version";
 
   @Test
   public void testServiceHeaderDefault() {
@@ -145,10 +144,12 @@ public class ApiClientHeaderProviderTest {
     ApiClientHeaderProvider provider =
         ApiClientHeaderProvider.newBuilder().setApiVersionToken("fake-version-string").build();
     assertThat(provider.getHeaders().size()).isEqualTo(2);
-    assertThat(provider.getHeaders().get(API_VERSION_HEADER_KEY)).matches("fake-version-string");
+    assertThat(provider.getHeaders().get(ApiClientHeaderProvider.API_VERSION_HEADER_KEY))
+        .matches("fake-version-string");
 
     ApiClientHeaderProvider emptyProvider =
         ApiClientHeaderProvider.newBuilder().setApiVersionToken("").build();
-    assertThat(emptyProvider.getHeaders().get(API_VERSION_HEADER_KEY).isEmpty());
+    assertThat(
+        emptyProvider.getHeaders().get(ApiClientHeaderProvider.API_VERSION_HEADER_KEY).isEmpty());
   }
 }

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/EchoStubSettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/EchoStubSettings.java
@@ -479,8 +479,8 @@ public class EchoStubSettings extends StubSettings<EchoStubSettings> {
   public static ApiClientHeaderProvider.Builder defaultGrpcApiClientHeaderProviderBuilder() {
     return ApiClientHeaderProvider.newBuilder()
         .setGeneratedLibToken("gapic", GaxProperties.getLibraryVersion(EchoStubSettings.class))
-        .setTransportToken(
-            GaxGrpcProperties.getGrpcTokenName(), GaxGrpcProperties.getGrpcVersion());
+        .setTransportToken(GaxGrpcProperties.getGrpcTokenName(), GaxGrpcProperties.getGrpcVersion())
+        .setApiVersionToken("v1_20240408");
   }
 
   public static ApiClientHeaderProvider.Builder defaultHttpJsonApiClientHeaderProviderBuilder() {
@@ -488,7 +488,8 @@ public class EchoStubSettings extends StubSettings<EchoStubSettings> {
         .setGeneratedLibToken("gapic", GaxProperties.getLibraryVersion(EchoStubSettings.class))
         .setTransportToken(
             GaxHttpJsonProperties.getHttpJsonTokenName(),
-            GaxHttpJsonProperties.getHttpJsonVersion());
+            GaxHttpJsonProperties.getHttpJsonVersion())
+        .setApiVersionToken("v1_20240408");
   }
 
   public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder() {


### PR DESCRIPTION
This is part 2, following changes in https://github.com/googleapis/sdk-platform-java/pull/2630

Changes in this pr:
- ApiClientHeaderProvider: add key and token setter for api version.
- AbstractServiceStubSettingsClassComposer: add logic to set this header when api-version is present (not null or empty)
- Unit and golden tests to reflect above changes. (This includeds a few new golden files created for tests based on the dedicated proto created in #2630)

This pr does not include gapic-showcased testing for now.
---
manual tested with [gapic-showcase](https://github.com/googleapis/gapic-showcase) v0.33.0

steps: 
- Use gapic-showcase v0.33.0 (which includes update in 1484)
- use `gapic-showcase run -v` which prints the request header
- From showcase folder, run `mvn verify -P enable-integration-tests -Dit.test=ITAutoPopulatedFields.java -pl=gapic-showcase`

Printed header in manual testing
Grpc
```
2024/04/16 10:26:41 Received Unary Request for Method: /google.showcase.v1beta1.Echo/Echo
2024/04/16 10:26:41     Request headers:
2024/04/16 10:26:41       grpc-accept-encoding: gzip
2024/04/16 10:26:41       content-type: application/grpc
2024/04/16 10:26:41       x-goog-api-version: v1_20240408
2024/04/16 10:26:41       :authority: localhost:7469
2024/04/16 10:26:41       user-agent: grpc-java-netty/1.62.2
2024/04/16 10:26:41       x-goog-api-client: gl-java/17.0.7__Eclipse-Adoptium__Temurin-17.0.7-7 gapic/0.0.1-SNAPSHOT gax/2.46.2-SNAPSHOT grpc/1.62.2
2024/04/16 10:26:41     Request:  error:{code:2}  request_id:"1e26ee16-ed07-4eeb-be0e-49b769678779"  other_request_id:"40883e5d-3b20-4add-854c-9808bd009260"
2024/04/16 10:26:41     Returning Error: rpc error: code = Unknown desc = 
```
Httpjson
```
2024/04/16 10:26:41 Received POST request matching '/v1beta1/echo:echo': "/v1beta1/echo:echo"                                                               
2024/04/16 10:26:41   urlPathParams (expect 0, have 0): map[]                 
2024/04/16 10:26:41   urlRequestHeaders:                                                                                                                    
    User-Agent: "Google-HTTP-Java-Client/1.44.1 (gzip)"                                                                                                     
    Content-Type: "application/json; charset=utf-8"                           
    Connection: "keep-alive"                                                                                                                                
    Accept-Encoding: "gzip"                                                   
    X-Goog-Api-Client: "gl-java/17.0.7__Eclipse-Adoptium__Temurin-17.0.7-7 gapic/0.0.1-SNAPSHOT gax/2.46.2-SNAPSHOT rest/"                                  
    X-Goog-Api-Version: "v1_20240408"                                                                                                                       
    Accept: "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"            
    Content-Length: "129"                                                     
2024/04/16 10:26:41   request: {                                                                                                                            
  "error":  {                                                                                                                                               
    "code":  500,                                                                                                                                           
    "message":  "",                                                                                                                                         
    "details":  []                                                            
  },                                                                                                                                                        
  "severity":  "UNNECESSARY",                                                                                                                               
  "header":  "",                                                                                                                                            
  "otherHeader":  "",                                                         
  "requestId":  "e690a84b-176d-421e-9e5d-ba752f68fec8",                       
  "otherRequestId":  "47e0fbde-056a-43ae-bba6-8b6770d861f7"                   
}    
``` 