### PR TITLE
test: add showcase test for api-version

### DIFF
--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/ApiClientHeaderProvider.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/ApiClientHeaderProvider.java
@@ -42,7 +42,7 @@ public class ApiClientHeaderProvider implements HeaderProvider, Serializable {
   private static final long serialVersionUID = -8876627296793342119L;
   static final String QUOTA_PROJECT_ID_HEADER_KEY = "x-goog-user-project";
 
-  static final String API_VERSION_HEADER_KEY = "x-goog-api-version";
+  public static final String API_VERSION_HEADER_KEY = "x-goog-api-version";
 
   private final Map<String, String> headers;
 

--- a/showcase/gapic-showcase/pom.xml
+++ b/showcase/gapic-showcase/pom.xml
@@ -19,7 +19,7 @@
   </parent>
 
   <properties>
-    <gapic-showcase.version>0.33.0</gapic-showcase.version>
+    <gapic-showcase.version>0.35.0</gapic-showcase.version>
   </properties>
 
   <build>

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITApiVersionHeaders.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITApiVersionHeaders.java
@@ -30,6 +30,7 @@ import com.google.showcase.v1beta1.stub.EchoStubSettings;
 import io.grpc.*;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -50,6 +51,7 @@ public class ITApiVersionHeaders {
   private static final String EXPECTED_EXCEPTION_MESSAGE =
       "Header provider can't override the header: "
           + ApiClientHeaderProvider.API_VERSION_HEADER_KEY;
+  private static final int DEFAULT_AWAIT_TERMINATION_SEC = 10;
 
   // Implement a client interceptor to retrieve the trailing metadata from response.
   private static class GrpcCapturingClientInterceptor implements ClientInterceptor {
@@ -182,11 +184,16 @@ public class ITApiVersionHeaders {
   }
 
   @After
-  public void destroyClient() {
+  public void destroyClient() throws InterruptedException {
     grpcClient.close();
     httpJsonClient.close();
     grpcComplianceClient.close();
     httpJsonComplianceClient.close();
+
+    grpcClient.awaitTermination(DEFAULT_AWAIT_TERMINATION_SEC, TimeUnit.SECONDS);
+    httpJsonClient.awaitTermination(DEFAULT_AWAIT_TERMINATION_SEC, TimeUnit.SECONDS);
+    grpcComplianceClient.awaitTermination(DEFAULT_AWAIT_TERMINATION_SEC, TimeUnit.SECONDS);
+    httpJsonComplianceClient.awaitTermination(DEFAULT_AWAIT_TERMINATION_SEC, TimeUnit.SECONDS);
   }
 
   @Test

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITApiVersionHeaders.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITApiVersionHeaders.java
@@ -27,13 +27,16 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+// TODO: add testing on error responses once feat is implemented in showcase.
+//  https://github.com/googleapis/gapic-showcase/pull/1456
 public class ITApiVersionHeaders {
-  private static final String SPLIT_TOKEN = "&";
   private static final String API_VERSION_HEADER_STRING = "x-goog-api-version";
   private static final String HTTP_RESPONSE_HEADER_STRING =
       "x-showcase-request-" + API_VERSION_HEADER_STRING;
   private static final Metadata.Key<String> API_VERSION_HEADER_KEY =
       Metadata.Key.of(API_VERSION_HEADER_STRING, Metadata.ASCII_STRING_MARSHALLER);
+
+  private static final String EXPECTED_ECHO_API_VERSION = "v1_20240408";
 
   // Implement a client interceptor to retrieve the trailing metadata from response.
   private static class GrpcCapturingClientInterceptor implements ClientInterceptor {
@@ -177,7 +180,7 @@ public class ITApiVersionHeaders {
   public void testGrpc_matchesApiVersion() {
     grpcClient.echo(EchoRequest.newBuilder().build());
     String headerValue = grpcInterceptor.metadata.get(API_VERSION_HEADER_KEY);
-    assertThat(headerValue).isEqualTo("v1_20240408");
+    assertThat(headerValue).isEqualTo(EXPECTED_ECHO_API_VERSION);
   }
 
   @Test
@@ -186,7 +189,7 @@ public class ITApiVersionHeaders {
     ArrayList headerValues =
         (ArrayList) httpJsonInterceptor.metadata.getHeaders().get(HTTP_RESPONSE_HEADER_STRING);
     String headerValue = (String) headerValues.get(0);
-    assertThat(headerValue).isEqualTo("v1_20240408");
+    assertThat(headerValue).isEqualTo(EXPECTED_ECHO_API_VERSION);
   }
 
   @Test

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITApiVersionHeaders.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITApiVersionHeaders.java
@@ -18,6 +18,7 @@ package com.google.showcase.v1beta1.it;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.api.gax.httpjson.*;
+import com.google.api.gax.rpc.ApiClientHeaderProvider;
 import com.google.common.collect.ImmutableList;
 import com.google.showcase.v1beta1.*;
 import com.google.showcase.v1beta1.it.util.TestClientInitializer;
@@ -30,11 +31,11 @@ import org.junit.Test;
 // TODO: add testing on error responses once feat is implemented in showcase.
 //  https://github.com/googleapis/gapic-showcase/pull/1456
 public class ITApiVersionHeaders {
-  private static final String API_VERSION_HEADER_STRING = "x-goog-api-version";
   private static final String HTTP_RESPONSE_HEADER_STRING =
-      "x-showcase-request-" + API_VERSION_HEADER_STRING;
+      "x-showcase-request-" + ApiClientHeaderProvider.API_VERSION_HEADER_KEY;
   private static final Metadata.Key<String> API_VERSION_HEADER_KEY =
-      Metadata.Key.of(API_VERSION_HEADER_STRING, Metadata.ASCII_STRING_MARSHALLER);
+      Metadata.Key.of(
+          ApiClientHeaderProvider.API_VERSION_HEADER_KEY, Metadata.ASCII_STRING_MARSHALLER);
 
   private static final String EXPECTED_ECHO_API_VERSION = "v1_20240408";
 

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITApiVersionHeaders.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITApiVersionHeaders.java
@@ -16,6 +16,7 @@
 package com.google.showcase.v1beta1.it;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import com.google.api.gax.httpjson.*;
 import com.google.api.gax.rpc.ApiClientHeaderProvider;
@@ -46,6 +47,9 @@ public class ITApiVersionHeaders {
 
   private static final String EXPECTED_ECHO_API_VERSION = "v1_20240408";
   private static final String CUSTOM_API_VERSION = "user-supplied-version";
+  private static final String EXPECTED_EXCEPTION_MESSAGE =
+      "Header provider can't override the header: "
+          + ApiClientHeaderProvider.API_VERSION_HEADER_KEY;
 
   // Implement a client interceptor to retrieve the trailing metadata from response.
   private static class GrpcCapturingClientInterceptor implements ClientInterceptor {
@@ -218,7 +222,7 @@ public class ITApiVersionHeaders {
         .isNotIn(httpJsonComplianceInterceptor.metadata.getHeaders().keySet());
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testGrpcEcho_userApiVersionThrowsException() throws IOException {
     StubSettings stubSettings =
         grpcClient
@@ -230,13 +234,14 @@ public class ITApiVersionHeaders {
                     ApiClientHeaderProvider.API_VERSION_HEADER_KEY, CUSTOM_API_VERSION))
             .build();
 
-    try (EchoClient echo =
-        EchoClient.create(EchoSettings.create((EchoStubSettings) stubSettings))) {
-      assertThat(true).isFalse();
-    }
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> EchoClient.create(EchoSettings.create((EchoStubSettings) stubSettings)));
+    assertThat(exception.getMessage()).isEqualTo(EXPECTED_EXCEPTION_MESSAGE);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testHttpJsonEcho_userApiVersionThrowsException() throws IOException {
     StubSettings stubSettings =
         httpJsonClient
@@ -248,10 +253,11 @@ public class ITApiVersionHeaders {
                     ApiClientHeaderProvider.API_VERSION_HEADER_KEY, CUSTOM_API_VERSION))
             .build();
 
-    try (EchoClient echo =
-        EchoClient.create(EchoSettings.create((EchoStubSettings) stubSettings))) {
-      assertThat(true).isFalse();
-    }
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> EchoClient.create(EchoSettings.create((EchoStubSettings) stubSettings)));
+    assertThat(exception.getMessage()).isEqualTo(EXPECTED_EXCEPTION_MESSAGE);
   }
 
   @Test

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITApiVersionHeaders.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITApiVersionHeaders.java
@@ -30,6 +30,8 @@ import org.junit.Test;
 
 // TODO: add testing on error responses once feat is implemented in showcase.
 //  https://github.com/googleapis/gapic-showcase/pull/1456
+// TODO: watch for showcase gRPC trailer changes suggested in
+// https://github.com/googleapis/gapic-showcase/pull/1509#issuecomment-2089147103
 public class ITApiVersionHeaders {
   private static final String HTTP_RESPONSE_HEADER_STRING =
       "x-showcase-request-" + ApiClientHeaderProvider.API_VERSION_HEADER_KEY;

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITApiVersionHeaders.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITApiVersionHeaders.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.showcase.v1beta1.it;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.api.gax.httpjson.*;
+import com.google.common.collect.ImmutableList;
+import com.google.showcase.v1beta1.*;
+import com.google.showcase.v1beta1.it.util.TestClientInitializer;
+import io.grpc.*;
+import java.util.ArrayList;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ITApiVersionHeaders {
+  private static final String SPLIT_TOKEN = "&";
+  private static final String API_VERSION_HEADER_STRING = "x-goog-api-version";
+  private static final String HTTP_RESPONSE_HEADER_STRING =
+      "x-showcase-request-" + API_VERSION_HEADER_STRING;
+  private static final Metadata.Key<String> API_VERSION_HEADER_KEY =
+      Metadata.Key.of(API_VERSION_HEADER_STRING, Metadata.ASCII_STRING_MARSHALLER);
+
+  // Implement a client interceptor to retrieve the trailing metadata from response.
+  private static class GrpcCapturingClientInterceptor implements ClientInterceptor {
+    private Metadata metadata;
+
+    @Override
+    public <RequestT, ResponseT> ClientCall<RequestT, ResponseT> interceptCall(
+        MethodDescriptor<RequestT, ResponseT> method, final CallOptions callOptions, Channel next) {
+      ClientCall<RequestT, ResponseT> call = next.newCall(method, callOptions);
+      return new ForwardingClientCall.SimpleForwardingClientCall<RequestT, ResponseT>(call) {
+        @Override
+        public void start(Listener<ResponseT> responseListener, Metadata headers) {
+          Listener<ResponseT> wrappedListener =
+              new SimpleForwardingClientCallListener<ResponseT>(responseListener) {
+                @Override
+                public void onClose(Status status, Metadata trailers) {
+                  if (status.isOk()) {
+                    metadata = trailers;
+                  }
+                  super.onClose(status, trailers);
+                }
+              };
+
+          super.start(wrappedListener, headers);
+        }
+      };
+    }
+  }
+
+  private static class SimpleForwardingClientCallListener<RespT>
+      extends ClientCall.Listener<RespT> {
+    private final ClientCall.Listener<RespT> delegate;
+
+    SimpleForwardingClientCallListener(ClientCall.Listener<RespT> delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public void onHeaders(Metadata headers) {
+      delegate.onHeaders(headers);
+    }
+
+    @Override
+    public void onMessage(RespT message) {
+      delegate.onMessage(message);
+    }
+
+    @Override
+    public void onClose(Status status, Metadata trailers) {
+      delegate.onClose(status, trailers);
+    }
+
+    @Override
+    public void onReady() {
+      delegate.onReady();
+    }
+  }
+  // Implement a client interceptor to retrieve the response headers
+  private static class HttpJsonCapturingClientInterceptor implements HttpJsonClientInterceptor {
+    private HttpJsonMetadata metadata;
+
+    @Override
+    public <RequestT, ResponseT> HttpJsonClientCall<RequestT, ResponseT> interceptCall(
+        ApiMethodDescriptor<RequestT, ResponseT> method,
+        HttpJsonCallOptions callOptions,
+        HttpJsonChannel next) {
+      HttpJsonClientCall<RequestT, ResponseT> call = next.newCall(method, callOptions);
+      return new ForwardingHttpJsonClientCall.SimpleForwardingHttpJsonClientCall<
+          RequestT, ResponseT>(call) {
+        @Override
+        public void start(Listener<ResponseT> responseListener, HttpJsonMetadata requestHeaders) {
+          Listener<ResponseT> forwardingResponseListener =
+              new ForwardingHttpJsonClientCallListener.SimpleForwardingHttpJsonClientCallListener<
+                  ResponseT>(responseListener) {
+                @Override
+                public void onHeaders(HttpJsonMetadata responseHeaders) {
+                  metadata = responseHeaders;
+                  super.onHeaders(responseHeaders);
+                }
+
+                @Override
+                public void onMessage(ResponseT message) {
+                  super.onMessage(message);
+                }
+
+                @Override
+                public void onClose(int statusCode, HttpJsonMetadata trailers) {
+                  super.onClose(statusCode, trailers);
+                }
+              };
+
+          super.start(forwardingResponseListener, requestHeaders);
+        }
+      };
+    }
+  }
+
+  private HttpJsonCapturingClientInterceptor httpJsonInterceptor;
+  private GrpcCapturingClientInterceptor grpcInterceptor;
+  private HttpJsonCapturingClientInterceptor httpJsonComplianceInterceptor;
+  private GrpcCapturingClientInterceptor grpcComplianceInterceptor;
+  private EchoClient grpcClient;
+  private EchoClient httpJsonClient;
+  private ComplianceClient grpcComplianceClient;
+  private ComplianceClient httpJsonComplianceClient;
+
+  @Before
+  public void createClients() throws Exception {
+    // Create gRPC Interceptor and Client
+    grpcInterceptor = new GrpcCapturingClientInterceptor();
+    grpcClient = TestClientInitializer.createGrpcEchoClient(ImmutableList.of(grpcInterceptor));
+
+    // Create HttpJson Interceptor and Client
+    httpJsonInterceptor = new HttpJsonCapturingClientInterceptor();
+    httpJsonClient =
+        TestClientInitializer.createHttpJsonEchoClient(ImmutableList.of(httpJsonInterceptor));
+
+    // Create gRPC ComplianceClient and Interceptor
+    // Creating a compliance client to test case where api version is not set
+    grpcComplianceInterceptor = new GrpcCapturingClientInterceptor();
+    grpcComplianceClient =
+        TestClientInitializer.createGrpcComplianceClient(
+            ImmutableList.of(grpcComplianceInterceptor));
+
+    // Create HttpJson ComplianceClient and Interceptor
+    httpJsonComplianceInterceptor = new HttpJsonCapturingClientInterceptor();
+    httpJsonComplianceClient =
+        TestClientInitializer.createHttpJsonComplianceClient(
+            ImmutableList.of(httpJsonComplianceInterceptor));
+  }
+
+  @After
+  public void destroyClient() {
+    grpcClient.close();
+    httpJsonClient.close();
+    grpcComplianceClient.close();
+    httpJsonComplianceClient.close();
+  }
+
+  @Test
+  public void testGrpc_matchesApiVersion() {
+    grpcClient.echo(EchoRequest.newBuilder().build());
+    String headerValue = grpcInterceptor.metadata.get(API_VERSION_HEADER_KEY);
+    assertThat(headerValue).isEqualTo("v1_20240408");
+  }
+
+  @Test
+  public void testHttpJson_matchesHeaderName() {
+    httpJsonClient.echo(EchoRequest.newBuilder().build());
+    ArrayList headerValues =
+        (ArrayList) httpJsonInterceptor.metadata.getHeaders().get(HTTP_RESPONSE_HEADER_STRING);
+    String headerValue = (String) headerValues.get(0);
+    assertThat(headerValue).isEqualTo("v1_20240408");
+  }
+
+  @Test
+  public void testGrpc_noApiVersion() {
+    RepeatRequest request =
+            RepeatRequest.newBuilder().setInfo(ComplianceData.newBuilder().setFString("test")).build();
+    grpcComplianceClient.repeatDataSimplePath(request);
+    assertThat(API_VERSION_HEADER_KEY).isNotIn(grpcComplianceInterceptor.metadata.keys());
+  }
+
+  @Test
+  public void testHttpJson_noApiVersion() {
+    RepeatRequest request =
+            RepeatRequest.newBuilder().setInfo(ComplianceData.newBuilder().setFString("test")).build();
+    httpJsonComplianceClient.repeatDataSimplePath(request);
+    assertThat(API_VERSION_HEADER_KEY)
+            .isNotIn(httpJsonComplianceInterceptor.metadata.getHeaders().keySet());
+  }
+
+}

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITApiVersionHeaders.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITApiVersionHeaders.java
@@ -192,7 +192,7 @@ public class ITApiVersionHeaders {
   @Test
   public void testGrpc_noApiVersion() {
     RepeatRequest request =
-            RepeatRequest.newBuilder().setInfo(ComplianceData.newBuilder().setFString("test")).build();
+        RepeatRequest.newBuilder().setInfo(ComplianceData.newBuilder().setFString("test")).build();
     grpcComplianceClient.repeatDataSimplePath(request);
     assertThat(API_VERSION_HEADER_KEY).isNotIn(grpcComplianceInterceptor.metadata.keys());
   }
@@ -200,10 +200,9 @@ public class ITApiVersionHeaders {
   @Test
   public void testHttpJson_noApiVersion() {
     RepeatRequest request =
-            RepeatRequest.newBuilder().setInfo(ComplianceData.newBuilder().setFString("test")).build();
+        RepeatRequest.newBuilder().setInfo(ComplianceData.newBuilder().setFString("test")).build();
     httpJsonComplianceClient.repeatDataSimplePath(request);
     assertThat(API_VERSION_HEADER_KEY)
-            .isNotIn(httpJsonComplianceInterceptor.metadata.getHeaders().keySet());
+        .isNotIn(httpJsonComplianceInterceptor.metadata.getHeaders().keySet());
   }
-
 }


### PR DESCRIPTION
This pr updates gapic-showcase version to 0.35.0 and adds showcase tests to verify behavior of api version headers being emitted (changes in #2630 and #2671).

