### PR TITLE
chore: fix confusing step name

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -23,7 +23,7 @@ jobs:
           distribution: temurin
           cache: maven
       - run: mvn -version
-      - name: Unit Tests
+      - name: Install
         run: mvn install --errors --batch-mode --no-transfer-progress -Dcheckstyle.skip -T 1C
       - name: Create issue if previous step fails
         if: ${{ failure() }}


### PR DESCRIPTION
This is step does `mvn install` and is not only unit tests.