### PR TITLE
chore: Add `load()`s for the Bazel builtin java rules

### DIFF
--- a/gax-java/gax_java.bzl
+++ b/gax-java/gax_java.bzl
@@ -26,13 +26,15 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+load("@rules_java//java:defs.bzl", "java_test")
+
 def java_tests(name, srcs, runtime_deps, size):
     classNames = []
     for src in srcs:
         # convert .java file path to fully qualified class name
         className = src[(src.index("/com/") + 1):-5].replace("/", ".")
         classNames.append(className)
-        native.java_test(
+        java_test(
             name = className,
             test_class = className,
             runtime_deps = runtime_deps,


### PR DESCRIPTION
`load()` statements are being added to prepare for moving the rules out of Bazel and into `rules_java`

Thank you for opening a Pull Request! For general contributing guidelines, please refer to [contributing guide](https://github.com/googleapis/gapic-generator-java/blob/main/CONTRIBUTING.md)

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/gapic-generator-java/issues/new/choose) before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes https://github.com/googleapis/sdk-platform-java/issues/2683