### PR TITLE
chore: follow up fix to verify_library_generation

### DIFF
--- a/.github/workflows/verify_library_generation.yaml
+++ b/.github/workflows/verify_library_generation.yaml
@@ -26,7 +26,6 @@ jobs:
         echo "head_ref=${{ github.event.pull_request.head.ref }}"
         echo "GITHUB_BASE_REF=${{ github.base_ref }}"
          # Checkout base ref
-        git fetch --no-tags --prune origin +${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.base_ref }}
         git checkout ${{ github.event.pull_request.base.ref }}
         echo "current branch after checking out base_ref is: $(git branch --show-current)"
         # Checkout head ref

--- a/.github/workflows/verify_library_generation.yaml
+++ b/.github/workflows/verify_library_generation.yaml
@@ -1,11 +1,5 @@
 on:
-  push:
-    branches:
-    - main
   pull_request:
-    # do not run this workflow when merging the pull request.
-    types: [opened, reopened, edited, synchronize]
-  workflow_dispatch:
 name: verify_library_generation
 jobs:
   should-run-library-generation-tests:

--- a/.github/workflows/verify_library_generation.yaml
+++ b/.github/workflows/verify_library_generation.yaml
@@ -24,9 +24,8 @@ jobs:
         set -ex
         echo "base_ref=${{ github.event.pull_request.base.ref }}"
         echo "head_ref=${{ github.event.pull_request.head.ref }}"
-        sender_login="${{ github.event.sender.login }}"
-        # Renovate-bot works from a fork, so need to handle their PRs as a special case.
-        if [[ $sender_login != 'renovate-bot' ]]; then
+        # PRs that come from a fork need to be handled differently
+        if [[ ${{ github.event.pull_request.head.repo.full_name  }} != ${{ github.repository }} ]]; then
           git checkout ${base_ref}
           changed_directories="$(git diff --name-only ${base_ref} ${head_ref})"
         else

--- a/.github/workflows/verify_library_generation.yaml
+++ b/.github/workflows/verify_library_generation.yaml
@@ -15,25 +15,31 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
+        ref: ${{ github.head_ref }} # Check out the head branch from the fork
         fetch-depth: 0
     - name: get changed directories in the pull request
       id: get_changed_directories
       shell: bash
       run: |
         set -ex
-        git checkout "${base_ref}" # Checkout a detached head, and then fetch the base ref to populate the detached head.
-        git fetch --no-tags --prune origin +${base_ref}:refs/remotes/origin/${base_ref}
-        git checkout "${head_ref}" # Checkout a detached head, and then fetch the head ref to populate the detached head.
-        git fetch --no-tags --prune origin +${head_ref}:refs/remotes/origin/${head_ref}
-        changed_directories="$(git diff --name-only ${base_ref} ${head_ref})"
+        echo "base_ref=${{ github.event.pull_request.base.ref }}"
+        echo "head_ref=${{ github.event.pull_request.head.ref }}"
+        echo "GITHUB_BASE_REF=${{ github.base_ref }}"
+         # Checkout base ref
+        git fetch --no-tags --prune origin +${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.base_ref }}
+        git checkout ${{ github.event.pull_request.base.ref }}
+        echo "current branch after checking out base_ref is: $(git branch --show-current)"
+        # Checkout head ref
+        git fetch --no-tags --prune origin +${{ github.event.pull_request.head.ref }}:refs/remotes/origin/${{ github.event.pull_request.head.ref }}
+        git checkout ${{ github.event.pull_request.head.ref }}
+        echo "current branch after checking out head_ref is: $(git branch --show-current)"
+        # HEAD is a dynamic reference that points to the currently checked-out commit
+        changed_directories="$(git diff --name-only ${{ github.base_ref }} HEAD)"
         if [[ ${changed_directories} =~ "library_generation/" ]]; then
           echo "should_run=true" >> $GITHUB_OUTPUT
         else
           echo "should_run=false" >> $GITHUB_OUTPUT
         fi
-      env:
-        base_ref: ${{ github.event.pull_request.base.ref }}
-        head_ref: ${{ github.event.pull_request.head.ref }}
   library-generation-integration-tests:
     runs-on: ubuntu-22.04
     needs: should-run-library-generation-tests

--- a/.github/workflows/verify_library_generation.yaml
+++ b/.github/workflows/verify_library_generation.yaml
@@ -1,6 +1,6 @@
 on:
   pull_request:
--
+
 name: verify_library_generation
 jobs:
   should-run-library-generation-tests:

--- a/.github/workflows/verify_library_generation.yaml
+++ b/.github/workflows/verify_library_generation.yaml
@@ -24,16 +24,16 @@ jobs:
         set -ex
         echo "base_ref=${{ github.event.pull_request.base.ref }}"
         echo "head_ref=${{ github.event.pull_request.head.ref }}"
-        echo "GITHUB_BASE_REF=${{ github.base_ref }}"
-         # Checkout base ref
-        git checkout "${base_ref}"
-        echo "current branch after checking out base_ref is: $(git branch --show-current)"
-        # Checkout head ref
-        git fetch --no-tags --prune origin +${{ github.event.pull_request.head.ref }}:refs/remotes/origin/${{ github.event.pull_request.head.ref }}
-        git checkout ${{ github.event.pull_request.head.ref }}
-        echo "current branch after checking out head_ref is: $(git branch --show-current)"
-        # HEAD is a dynamic reference that points to the currently checked-out commit
-        changed_directories="$(git diff --name-only ${{ github.base_ref }} HEAD)"
+        # Renovate-bot works from a fork, so need to handle their PRs as a special case.
+        if [[ ${{ github.event.sender.login }} != 'renovate-bot' ]]; then
+          git checkout "${base_ref}"
+          changed_directories="$(git diff --name-only ${base_ref} ${head_ref})"
+        else
+          git remote add fork https://github.com/renovate-bot/gapic-generator-java.git
+          git fetch fork # create a mapping of the fork
+          git checkout -b "${head_ref}" fork/${head_ref}
+          changed_directories="$(git diff --name-only ${{ github.base_ref }} HEAD)"
+        fi
         if [[ ${changed_directories} =~ "library_generation/" ]]; then
           echo "should_run=true" >> $GITHUB_OUTPUT
         else

--- a/.github/workflows/verify_library_generation.yaml
+++ b/.github/workflows/verify_library_generation.yaml
@@ -27,7 +27,7 @@ jobs:
         sender_login="${{ github.event.sender.login }}"
         # Renovate-bot works from a fork, so need to handle their PRs as a special case.
         if [[ $sender_login != 'renovate-bot' ]]; then
-          git checkout "${base_ref}"
+          git checkout ${base_ref}
           changed_directories="$(git diff --name-only ${base_ref} ${head_ref})"
         else
           git remote add fork https://github.com/renovate-bot/gapic-generator-java.git

--- a/.github/workflows/verify_library_generation.yaml
+++ b/.github/workflows/verify_library_generation.yaml
@@ -24,8 +24,9 @@ jobs:
         set -ex
         echo "base_ref=${{ github.event.pull_request.base.ref }}"
         echo "head_ref=${{ github.event.pull_request.head.ref }}"
+        sender_login="${{ github.event.sender.login }}"
         # Renovate-bot works from a fork, so need to handle their PRs as a special case.
-        if [[ ${{ github.event.sender.login }} != 'renovate-bot' ]]; then
+        if [[ $sender_login != 'renovate-bot' ]]; then
           git checkout "${base_ref}"
           changed_directories="$(git diff --name-only ${base_ref} ${head_ref})"
         else

--- a/.github/workflows/verify_library_generation.yaml
+++ b/.github/workflows/verify_library_generation.yaml
@@ -24,11 +24,11 @@ jobs:
         set -ex
         echo "base_ref=${{ github.event.pull_request.base.ref }}"
         echo "head_ref=${{ github.event.pull_request.head.ref }}"
-        echo "${{ github.event.pull_request.toString() }}"
         echo "Head repo URL: ${{ github.event.pull_request.head.repo.html_url }}"
         # PRs that come from a fork need to be handled differently
         if [[ ${{ github.event.pull_request.head.repo.full_name  }} == ${{ github.repository }} ]]; then
           git checkout ${base_ref}
+          git checkout ${head_ref}
           changed_directories="$(git diff --name-only ${base_ref} ${head_ref})"
         else
           # TODO: update this to be a generic URL if possible

--- a/.github/workflows/verify_library_generation.yaml
+++ b/.github/workflows/verify_library_generation.yaml
@@ -24,7 +24,8 @@ jobs:
         set -ex
         echo "base_ref=${{ github.event.pull_request.base.ref }}"
         echo "head_ref=${{ github.event.pull_request.head.ref }}"
-        echo "Head repo URL: ${{ github.event.pull_request.head.repo.html_url }}
+        echo "${{ github.event.pull_request.toString() }}"
+        echo "Head repo URL: ${{ github.event.pull_request.head.repo.html_url }}"
         # PRs that come from a fork need to be handled differently
         if [[ ${{ github.event.pull_request.head.repo.full_name  }} == ${{ github.repository }} ]]; then
           git checkout ${base_ref}

--- a/.github/workflows/verify_library_generation.yaml
+++ b/.github/workflows/verify_library_generation.yaml
@@ -24,11 +24,13 @@ jobs:
         set -ex
         echo "base_ref=${{ github.event.pull_request.base.ref }}"
         echo "head_ref=${{ github.event.pull_request.head.ref }}"
+        echo "everything: ${{ github.event.pull_request }}"
         # PRs that come from a fork need to be handled differently
         if [[ ${{ github.event.pull_request.head.repo.full_name  }} == ${{ github.repository }} ]]; then
           git checkout ${base_ref}
           changed_directories="$(git diff --name-only ${base_ref} ${head_ref})"
         else
+          # TODO: update this to be a generic URL if possible
           git remote add fork https://github.com/renovate-bot/gapic-generator-java.git
           git fetch fork # create a mapping of the fork
           git checkout -b "${head_ref}" fork/${head_ref}

--- a/.github/workflows/verify_library_generation.yaml
+++ b/.github/workflows/verify_library_generation.yaml
@@ -15,33 +15,34 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        ref: ${{ github.head_ref }} # Check out the head branch from the fork
         fetch-depth: 0
     - name: get changed directories in the pull request
       id: get_changed_directories
       shell: bash
       run: |
         set -ex
-        echo "base_ref=${{ github.event.pull_request.base.ref }}"
-        echo "head_ref=${{ github.event.pull_request.head.ref }}"
-        echo "Head repo URL: ${{ github.event.pull_request.head.repo.html_url }}"
         # PRs that come from a fork need to be handled differently
-        if [[ ${{ github.event.pull_request.head.repo.full_name  }} == ${{ github.repository }} ]]; then
+        if [[ ${head_repo_name} == ${base_repo} ]]; then
           git checkout ${base_ref}
           git checkout ${head_ref}
           changed_directories="$(git diff --name-only ${base_ref} ${head_ref})"
         else
-          # TODO: update this to be a generic URL if possible
-          git remote add fork ${{ github.event.pull_request.head.repo.html_url }}
+          git remote add fork ${head_repo_url}
           git fetch fork # create a mapping of the fork
           git checkout -b "${head_ref}" fork/${head_ref}
-          changed_directories="$(git diff --name-only ${{ github.base_ref }} HEAD)"
+          changed_directories="$(git diff --name-only "fork/${head_ref}" "origin/${base_ref}")"
         fi
         if [[ ${changed_directories} =~ "library_generation/" ]]; then
           echo "should_run=true" >> $GITHUB_OUTPUT
         else
           echo "should_run=false" >> $GITHUB_OUTPUT
         fi
+      env:
+        base_ref: ${{ github.event.pull_request.base.ref }}
+        head_ref: ${{ github.event.pull_request.head.ref }}
+        head_repo_url: ${{ github.event.pull_request.head.repo.html_url }}
+        head_repo_name: ${{ github.event.pull_request.head.repo.full_name  }}
+        base_repo: ${{ github.repository }}
   library-generation-integration-tests:
     runs-on: ubuntu-22.04
     needs: should-run-library-generation-tests

--- a/.github/workflows/verify_library_generation.yaml
+++ b/.github/workflows/verify_library_generation.yaml
@@ -21,8 +21,10 @@ jobs:
       shell: bash
       run: |
         set -ex
-        git checkout "${base_ref}"
-        git checkout "${head_ref}"
+        git checkout "${base_ref}" # Checkout a detached head, and then fetch the base ref to populate the detached head.
+        git fetch --no-tags --prune origin +${base_ref}:refs/remotes/origin/${base_ref}
+        git checkout "${head_ref}" # Checkout a detached head, and then fetch the head ref to populate the detached head.
+        git fetch --no-tags --prune origin +${head_ref}:refs/remotes/origin/${head_ref}
         changed_directories="$(git diff --name-only ${base_ref} ${head_ref})"
         if [[ ${changed_directories} =~ "library_generation/" ]]; then
           echo "should_run=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/verify_library_generation.yaml
+++ b/.github/workflows/verify_library_generation.yaml
@@ -24,14 +24,14 @@ jobs:
         set -ex
         echo "base_ref=${{ github.event.pull_request.base.ref }}"
         echo "head_ref=${{ github.event.pull_request.head.ref }}"
-        echo "everything: ${{ github.event.pull_request }}"
+        echo "Head repo URL: ${{ github.event.pull_request.head.repo.html_url }}
         # PRs that come from a fork need to be handled differently
         if [[ ${{ github.event.pull_request.head.repo.full_name  }} == ${{ github.repository }} ]]; then
           git checkout ${base_ref}
           changed_directories="$(git diff --name-only ${base_ref} ${head_ref})"
         else
           # TODO: update this to be a generic URL if possible
-          git remote add fork https://github.com/renovate-bot/gapic-generator-java.git
+          git remote add fork ${{ github.event.pull_request.head.repo.html_url }}
           git fetch fork # create a mapping of the fork
           git checkout -b "${head_ref}" fork/${head_ref}
           changed_directories="$(git diff --name-only ${{ github.base_ref }} HEAD)"

--- a/.github/workflows/verify_library_generation.yaml
+++ b/.github/workflows/verify_library_generation.yaml
@@ -1,5 +1,6 @@
 on:
   pull_request:
+-
 name: verify_library_generation
 jobs:
   should-run-library-generation-tests:

--- a/.github/workflows/verify_library_generation.yaml
+++ b/.github/workflows/verify_library_generation.yaml
@@ -25,7 +25,7 @@ jobs:
         echo "base_ref=${{ github.event.pull_request.base.ref }}"
         echo "head_ref=${{ github.event.pull_request.head.ref }}"
         # PRs that come from a fork need to be handled differently
-        if [[ ${{ github.event.pull_request.head.repo.full_name  }} != ${{ github.repository }} ]]; then
+        if [[ ${{ github.event.pull_request.head.repo.full_name  }} == ${{ github.repository }} ]]; then
           git checkout ${base_ref}
           changed_directories="$(git diff --name-only ${base_ref} ${head_ref})"
         else

--- a/.github/workflows/verify_library_generation.yaml
+++ b/.github/workflows/verify_library_generation.yaml
@@ -3,7 +3,8 @@ on:
     branches:
     - main
   pull_request:
-
+    # do not run this workflow when merging the pull request.
+    types: [opened, reopened, edited, synchronize]
   workflow_dispatch:
 name: verify_library_generation
 jobs:

--- a/library_generation/test/integration_tests.py
+++ b/library_generation/test/integration_tests.py
@@ -190,8 +190,7 @@ class IntegrationTest(unittest.TestCase):
 
     @classmethod
     def __remove_generated_files(cls):
-        # uncomment this line when the generated files don't owned by root.
-        # shutil.rmtree(f"{output_dir}", ignore_errors=True)
+        shutil.rmtree(f"{output_dir}", ignore_errors=True)
         if os.path.isdir(f"{golden_dir}"):
             shutil.rmtree(f"{golden_dir}")
 


### PR DESCRIPTION
https://github.com/googleapis/sdk-platform-java/pull/2716 didn't quite fix what it should have. Follow up to fix the error:

```
Previous HEAD position was e54601fce Merge 30c7c5b4f9825c14458d6ef31e0b3e3fccbb4207 into 5d4567f883b1e29cd5f299d392c5a809b451aa18
Switched to a new branch 'main'
branch 'main' set up to track 'origin/main'.
+ git fetch --no-tags --prune origin +main:refs/remotes/origin/main
From https://github.com/googleapis/sdk-platform-java
 - [deleted]             (none)     -> origin/main
+ git checkout renovate/markupsafe-2.x
error: pathspec 'renovate/markupsafe-2.x' did not match any file(s) known to git
```