### PR TITLE
chore: skip library generation tests after merging a pull request

### DIFF
--- a/.github/workflows/verify_library_generation.yaml
+++ b/.github/workflows/verify_library_generation.yaml
@@ -3,7 +3,7 @@ on:
     branches:
     - main
   pull_request:
-
+    types: [opened, reopened, edited, synchronize]
   workflow_dispatch:
 name: verify_library_generation
 jobs:

--- a/.github/workflows/verify_library_generation.yaml
+++ b/.github/workflows/verify_library_generation.yaml
@@ -3,6 +3,7 @@ on:
     branches:
     - main
   pull_request:
+    # do not run this workflow when merging the pull request.
     types: [opened, reopened, edited, synchronize]
   workflow_dispatch:
 name: verify_library_generation


### PR DESCRIPTION
In this PR:
- Skip running library generation test after merging a pull request. Related error: 
```
Run set -ex
  set -ex
  git checkout "${base_ref}"
  git checkout "${head_ref}"
  changed_directories="$(git diff --name-only ${base_ref} ${head_ref})"
  if [[ ${changed_directories} =~ "library_generation/" ]]; then
    echo "should_run=true" >> $GITHUB_OUTPUT
  else
    echo "should_run=false" >> $GITHUB_OUTPUT
  fi
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    base_ref: 
    head_ref: 
+ git checkout ''
fatal: empty string is not a valid pathspec. please use . instead if you meant to match all paths
```

Full log: https://github.com/googleapis/sdk-platform-java/actions/runs/8913958564/job/24480528068