### PR TITLE
chore: do not run workflow on push

### DIFF
--- a/.github/workflows/verify_library_generation.yaml
+++ b/.github/workflows/verify_library_generation.yaml
@@ -1,11 +1,6 @@
 on:
-  push:
-    branches:
-    - main
   pull_request:
-    # do not run this workflow when merging the pull request.
-    types: [opened, reopened, edited, synchronize]
-  workflow_dispatch:
+
 name: verify_library_generation
 jobs:
   should-run-library-generation-tests:

--- a/.github/workflows/verify_library_generation.yaml
+++ b/.github/workflows/verify_library_generation.yaml
@@ -16,9 +16,11 @@ jobs:
       shell: bash
       run: |
         set -ex
-        git checkout "${base_ref}" # Checkout a detached head, and then fetch the base ref to populate the detached head.
+        # Checkout a detached head, and then fetch the base ref to populate the detached head.
+        git checkout "${base_ref}"
         git fetch --no-tags --prune origin +${base_ref}:refs/remotes/origin/${base_ref}
-        git checkout "${head_ref}" # Checkout a detached head, and then fetch the head ref to populate the detached head.
+        # Checkout a detached head, and then fetch the head ref to populate the detached head.
+        git checkout "${head_ref}"
         git fetch --no-tags --prune origin +${head_ref}:refs/remotes/origin/${head_ref}
         changed_directories="$(git diff --name-only ${base_ref} ${head_ref})"
         if [[ ${changed_directories} =~ "library_generation/" ]]; then


### PR DESCRIPTION
In this PR:
- Remove `on.push` trigger so that the workflow doesn't run against a specific branch.

Official doc: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore