### PR TITLE
chore: update package information report

### DIFF
--- a/java-shared-dependencies/dependency-analyzer/src/main/java/com/google/cloud/DependencyAnalyzer.java
+++ b/java-shared-dependencies/dependency-analyzer/src/main/java/com/google/cloud/DependencyAnalyzer.java
@@ -86,10 +86,12 @@ public class DependencyAnalyzer {
    */
   public static void main(String[] args) throws IllegalArgumentException {
     checkArgument(args.length == 3,
-        "The length of the inputs should be 3.\n" +
-            "The 1st input should be the package management system.\n" +
-            "The 2nd input should be the package name.\n" +
-            "The 3rd input should be the package version.\n"
+        """
+            The length of the inputs should be 3.
+            The 1st input should be the package management system.
+            The 2nd input should be the package name.
+            The 3rd input should be the package version.
+            """
     );
 
     String system = args[0];

--- a/java-shared-dependencies/dependency-analyzer/src/main/java/com/google/cloud/external/DepsDevClient.java
+++ b/java-shared-dependencies/dependency-analyzer/src/main/java/com/google/cloud/external/DepsDevClient.java
@@ -27,9 +27,11 @@ public class DepsDevClient {
 
   private final HttpClient client;
   public final Gson gson;
-  private final static String advisoryUrlBase = "https://api.deps.dev/v3/advisories/%s";
-  private final static String queryUrlBase = "https://api.deps.dev/v3/query?versionKey.system=%s&versionKey.name=%s&versionKey.version=%s";
-  private final static String dependencyUrlBase = "https://api.deps.dev/v3/systems/%s/packages/%s/versions/%s:dependencies";
+  private final static String ADVISORY_URL_BASE = "https://api.deps.dev/v3/advisories/%s";
+
+  private final static String DEPENDENCY_URLBASE = "https://api.deps.dev/v3/systems/%s/packages/%s/versions/%s:dependencies";
+
+  public final static String QUERY_URL_BASE = "https://api.deps.dev/v3/query?versionKey.system=%s&versionKey.name=%s&versionKey.version=%s";
 
   public DepsDevClient(HttpClient client) {
     this.client = client;
@@ -76,15 +78,15 @@ public class DepsDevClient {
   }
 
   private String getAdvisoryUrl(String advisoryId) {
-    return String.format(advisoryUrlBase, advisoryId);
+    return String.format(ADVISORY_URL_BASE, advisoryId);
   }
 
   private String getQueryUrl(String system, String name, String version) {
-    return String.format(queryUrlBase, system, name, version);
+    return String.format(QUERY_URL_BASE, system, name, version);
   }
 
   private String getDependencyUrl(String system, String name, String version) {
-    return String.format(dependencyUrlBase, system, name, version);
+    return String.format(DEPENDENCY_URLBASE, system, name, version);
   }
 
   private HttpResponse<String> getResponse(String endpoint)

--- a/java-shared-dependencies/dependency-analyzer/src/main/java/com/google/cloud/external/DepsDevClient.java
+++ b/java-shared-dependencies/dependency-analyzer/src/main/java/com/google/cloud/external/DepsDevClient.java
@@ -6,6 +6,7 @@ import com.google.cloud.model.Node;
 import com.google.cloud.model.QueryResult;
 import com.google.cloud.model.Relation;
 import com.google.cloud.model.VersionKey;
+import com.google.errorprone.annotations.RestrictedApi;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonDeserializationContext;
@@ -83,11 +84,17 @@ public class DepsDevClient {
     return String.format(ADVISORY_URL_BASE, advisoryId);
   }
 
-  private String getQueryUrl(String system, String name, String version) {
+  @RestrictedApi(
+      explanation = "This method is for internal use only.",
+      allowedOnPath = "test/java/com/google/cloud/external")
+  public String getQueryUrl(String system, String name, String version) {
     return String.format(QUERY_URL_BASE, system, name, encode(version));
   }
 
-  private String getDependencyUrl(String system, String name, String version) {
+  @RestrictedApi(
+      explanation = "This method is for internal use only.",
+      allowedOnPath = "test/java/com/google/cloud/external")
+  public String getDependencyUrl(String system, String name, String version) {
     return String.format(DEPENDENCY_URLBASE, system, name, encode(version));
   }
 

--- a/java-shared-dependencies/dependency-analyzer/src/main/java/com/google/cloud/external/DepsDevClient.java
+++ b/java-shared-dependencies/dependency-analyzer/src/main/java/com/google/cloud/external/DepsDevClient.java
@@ -16,10 +16,12 @@ import java.io.IOException;
 import java.lang.reflect.Type;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -82,11 +84,15 @@ public class DepsDevClient {
   }
 
   private String getQueryUrl(String system, String name, String version) {
-    return String.format(QUERY_URL_BASE, system, name, version);
+    return String.format(QUERY_URL_BASE, system, name, encode(version));
   }
 
   private String getDependencyUrl(String system, String name, String version) {
-    return String.format(DEPENDENCY_URLBASE, system, name, version);
+    return String.format(DEPENDENCY_URLBASE, system, name, encode(version));
+  }
+
+  private String encode(String str) {
+    return URLEncoder.encode(str, StandardCharsets.UTF_8);
   }
 
   private HttpResponse<String> getResponse(String endpoint)

--- a/java-shared-dependencies/dependency-analyzer/src/main/java/com/google/cloud/model/AnalysisResult.java
+++ b/java-shared-dependencies/dependency-analyzer/src/main/java/com/google/cloud/model/AnalysisResult.java
@@ -128,10 +128,11 @@ public class AnalysisResult {
 
   private void appendToReport(StringBuilder builder, PackageInfo packageInfo) {
     VersionKey versionKey = packageInfo.versionKey();
+    // generate the report using Markdown format.
     builder.append(String.format("### %s\n", versionKey));
     builder.append(String.format("Licenses: %s\n", packageInfo.licenses()));
     builder.append(
-        String.format("Vulnerabilities: None. Checked in %s\n",
+        String.format("Vulnerabilities: None\n. Checked in [deps.dev query](%s)\n",
             getQueryUrl(
                 versionKey.pkgManagement().toString(),
                 versionKey.name(),

--- a/java-shared-dependencies/dependency-analyzer/src/main/java/com/google/cloud/model/AnalysisResult.java
+++ b/java-shared-dependencies/dependency-analyzer/src/main/java/com/google/cloud/model/AnalysisResult.java
@@ -110,11 +110,18 @@ public class AnalysisResult {
   private String packageInfoReport() {
     StringBuilder builder = new StringBuilder();
     builder.append("Please copy and paste the package information below to your ticket.\n");
+    builder.append("\n\n");
     appendToReport(builder, packageInfos.get(0));
-    builder.append("## Dependencies:");
-    for (int i = 1; i < packageInfos.size(); i++) {
-      appendToReport(builder, packageInfos.get(i));
+
+    builder.append("## Dependencies:\n");
+    if (packageInfos.size() <= 1) {
+      builder.append("None");
+    } else {
+      for (int i = 1; i < packageInfos.size(); i++) {
+        appendToReport(builder, packageInfos.get(i));
+      }
     }
+    builder.append("\n\n");
 
     return builder.toString();
   }
@@ -129,6 +136,7 @@ public class AnalysisResult {
                 versionKey.pkgManagement().toString(),
                 versionKey.name(),
                 versionKey.version())));
+    builder.append("\n");
   }
 
   private String getQueryUrl(String system, String name, String version) {

--- a/java-shared-dependencies/dependency-analyzer/src/main/java/com/google/cloud/model/AnalysisResult.java
+++ b/java-shared-dependencies/dependency-analyzer/src/main/java/com/google/cloud/model/AnalysisResult.java
@@ -129,10 +129,10 @@ public class AnalysisResult {
   private void appendToReport(StringBuilder builder, PackageInfo packageInfo) {
     VersionKey versionKey = packageInfo.versionKey();
     // generate the report using Markdown format.
-    builder.append(String.format("### %s\n", versionKey));
+    builder.append(String.format("## Package information of %s\n", versionKey));
     builder.append(String.format("Licenses: %s\n", packageInfo.licenses()));
     builder.append(
-        String.format("Vulnerabilities: None\n. Checked in [deps.dev query](%s)\n",
+        String.format("Vulnerabilities: None.\nChecked in [deps.dev query](%s)\n",
             getQueryUrl(
                 versionKey.pkgManagement().toString(),
                 versionKey.name(),

--- a/java-shared-dependencies/dependency-analyzer/src/main/java/com/google/cloud/model/AnalysisResult.java
+++ b/java-shared-dependencies/dependency-analyzer/src/main/java/com/google/cloud/model/AnalysisResult.java
@@ -107,7 +107,7 @@ public class AnalysisResult {
     return "===========================================================";
   }
 
-  private String packageInfoReport() {
+  public String packageInfoReport() {
     StringBuilder builder = new StringBuilder();
     PackageInfo root = packageInfos.get(0);
     String title = String.format("""

--- a/java-shared-dependencies/dependency-analyzer/src/main/java/com/google/cloud/model/AnalysisResult.java
+++ b/java-shared-dependencies/dependency-analyzer/src/main/java/com/google/cloud/model/AnalysisResult.java
@@ -109,45 +109,49 @@ public class AnalysisResult {
 
   private String packageInfoReport() {
     StringBuilder builder = new StringBuilder();
-    builder.append("Please copy and paste the package information below to your ticket.\n");
-    builder.append("\n\n");
-    appendToReport(builder, packageInfos.get(0), true);
+    PackageInfo root = packageInfos.get(0);
+    String title = String.format("""
+        Please copy and paste the package information below to your ticket.
+                
+        ## Package information of %s
+        %s
+        """, root.versionKey(), packageInfoSection(root));
+    builder.append(title);
 
     builder.append("## Dependencies:\n");
-    if (packageInfos.size() <= 1) {
+    if (packageInfos.size() == 1) {
       builder.append("None");
     } else {
       for (int i = 1; i < packageInfos.size(); i++) {
-        appendToReport(builder, packageInfos.get(i), false);
+        PackageInfo info = packageInfos.get(i);
+        String dependencyInfo = String.format("""
+            ### Package information of %s
+            %s
+            """, info.versionKey(), packageInfoSection(info));
+        builder.append(dependencyInfo);
       }
     }
-    builder.append("\n\n");
+    builder.append("\n");
 
     return builder.toString();
   }
 
-  private void appendToReport(StringBuilder builder, PackageInfo packageInfo, boolean isRoot) {
+  private String packageInfoSection(PackageInfo packageInfo) {
     VersionKey versionKey = packageInfo.versionKey();
     // generate the report using Markdown format.
-    String title = "## Package information of %s\n";
-    if (isRoot) {
-      builder.append(String.format(title, versionKey));
-    } else {
-      // add an extra "#" at the beginning of the title to emphasize that
-      // this section is a subsection of Dependencies.
-      builder.append(String.format("#" + title, versionKey));
-    }
-
-    builder.append(String.format("Licenses: %s\n", packageInfo.licenses()));
-    builder.append(
-        String.format("Vulnerabilities: None.\nChecked in [%s (%s)](%s)\n",
+    String packageInfoReport = """
+        Licenses: %s
+        Vulnerabilities: None.
+        Checked in [%s (%s)](%s)
+        """;
+    return String.format(packageInfoReport,
+        packageInfo.licenses(),
+        versionKey.name(),
+        versionKey.version(),
+        getQueryUrl(
+            versionKey.pkgManagement().toString(),
             versionKey.name(),
-            versionKey.version(),
-            getQueryUrl(
-                versionKey.pkgManagement().toString(),
-                versionKey.name(),
-                versionKey.version())));
-    builder.append("\n");
+            versionKey.version()));
   }
 
   private String getQueryUrl(String system, String name, String version) {

--- a/java-shared-dependencies/dependency-analyzer/src/main/java/com/google/cloud/model/AnalysisResult.java
+++ b/java-shared-dependencies/dependency-analyzer/src/main/java/com/google/cloud/model/AnalysisResult.java
@@ -111,14 +111,14 @@ public class AnalysisResult {
     StringBuilder builder = new StringBuilder();
     builder.append("Please copy and paste the package information below to your ticket.\n");
     builder.append("\n\n");
-    appendToReport(builder, packageInfos.get(0));
+    appendToReport(builder, packageInfos.get(0), true);
 
     builder.append("## Dependencies:\n");
     if (packageInfos.size() <= 1) {
       builder.append("None");
     } else {
       for (int i = 1; i < packageInfos.size(); i++) {
-        appendToReport(builder, packageInfos.get(i));
+        appendToReport(builder, packageInfos.get(i), false);
       }
     }
     builder.append("\n\n");
@@ -126,13 +126,23 @@ public class AnalysisResult {
     return builder.toString();
   }
 
-  private void appendToReport(StringBuilder builder, PackageInfo packageInfo) {
+  private void appendToReport(StringBuilder builder, PackageInfo packageInfo, boolean isRoot) {
     VersionKey versionKey = packageInfo.versionKey();
     // generate the report using Markdown format.
-    builder.append(String.format("## Package information of %s\n", versionKey));
+    String title = "## Package information of %s\n";
+    if (isRoot) {
+      builder.append(String.format(title, versionKey));
+    } else {
+      // add an extra "#" at the beginning of the title to emphasize that
+      // this section is a subsection of Dependencies.
+      builder.append(String.format("#" + title, versionKey));
+    }
+
     builder.append(String.format("Licenses: %s\n", packageInfo.licenses()));
     builder.append(
-        String.format("Vulnerabilities: None.\nChecked in [deps.dev query](%s)\n",
+        String.format("Vulnerabilities: None.\nChecked in [%s (%s)](%s)\n",
+            versionKey.name(),
+            versionKey.version(),
             getQueryUrl(
                 versionKey.pkgManagement().toString(),
                 versionKey.name(),

--- a/java-shared-dependencies/dependency-analyzer/src/main/java/com/google/cloud/model/License.java
+++ b/java-shared-dependencies/dependency-analyzer/src/main/java/com/google/cloud/model/License.java
@@ -16,6 +16,7 @@ import java.util.logging.Logger;
 public enum License {
   APACHE_2_0("Apache-2.0", Set.of(NOTICE)),
   BCL("BCL", Set.of(RESTRICTED, NOTICE)),
+  BSD_3_CLAUSE("BSD-3-Clause", Set.of(NOTICE)),
   GL2PS("GL2PS", Set.of(RESTRICTED, NOTICE)),
   MIT("MIT", Set.of(NOTICE)),
   NOT_RECOGNIZED("Not-Recognized", Set.of());

--- a/java-shared-dependencies/dependency-analyzer/src/main/java/com/google/cloud/model/License.java
+++ b/java-shared-dependencies/dependency-analyzer/src/main/java/com/google/cloud/model/License.java
@@ -14,17 +14,20 @@ import java.util.logging.Logger;
  * For more information, please refer to go/thirdpartylicenses.
  */
 public enum License {
-  APACHE_2_0(Set.of(NOTICE)),
-  BCL(Set.of(RESTRICTED, NOTICE)),
-  GL2PS(Set.of(RESTRICTED, NOTICE)),
-  MIT(Set.of(NOTICE)),
-  NOT_RECOGNIZED(Set.of());
+  APACHE_2_0("Apache-2.0", Set.of(NOTICE)),
+  BCL("BCL", Set.of(RESTRICTED, NOTICE)),
+  GL2PS("GL2PS", Set.of(RESTRICTED, NOTICE)),
+  MIT("MIT", Set.of(NOTICE)),
+  NOT_RECOGNIZED("Not-Recognized", Set.of());
 
   private final static Logger LOGGER = Logger.getLogger(License.class.getName());
 
+  private final String licenseStr;
+
   private final Set<LicenseCategory> categories;
 
-  License(Set<LicenseCategory> categories) {
+  License(String licenseStr, Set<LicenseCategory> categories) {
+    this.licenseStr = licenseStr;
     this.categories = categories;
   }
 
@@ -43,5 +46,16 @@ public enum License {
 
   public Set<LicenseCategory> getCategories() {
     return ImmutableSet.copyOf(categories);
+  }
+
+  @Override
+  public String toString() {
+    Set<LicenseCategory> compliantCategories = LicenseCategory.compliantCategories();
+    for (LicenseCategory category : this.categories) {
+      if (!compliantCategories.contains(category)) {
+        return this.licenseStr;
+      }
+    }
+    return String.format("%s (Google-compliant)", this.licenseStr);
   }
 }

--- a/java-shared-dependencies/dependency-analyzer/src/main/java/com/google/cloud/model/LicenseCategory.java
+++ b/java-shared-dependencies/dependency-analyzer/src/main/java/com/google/cloud/model/LicenseCategory.java
@@ -1,5 +1,8 @@
 package com.google.cloud.model;
 
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+
 /**
  * The type of license associated with open-source software.
  * <p>
@@ -8,5 +11,9 @@ package com.google.cloud.model;
 public enum LicenseCategory {
   PERMISSIVE,
   RESTRICTED,
-  NOTICE
+  NOTICE;
+
+  public static Set<LicenseCategory> compliantCategories() {
+    return ImmutableSet.of(LicenseCategory.NOTICE);
+  }
 }

--- a/java-shared-dependencies/dependency-analyzer/src/main/java/com/google/cloud/model/VersionKey.java
+++ b/java-shared-dependencies/dependency-analyzer/src/main/java/com/google/cloud/model/VersionKey.java
@@ -20,4 +20,16 @@ public record VersionKey(
     return new VersionKey(pkg, name, version);
   }
 
+  @Override
+  public String toString() {
+    if (pkgManagement == PkgManagement.MAVEN) {
+      return String.format("%s:%s", name, version);
+    }
+
+    return "VersionKey{" +
+        "pkgManagement=" + pkgManagement +
+        ", name='" + name + '\'' +
+        ", version='" + version + '\'' +
+        '}';
+  }
 }

--- a/java-shared-dependencies/dependency-analyzer/src/test/java/com/google/cloud/external/DepsDevClientTest.java
+++ b/java-shared-dependencies/dependency-analyzer/src/test/java/com/google/cloud/external/DepsDevClientTest.java
@@ -21,13 +21,12 @@ import org.junit.Test;
 
 public class DepsDevClientTest {
 
-  private HttpClient httpClient;
   private HttpResponse<String> response;
   private DepsDevClient client;
 
   @Before
   public void setUp() throws IOException, InterruptedException {
-    httpClient = mock(HttpClient.class);
+    HttpClient httpClient = mock(HttpClient.class);
     client = new DepsDevClient(httpClient);
     response = mock(HttpResponse.class);
     when(httpClient.send(any(HttpRequest.class), any(BodyHandler.class)))
@@ -50,26 +49,13 @@ public class DepsDevClientTest {
       throws URISyntaxException, IOException, InterruptedException, IllegalArgumentException {
     String responseBody = "{\"results\":[{\"version\":{\"versionKey\":{\"system\":\"MAVEN\",\"name\":\"org.apache.logging.log4j:log4j-core\",\"version\":\"2.17.0\"},\"publishedAt\":\"2021-12-18T01:58:10Z\",\"isDefault\":false,\"licenses\":[\"Apache-2.0\"],\"advisoryKeys\":[{\"id\":\"GHSA-8489-44mv-ggj8\"}],\"links\":[{\"label\":\"SOURCE_REPO\",\"url\":\"https://gitbox.apache.org/repos/asf?p=logging-log4j2.git\"},{\"label\":\"ISSUE_TRACKER\",\"url\":\"https://issues.apache.org/jira/browse/LOG4J2\"},{\"label\":\"HOMEPAGE\",\"url\":\"https://logging.apache.org/log4j/2.x/\"}],\"slsaProvenances\":[],\"registries\":[\"https://repo.maven.apache.org/maven2/\"],\"relatedProjects\":[{\"projectKey\":{\"id\":\"\"},\"relationProvenance\":\"UNVERIFIED_METADATA\",\"relationType\":\"ISSUE_TRACKER\"}]}}]}";
     when(response.body()).thenReturn(responseBody);
-    VersionKey log4jCore = VersionKey.from("maven", "org.apache.logging.log4j:log4j-core", "2.17.0");
+    VersionKey log4jCore = VersionKey.from("maven", "org.apache.logging.log4j:log4j-core",
+        "2.17.0");
     QueryResult queryResult = client.getQueryResult(log4jCore);
     assertThat(queryResult.results()).hasSize(1);
     Version version = queryResult.results().get(0).version();
     assertThat(version.advisoryKeys()).isEqualTo(List.of(new AdvisoryKey("GHSA-8489-44mv-ggj8")));
     assertThat(version.licenses()).isEqualTo(List.of("Apache-2.0"));
     assertThat(version.versionKey()).isEqualTo(log4jCore);
-  }
-
-  @Test
-  public void testGetQueryResult()
-      throws URISyntaxException, IOException, InterruptedException, IllegalArgumentException {
-    String responseBody = "{\"results\":[{\"version\":{\"versionKey\":{\"system\":\"MAVEN\",\"name\":\"com.google.api:gapic-generator-java\",\"version\":\"2.39.0\"},\"isDefault\":true,\"licenses\":[\"Apache-2.0\"],\"advisoryKeys\":[],\"links\":[{\"label\":\"SOURCE_REPO\",\"url\":\"https://github.com/googleapis/sdk-platform-java\"},{\"label\":\"ISSUE_TRACKER\",\"url\":\"https://github.com/googleapis/sdk-platform-java/issues\"},{\"label\":\"HOMEPAGE\",\"url\":\"https://github.com/googleapis/sdk-platform-java\"}],\"slsaProvenances\":[],\"registries\":[\"https://repo.maven.apache.org/maven2/\"],\"relatedProjects\":[{\"projectKey\":{\"id\":\"github.com/googleapis/sdk-platform-java\"},\"relationProvenance\":\"UNVERIFIED_METADATA\",\"relationType\":\"SOURCE_REPO\"},{\"projectKey\":{\"id\":\"github.com/googleapis/sdk-platform-java\"},\"relationProvenance\":\"UNVERIFIED_METADATA\",\"relationType\":\"ISSUE_TRACKER\"}]}}]}";
-    when(response.body()).thenReturn(responseBody);
-    VersionKey generator = VersionKey.from("maven", "com.google.api:gapic-generator-java", "2.39.0");
-    QueryResult queryResult = client.getQueryResult(generator);
-    assertThat(queryResult.results()).hasSize(1);
-    Version version = queryResult.results().get(0).version();
-    assertThat(version.advisoryKeys()).isEqualTo(List.of());
-    assertThat(version.licenses()).isEqualTo(List.of("Apache-2.0"));
-    assertThat(version.versionKey()).isEqualTo(generator);
   }
 }

--- a/java-shared-dependencies/dependency-analyzer/src/test/java/com/google/cloud/external/DepsDevClientTest.java
+++ b/java-shared-dependencies/dependency-analyzer/src/test/java/com/google/cloud/external/DepsDevClientTest.java
@@ -58,4 +58,18 @@ public class DepsDevClientTest {
     assertThat(version.licenses()).isEqualTo(List.of("Apache-2.0"));
     assertThat(version.versionKey()).isEqualTo(log4jCore);
   }
+
+  @Test
+  public void testGetQueryResult()
+      throws URISyntaxException, IOException, InterruptedException, IllegalArgumentException {
+    String responseBody = "{\"results\":[{\"version\":{\"versionKey\":{\"system\":\"MAVEN\",\"name\":\"com.google.api:gapic-generator-java\",\"version\":\"2.39.0\"},\"isDefault\":true,\"licenses\":[\"Apache-2.0\"],\"advisoryKeys\":[],\"links\":[{\"label\":\"SOURCE_REPO\",\"url\":\"https://github.com/googleapis/sdk-platform-java\"},{\"label\":\"ISSUE_TRACKER\",\"url\":\"https://github.com/googleapis/sdk-platform-java/issues\"},{\"label\":\"HOMEPAGE\",\"url\":\"https://github.com/googleapis/sdk-platform-java\"}],\"slsaProvenances\":[],\"registries\":[\"https://repo.maven.apache.org/maven2/\"],\"relatedProjects\":[{\"projectKey\":{\"id\":\"github.com/googleapis/sdk-platform-java\"},\"relationProvenance\":\"UNVERIFIED_METADATA\",\"relationType\":\"SOURCE_REPO\"},{\"projectKey\":{\"id\":\"github.com/googleapis/sdk-platform-java\"},\"relationProvenance\":\"UNVERIFIED_METADATA\",\"relationType\":\"ISSUE_TRACKER\"}]}}]}";
+    when(response.body()).thenReturn(responseBody);
+    VersionKey generator = VersionKey.from("maven", "com.google.api:gapic-generator-java", "2.39.0");
+    QueryResult queryResult = client.getQueryResult(generator);
+    assertThat(queryResult.results()).hasSize(1);
+    Version version = queryResult.results().get(0).version();
+    assertThat(version.advisoryKeys()).isEqualTo(List.of());
+    assertThat(version.licenses()).isEqualTo(List.of("Apache-2.0"));
+    assertThat(version.versionKey()).isEqualTo(generator);
+  }
 }

--- a/java-shared-dependencies/dependency-analyzer/src/test/java/com/google/cloud/external/DepsDevClientTest.java
+++ b/java-shared-dependencies/dependency-analyzer/src/test/java/com/google/cloud/external/DepsDevClientTest.java
@@ -49,8 +49,8 @@ public class DepsDevClientTest {
       throws URISyntaxException, IOException, InterruptedException, IllegalArgumentException {
     String responseBody = "{\"results\":[{\"version\":{\"versionKey\":{\"system\":\"MAVEN\",\"name\":\"org.apache.logging.log4j:log4j-core\",\"version\":\"2.17.0\"},\"publishedAt\":\"2021-12-18T01:58:10Z\",\"isDefault\":false,\"licenses\":[\"Apache-2.0\"],\"advisoryKeys\":[{\"id\":\"GHSA-8489-44mv-ggj8\"}],\"links\":[{\"label\":\"SOURCE_REPO\",\"url\":\"https://gitbox.apache.org/repos/asf?p=logging-log4j2.git\"},{\"label\":\"ISSUE_TRACKER\",\"url\":\"https://issues.apache.org/jira/browse/LOG4J2\"},{\"label\":\"HOMEPAGE\",\"url\":\"https://logging.apache.org/log4j/2.x/\"}],\"slsaProvenances\":[],\"registries\":[\"https://repo.maven.apache.org/maven2/\"],\"relatedProjects\":[{\"projectKey\":{\"id\":\"\"},\"relationProvenance\":\"UNVERIFIED_METADATA\",\"relationType\":\"ISSUE_TRACKER\"}]}}]}";
     when(response.body()).thenReturn(responseBody);
-    VersionKey log4jCore = VersionKey.from("maven", "org.apache.logging.log4j:log4j-core",
-        "2.17.0");
+    VersionKey log4jCore =
+        VersionKey.from("maven", "org.apache.logging.log4j:log4j-core", "2.17.0");
     QueryResult queryResult = client.getQueryResult(log4jCore);
     assertThat(queryResult.results()).hasSize(1);
     Version version = queryResult.results().get(0).version();

--- a/java-shared-dependencies/dependency-analyzer/src/test/java/com/google/cloud/external/DepsDevClientTest.java
+++ b/java-shared-dependencies/dependency-analyzer/src/test/java/com/google/cloud/external/DepsDevClientTest.java
@@ -1,6 +1,7 @@
 package com.google.cloud.external;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -31,6 +32,20 @@ public class DepsDevClientTest {
     response = mock(HttpResponse.class);
     when(httpClient.send(any(HttpRequest.class), any(BodyHandler.class)))
         .thenReturn(response);
+  }
+
+  @Test
+  public void testGetQueryUrlReturnsEncodedUrl() {
+    assertEquals(
+        "https://api.deps.dev/v3/query?versionKey.system=MAVEN&versionKey.name=com.google.errorprone:javac-shaded&versionKey.version=9%2B181-r4173-1",
+        client.getQueryUrl("MAVEN", "com.google.errorprone:javac-shaded", "9+181-r4173-1"));
+  }
+
+  @Test
+  public void testGetDependenciesReturnsEncodedUrl() {
+    assertEquals(
+        "https://api.deps.dev/v3/systems/MAVEN/packages/com.google.errorprone:javac-shaded/versions/9%2B181-r4173-1:dependencies",
+        client.getDependencyUrl("MAVEN", "com.google.errorprone:javac-shaded", "9+181-r4173-1"));
   }
 
   @Test

--- a/java-shared-dependencies/dependency-analyzer/src/test/java/com/google/cloud/model/AnalysisResultTest.java
+++ b/java-shared-dependencies/dependency-analyzer/src/test/java/com/google/cloud/model/AnalysisResultTest.java
@@ -59,4 +59,62 @@ public class AnalysisResultTest {
     ReportResult result = AnalysisResult.of(root, results).generateReport();
     assertEquals(ReportResult.PASS, result);
   }
+
+  @Test
+  public void testPackageInfoReportReturnsCorrectContents() {
+    VersionKey root = VersionKey.from("maven", "com.example:artifact", "1.2.3");
+    List<PackageInfo> results = List.of(
+        new PackageInfo(
+            root,
+            List.of("Apache-2.0"),
+            List.of()
+        ),
+        new PackageInfo(
+            VersionKey.from("maven", "com.example:dependency", "4.5.6"),
+            List.of("Apache-2.0", "MIT"),
+            List.of()
+        ),
+        new PackageInfo(
+            VersionKey.from("maven", "com.example:nested-dependency", "2.3.1"),
+            List.of("Apache-2.0", "MIT"),
+            List.of()
+        )
+    );
+    assertEquals("""
+        Please copy and paste the package information below to your ticket.
+                
+        ## Package information of com.example:artifact:1.2.3
+        Licenses: [Apache-2.0]
+        Vulnerabilities: None.
+        Checked in [com.example:artifact (1.2.3)](https://api.deps.dev/v3/query?versionKey.system=MAVEN&versionKey.name=com.example:artifact&versionKey.version=1.2.3)
+                
+        ## Dependencies:
+        ### Package information of com.example:dependency:4.5.6
+        Licenses: [Apache-2.0, MIT]
+        Vulnerabilities: None.
+        Checked in [com.example:dependency (4.5.6)](https://api.deps.dev/v3/query?versionKey.system=MAVEN&versionKey.name=com.example:dependency&versionKey.version=4.5.6)
+        
+        ### Package information of com.example:nested-dependency:2.3.1
+        Licenses: [Apache-2.0, MIT]
+        Vulnerabilities: None.
+        Checked in [com.example:nested-dependency (2.3.1)](https://api.deps.dev/v3/query?versionKey.system=MAVEN&versionKey.name=com.example:nested-dependency&versionKey.version=2.3.1)
+        
+        
+        """, AnalysisResult.of(root, results).packageInfoReport());
+  }
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/java-shared-dependencies/dependency-analyzer/src/test/java/com/google/cloud/model/AnalysisResultTest.java
+++ b/java-shared-dependencies/dependency-analyzer/src/test/java/com/google/cloud/model/AnalysisResultTest.java
@@ -93,28 +93,13 @@ public class AnalysisResultTest {
         Licenses: [Apache-2.0, MIT]
         Vulnerabilities: None.
         Checked in [com.example:dependency (4.5.6)](https://api.deps.dev/v3/query?versionKey.system=MAVEN&versionKey.name=com.example:dependency&versionKey.version=4.5.6)
-        
+                
         ### Package information of com.example:nested-dependency:2.3.1
         Licenses: [Apache-2.0, MIT]
         Vulnerabilities: None.
         Checked in [com.example:nested-dependency (2.3.1)](https://api.deps.dev/v3/query?versionKey.system=MAVEN&versionKey.name=com.example:nested-dependency&versionKey.version=2.3.1)
-        
-        
+                
+                
         """, AnalysisResult.of(root, results).packageInfoReport());
   }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/java-shared-dependencies/dependency-analyzer/src/test/java/com/google/cloud/model/LicenseTest.java
+++ b/java-shared-dependencies/dependency-analyzer/src/test/java/com/google/cloud/model/LicenseTest.java
@@ -16,4 +16,16 @@ public class LicenseTest {
     String license = "Non-existent-license";
     assertEquals(License.NOT_RECOGNIZED, License.toLicense(license));
   }
+
+  @Test
+  public void testToStringOfACompliantLicense() {
+    String license = "Apache-2.0";
+    assertEquals("Apache-2.0 (Google-compliant)", License.toLicense(license).toString());
+  }
+
+  @Test
+  public void testToStringOfANonCompliantLicense() {
+    String license = "BCL";
+    assertEquals("BCL", License.toLicense(license).toString());
+  }
 }


### PR DESCRIPTION
In this PR:
- Generate package information report for package that has no non-compliant licenses and security vulnerabilities.
- Encode version using `URLEncoder`. The version may contain special characters that needs to be encoded before sending to deps.dev, e.g., [9+181-r4173-1](https://deps.dev/maven/com.google.errorprone%3Ajavac-shaded/9%2B181-r4173-1).

An example of the report:
```
## Package information of io.opentelemetry:opentelemetry-api:1.37.0
Licenses: [Apache-2.0]
Vulnerabilities: None.
Checked in [deps.dev query](https://api.deps.dev/v3/query?versionKey.system=MAVEN&versionKey.name=io.opentelemetry:opentelemetry-api&versionKey.version=1.37.0)

## Dependencies:
## Package information of io.opentelemetry:opentelemetry-context:1.37.0
Licenses: [Apache-2.0]
Vulnerabilities: None.
Checked in [deps.dev query](https://api.deps.dev/v3/query?versionKey.system=MAVEN&versionKey.name=io.opentelemetry:opentelemetry-context&versionKey.version=1.37.0)
```