### PR TITLE
deps: Make opentelemetry-api an optional dependency.

### DIFF
--- a/gax-java/gax/pom.xml
+++ b/gax-java/gax/pom.xml
@@ -60,6 +60,7 @@
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-api</artifactId>
+      <optional>true</optional>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Mark opentelemetry-api as an optional dependency per [internal discussion](https://docs.google.com/document/d/1mhuUD6yZfMJHdOvmHwYM-pYnjMO_t7DwCGKJmSPYE5k/edit?resourcekey=0-fLgYpys-qO89rF_kwOejug&tab=t.0#heading=h.9y4fw0m64snt). Both [java-bigtable](https://github.com/googleapis/java-bigtable/blob/3f37d8da8b51a3fea56d1c462b9500ee2c244973/google-cloud-bigtable/pom.xml#L222) and [java-spanner ](https://github.com/googleapis/java-spanner/blob/6f522dd73123b3de8399902e28d755a5496829c3/google-cloud-spanner/pom.xml#L253)already declare this dependency in their poms, so this is not a breaking change.