### PR TITLE
chore: add a log in config checker

### DIFF
--- a/library_generation/cli/entry_point.py
+++ b/library_generation/cli/entry_point.py
@@ -161,6 +161,7 @@ def validate_generation_config(generation_config_path: str) -> None:
         generation_config_path = "generation_config.yaml"
     try:
         from_yaml(os.path.abspath(generation_config_path))
+        print(f"{generation_config_path} is validated without error.")
     except ValueError as err:
         print(err)
         sys.exit(1)

--- a/library_generation/cli/entry_point.py
+++ b/library_generation/cli/entry_point.py
@@ -161,7 +161,7 @@ def validate_generation_config(generation_config_path: str) -> None:
         generation_config_path = "generation_config.yaml"
     try:
         from_yaml(os.path.abspath(generation_config_path))
-        print(f"{generation_config_path} is validated without error.")
+        print(f"{generation_config_path} is validated without any errors.")
     except ValueError as err:
         print(err)
         sys.exit(1)


### PR DESCRIPTION
In this PR:
- Add a log when the config validation succeeds.

Context: I tested the checker in [here](https://github.com/googleapis/google-cloud-java/actions/runs/8884272073/job/24392990025?pr=10761). It will be good if the checker emit a log when the check passed.