### PR TITLE
fix: opentelemetry-bom to be in third-party-dependencies BOM

### DIFF
--- a/gapic-generator-java-bom/pom.xml
+++ b/gapic-generator-java-bom/pom.xml
@@ -70,13 +70,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <dependency>
-        <groupId>io.opentelemetry</groupId>
-        <artifactId>opentelemetry-bom</artifactId>
-        <version>${opentelemetry.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
 
       <!-- Libraries published from this repositories -->
       <dependency>

--- a/java-shared-dependencies/third-party-dependencies/pom.xml
+++ b/java-shared-dependencies/third-party-dependencies/pom.xml
@@ -125,9 +125,16 @@
         <version>${codec.version}</version>
       </dependency>
       <dependency>
-       <groupId>io.opentelemetry.instrumentation</groupId>
-       <artifactId>opentelemetry-grpc-1.6</artifactId>
-       <version>${opentelemetry-grpc-instrumentation.version}</version>
+        <groupId>io.opentelemetry</groupId>
+        <artifactId>opentelemetry-bom</artifactId>
+        <version>${opentelemetry.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.opentelemetry.instrumentation</groupId>
+        <artifactId>opentelemetry-grpc-1.6</artifactId>
+        <version>${opentelemetry-grpc-instrumentation.version}</version>
       </dependency>
 
       <!-- TODO: replace with opencensus-bom when available -->


### PR DESCRIPTION
Importing opentelemetry-bom in gapic-generator-java-bom (and thus Google Cloud Libraries BOM) wrongly implies that we (Google) publish the OpenTelemetry artifacts.

https://jlbp.dev/JLBP-15 states:

>  Your project's BOM should not include any of your dependencies on other libraries.

In this change, the opentelemetry-bom is declared in the third-party-dependencies BOM and thus will be excluded in the Google Cloud Libraries BOM, which does not import the third-party-dependencies BOM.

Related to b/338624813