### PR TITLE
chore: show difference in integration test

### DIFF
--- a/library_generation/test/integration_tests.py
+++ b/library_generation/test/integration_tests.py
@@ -120,13 +120,7 @@ class IntegrationTest(unittest.TestCase):
                 print_file = lambda f: print(f"   -  {f}")
                 if len(diff_files) > 0:
                     print("  Some files (found in both folders) are differing:")
-                    [print_file(f) for f in diff_files]
-                if len(golden_only) > 0:
-                    print("  There were files found only in the golden dir:")
-                    [print_file(f) for f in golden_only]
-                if len(generated_only) > 0:
-                    print("  Some files were found to have differences:")
-                    for diff_file in generated_only:
+                    for diff_file in diff_files:
                         print(f"Difference in {diff_file}:")
                         with open(
                             f"{golden_dir}/{library_name}/{diff_file}"
@@ -139,6 +133,12 @@ class IntegrationTest(unittest.TestCase):
                                         actual_file.readlines(),
                                     )
                                 ]
+                if len(golden_only) > 0:
+                    print("  There were files found only in the golden dir:")
+                    [print_file(f) for f in golden_only]
+                if len(generated_only) > 0:
+                    print("  There were files found only in the generated dir:")
+                    [print_file(f) for f in generated_only]
 
                 self.assertTrue(len(golden_only) == 0)
                 self.assertTrue(len(generated_only) == 0)


### PR DESCRIPTION
In this PR:
- Show file diff in integration tests.

I manually edited a line in test branch and this is the test result:
```
Difference in google-cloud-alloydb/src/main/java/com/google/cloud/alloydb/v1/AlloyDBAdminClient.java:
--- 

+++ 

@@ -774,7 +774,7 @@

 

   /**

    * Constructs an instance of AlloyDBAdminClient, using the given stub for making calls. This is

-   * for advanced usage - prefer using create(AlloyDBAdminSettings) - manually added.

+   * for advanced usage - prefer using create(AlloyDBAdminSettings).

    */

   public static final AlloyDBAdminClient create(AlloyDBAdminStub stub) {

     return new AlloyDBAdminClient(stub);

Error: Process completed with exit code 1.
```