### PR TITLE
fix: only append `.api.grpc` suffix to group id if the artifact id starts with `proto-` or `grpc-`

### DIFF
--- a/library_generation/README.md
+++ b/library_generation/README.md
@@ -300,7 +300,7 @@ The transfer was not a verbatim copy, it rather had modifications:
  * `entrypoint.sh` was modified to have input arguments and slightly modified
    the way the helper scripts are called
  * Other helper scripts were modified to have input arguments.
- * `fix-poms.py` modified the way the monorepo is detected
+ * `fix_poms.py` modified the way the monorepo is detected
 
 All these modifications imply that whenever we want to reflect a change from the
 original owlbot in synthtool we may be better off modifying the affected source

--- a/library_generation/owlbot/bin/entrypoint.sh
+++ b/library_generation/owlbot/bin/entrypoint.sh
@@ -57,7 +57,7 @@ echo "...done"
 
 # write or restore pom.xml files
 echo "Generating missing pom.xml..."
-python3 "${scripts_root}/owlbot/src/fix-poms.py" "${versions_file}" "${is_monorepo}"
+python3 "${scripts_root}/owlbot/src/fix_poms.py" "${versions_file}" "${is_monorepo}"
 echo "...done"
 
 # write or restore clirr-ignored-differences.xml

--- a/library_generation/owlbot/src/fix-poms.py
+++ b/library_generation/owlbot/src/fix-poms.py
@@ -14,15 +14,12 @@
 
 import sys
 import glob
-import inspect
-import itertools
 import json
 from lxml import etree
 import os
 import re
 from typing import List, Mapping
 from poms import module, templates
-from pathlib import Path
 
 
 def load_versions(filename: str, default_group_id: str) -> Mapping[str, module.Module]:
@@ -39,9 +36,10 @@ def load_versions(filename: str, default_group_id: str) -> Mapping[str, module.M
             if len(parts) == 3:
                 artifact_id = parts[0]
                 group_id = (
-                    default_group_id
-                    if artifact_id.startswith("google-")
-                    else __proto_group_id(default_group_id)
+                    __proto_group_id(default_group_id)
+                    if artifact_id.startswith("proto-")
+                    or artifact_id.startswith("grpc-")
+                    else default_group_id
                 )
                 modules[artifact_id] = module.Module(
                     group_id=group_id,

--- a/library_generation/owlbot/src/fix-poms.py
+++ b/library_generation/owlbot/src/fix-poms.py
@@ -39,6 +39,9 @@ def load_versions(filename: str, default_group_id: str) -> Mapping[str, module.M
                     __proto_group_id(default_group_id)
                     if artifact_id.startswith("proto-")
                     or artifact_id.startswith("grpc-")
+                    # artifact id may not start with `google-`, e.g.,
+                    # ad-manager, we don't want to change group id
+                    # in this case.
                     else default_group_id
                 )
                 modules[artifact_id] = module.Module(

--- a/library_generation/owlbot/src/fix-poms.py
+++ b/library_generation/owlbot/src/fix-poms.py
@@ -36,12 +36,16 @@ def load_versions(filename: str, default_group_id: str) -> Mapping[str, module.M
             if len(parts) == 3:
                 artifact_id = parts[0]
                 group_id = (
+                    # For artifact id starts with `proto-` or `grpc-`, we
+                    # need special treatments to append `.api.grpc` suffix
+                    # to its corresponding group id.
+                    # For other artifact id, keep the existing group id.
+                    # Other than the two aforementioned artifact id, do not
+                    # assume artifact id always starts with `google-`. Known
+                    # exception is ad-manager.
                     __proto_group_id(default_group_id)
                     if artifact_id.startswith("proto-")
                     or artifact_id.startswith("grpc-")
-                    # artifact id may not start with `google-`, e.g.,
-                    # ad-manager, we don't want to change group id
-                    # in this case.
                     else default_group_id
                 )
                 modules[artifact_id] = module.Module(

--- a/library_generation/owlbot/src/fix_poms.py
+++ b/library_generation/owlbot/src/fix_poms.py
@@ -19,7 +19,7 @@ from lxml import etree
 import os
 import re
 from typing import List, Mapping
-from poms import module, templates
+from library_generation.owlbot.src.poms import module, templates
 
 
 def load_versions(filename: str, default_group_id: str) -> Mapping[str, module.Module]:

--- a/library_generation/setup.py
+++ b/library_generation/setup.py
@@ -19,6 +19,8 @@ setup(
             "gapic-generator-java-wrapper",
             "requirements.*",
             "owlbot/bin/*.sh",
+            "owlbot/src/*.py",
+            "owlbot/src/poms/*.py",
             "owlbot/templates/clirr/*.j2",
             "owlbot/templates/poms/*.j2",
             "owlbot/templates/java_library/**/*",

--- a/library_generation/test/compare_poms.py
+++ b/library_generation/test/compare_poms.py
@@ -102,6 +102,16 @@ def compare_xml(expected, actual, print_trees):
     return False
 
 
+def compare_pom_in_subdir(base_dir: str, subdir: str) -> bool:
+    golden = os.path.join(base_dir, subdir, "pom-golden.xml")
+    pom = os.path.join(base_dir, subdir, "pom.xml")
+    return compare_xml(
+        golden,
+        pom,
+        False,
+    )
+
+
 if __name__ == "__main__":
     if len(sys.argv) != 4:
         eprint(

--- a/library_generation/test/owlbot/fix_poms_unit_tests.py
+++ b/library_generation/test/owlbot/fix_poms_unit_tests.py
@@ -1,0 +1,59 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import shutil
+import unittest
+from library_generation.owlbot.src.fix_poms import main
+from library_generation.test.compare_poms import compare_xml
+from library_generation.test.test_utils import FileComparator
+
+script_dir = os.path.dirname(os.path.realpath(__file__))
+resources_dir = os.path.join(script_dir, "..", "resources", "test-owlbot")
+file_comparator = FileComparator()
+
+
+class FixPomsTest(unittest.TestCase):
+    def test_fix_poms_update_poms_for_ad_manager_correctly(self):
+        ad_manager_resource = os.path.join(resources_dir, "java-admanager")
+        versions_file = os.path.join(ad_manager_resource, "versions.txt")
+        os.chdir(ad_manager_resource)
+        sub_dirs = ["ad-manager", "ad-manager-bom", "proto-ad-manager-v1", "."]
+        for sub_dir in sub_dirs:
+            self.__copy__golden(ad_manager_resource, sub_dir)
+        main(versions_file, "true")
+        for sub_dir in sub_dirs:
+            self.assertFalse(self.__compare_pom_in_subdir(ad_manager_resource, sub_dir))
+        for sub_dir in sub_dirs:
+            self.__remove_file_in_subdir(ad_manager_resource, sub_dir)
+
+    @classmethod
+    def __copy__golden(cls, base_dir: str, subdir: str):
+        golden = os.path.join(base_dir, subdir, "pom-golden.xml")
+        pom = os.path.join(base_dir, subdir, "pom.xml")
+        shutil.copyfile(golden, pom)
+
+    @classmethod
+    def __compare_pom_in_subdir(cls, base_dir: str, subdir: str):
+        golden = os.path.join(base_dir, subdir, "pom-golden.xml")
+        pom = os.path.join(base_dir, subdir, "pom.xml")
+        return compare_xml(
+            golden,
+            pom,
+            False,
+        )
+
+    @classmethod
+    def __remove_file_in_subdir(cls, base_dir: str, subdir: str):
+        pom = os.path.join(base_dir, subdir, "pom.xml")
+        os.unlink(pom)

--- a/library_generation/test/owlbot/fix_poms_unit_tests.py
+++ b/library_generation/test/owlbot/fix_poms_unit_tests.py
@@ -15,16 +15,14 @@ import os
 import shutil
 import unittest
 from library_generation.owlbot.src.fix_poms import main
-from library_generation.test.compare_poms import compare_xml
-from library_generation.test.test_utils import FileComparator
+from library_generation.test.compare_poms import compare_pom_in_subdir
 
 script_dir = os.path.dirname(os.path.realpath(__file__))
 resources_dir = os.path.join(script_dir, "..", "resources", "test-owlbot")
-file_comparator = FileComparator()
 
 
 class FixPomsTest(unittest.TestCase):
-    def test_fix_poms_update_poms_for_ad_manager_correctly(self):
+    def test_update_poms_group_id_does_not_start_with_google_correctly(self):
         ad_manager_resource = os.path.join(resources_dir, "java-admanager")
         versions_file = os.path.join(ad_manager_resource, "versions.txt")
         os.chdir(ad_manager_resource)
@@ -33,7 +31,7 @@ class FixPomsTest(unittest.TestCase):
             self.__copy__golden(ad_manager_resource, sub_dir)
         main(versions_file, "true")
         for sub_dir in sub_dirs:
-            self.assertFalse(self.__compare_pom_in_subdir(ad_manager_resource, sub_dir))
+            self.assertFalse(compare_pom_in_subdir(ad_manager_resource, sub_dir))
         for sub_dir in sub_dirs:
             self.__remove_file_in_subdir(ad_manager_resource, sub_dir)
 
@@ -42,16 +40,6 @@ class FixPomsTest(unittest.TestCase):
         golden = os.path.join(base_dir, subdir, "pom-golden.xml")
         pom = os.path.join(base_dir, subdir, "pom.xml")
         shutil.copyfile(golden, pom)
-
-    @classmethod
-    def __compare_pom_in_subdir(cls, base_dir: str, subdir: str):
-        golden = os.path.join(base_dir, subdir, "pom-golden.xml")
-        pom = os.path.join(base_dir, subdir, "pom.xml")
-        return compare_xml(
-            golden,
-            pom,
-            False,
-        )
 
     @classmethod
     def __remove_file_in_subdir(cls, base_dir: str, subdir: str):

--- a/library_generation/test/resources/test-owlbot/java-admanager/.repo-metadata.json
+++ b/library_generation/test/resources/test-owlbot/java-admanager/.repo-metadata.json
@@ -1,0 +1,16 @@
+{
+  "api_shortname": "admanager",
+  "name_pretty": "Google Ad Manager API",
+  "product_documentation": "https://developers.google.com/ad-manager/api/beta",
+  "api_description": "The Ad Manager API enables an app to integrate with Google Ad Manager. You can read Ad Manager data and run reports using the API.",
+  "client_documentation": "https://cloud.google.com/java/docs/reference/ad-manager/latest/overview",
+  "release_level": "preview",
+  "transport": "http",
+  "language": "java",
+  "repo": "googleapis/google-cloud-java",
+  "repo_short": "java-admanager",
+  "distribution_name": "com.google.api-ads:ad-manager",
+  "api_id": "admanager.googleapis.com",
+  "library_type": "GAPIC_AUTO",
+  "requires_billing": true
+}

--- a/library_generation/test/resources/test-owlbot/java-admanager/ad-manager-bom/pom-golden.xml
+++ b/library_generation/test/resources/test-owlbot/java-admanager/ad-manager-bom/pom-golden.xml
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.google.api-ads</groupId>
+  <artifactId>ad-manager-bom</artifactId>
+  <version>0.2.0-SNAPSHOT</version><!-- {x-version-update:ad-manager:current} -->
+  <packaging>pom</packaging>
+  <parent>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>google-cloud-pom-parent</artifactId>
+    <version>1.37.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-java:current} -->
+    <relativePath>../../google-cloud-pom-parent/pom.xml</relativePath>
+  </parent>
+
+  <name>Google Google Ad Manager API BOM</name>
+  <description>
+    BOM for Google Ad Manager API
+  </description>
+
+  <properties>
+    <maven.antrun.skip>true</maven.antrun.skip>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.api-ads</groupId>
+        <artifactId>ad-manager</artifactId>
+        <version>0.2.0-SNAPSHOT</version><!-- {x-version-update:ad-manager:current} -->
+      </dependency>
+      <dependency>
+        <groupId>com.google.api-ads.api.grpc</groupId>
+        <artifactId>proto-ad-manager-v1</artifactId>
+        <version>0.2.0-SNAPSHOT</version><!-- {x-version-update:proto-ad-manager-v1:current} -->
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/library_generation/test/resources/test-owlbot/java-admanager/ad-manager/pom-golden.xml
+++ b/library_generation/test/resources/test-owlbot/java-admanager/ad-manager/pom-golden.xml
@@ -1,0 +1,108 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.google.api-ads</groupId>
+  <artifactId>ad-manager</artifactId>
+  <version>0.2.0-SNAPSHOT</version><!-- {x-version-update:ad-manager:current} -->
+  <packaging>jar</packaging>
+  <name>Google Google Ad Manager API</name>
+  <description>Google Ad Manager API The Ad Manager API enables an app to integrate with Google Ad Manager. You can read Ad Manager data and run reports using the API.</description>
+  <parent>
+    <groupId>com.google.api-ads</groupId>
+    <artifactId>ad-manager-parent</artifactId>
+    <version>0.2.0-SNAPSHOT</version><!-- {x-version-update:ad-manager:current} -->
+  </parent>
+  <properties>
+    <site.installationModule>ad-manager</site.installationModule>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-stub</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-protobuf</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>api-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>proto-google-common-protos</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.api-ads.api.grpc</groupId>
+      <artifactId>proto-ad-manager-v1</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>gax</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>gax-grpc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>gax-httpjson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>grpc-google-common-protos</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>proto-google-iam-v1</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>grpc-google-iam-v1</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.threeten</groupId>
+      <artifactId>threetenbp</artifactId>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Need testing utility classes for generated gRPC clients tests -->
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>gax</artifactId>
+      <classifier>testlib</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>gax-grpc</artifactId>
+      <classifier>testlib</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>gax-httpjson</artifactId>
+      <classifier>testlib</classifier>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/library_generation/test/resources/test-owlbot/java-admanager/pom-golden.xml
+++ b/library_generation/test/resources/test-owlbot/java-admanager/pom-golden.xml
@@ -1,0 +1,49 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.google.api-ads</groupId>
+  <artifactId>ad-manager-parent</artifactId>
+  <packaging>pom</packaging>
+  <version>0.2.0-SNAPSHOT</version><!-- {x-version-update:ad-manager:current} -->
+  <name>Google Google Ad Manager API Parent</name>
+  <description>
+    Java idiomatic client for Google Cloud Platform services.
+  </description>
+
+  <parent>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>google-cloud-jar-parent</artifactId>
+    <version>1.37.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-java:current} -->
+    <relativePath>../google-cloud-jar-parent/pom.xml</relativePath>
+  </parent>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <github.global.server>github</github.global.server>
+    <site.installationModule>ad-manager-parent</site.installationModule>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.api-ads</groupId>
+        <artifactId>ad-manager</artifactId>
+        <version>0.2.0-SNAPSHOT</version><!-- {x-version-update:ad-manager:current} -->
+      </dependency>
+      <dependency>
+        <groupId>com.google.api-ads.api.grpc</groupId>
+        <artifactId>proto-ad-manager-v1</artifactId>
+        <version>0.2.0-SNAPSHOT</version><!-- {x-version-update:proto-ad-manager-v1:current} -->
+      </dependency>
+
+    </dependencies>
+  </dependencyManagement>
+
+  <modules>
+    <module>ad-manager</module>
+    <module>proto-ad-manager-v1</module>
+    <module>ad-manager-bom</module>
+  </modules>
+
+</project>

--- a/library_generation/test/resources/test-owlbot/java-admanager/proto-ad-manager-v1/pom-golden.xml
+++ b/library_generation/test/resources/test-owlbot/java-admanager/proto-ad-manager-v1/pom-golden.xml
@@ -1,0 +1,37 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.google.api-ads.api.grpc</groupId>
+  <artifactId>proto-ad-manager-v1</artifactId>
+  <version>0.2.0-SNAPSHOT</version><!-- {x-version-update:proto-ad-manager-v1:current} -->
+  <name>proto-ad-manager-v1</name>
+  <description>Proto library for ad-manager</description>
+  <parent>
+    <groupId>com.google.api-ads</groupId>
+    <artifactId>ad-manager-parent</artifactId>
+    <version>0.2.0-SNAPSHOT</version><!-- {x-version-update:ad-manager:current} -->
+  </parent>
+  <dependencies>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>proto-google-common-protos</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>proto-google-iam-v1</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>api-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/library_generation/test/resources/test-owlbot/java-admanager/versions.txt
+++ b/library_generation/test/resources/test-owlbot/java-admanager/versions.txt
@@ -1,0 +1,6 @@
+# Format:
+# module:released-version:current-version
+
+google-cloud-java:1.36.0:1.37.0-SNAPSHOT
+ad-manager:0.1.0:0.2.0-SNAPSHOT
+proto-ad-manager-v1:0.1.0:0.2.0-SNAPSHOT


### PR DESCRIPTION
In this PR:
- Only append `.api.grpc` suffix to group id if the corresponding artifact id starts with `proto-` or `grpc-`.

We need to support `ad-manager`, which is the first artifact id doesn't start with `proto-`, `grpc-` and `google-`.