### PR TITLE
ci: add timestamps to graalvm's mvn setup commands

### DIFF
--- a/.cloudbuild/graalvm/cloudbuild-test-a.yaml
+++ b/.cloudbuild/graalvm/cloudbuild-test-a.yaml
@@ -18,9 +18,14 @@ substitutions:
   _JAVA_SHARED_CONFIG_VERSION: '1.7.7'
 
 steps:
-  # GraalVM A build
   - name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:${_SHARED_DEPENDENCIES_VERSION}", "--file", "graalvm_a.Dockerfile", "--build-arg", "JAVA_SHARED_CONFIG_VERSION=$_JAVA_SHARED_CONFIG_VERSION", "."]
+    args: [
+      "build",
+      "-t", "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:${_SHARED_DEPENDENCIES_VERSION}",
+      "--file", "graalvm_a.Dockerfile",
+      "--build-arg", "JAVA_SHARED_CONFIG_VERSION=$_JAVA_SHARED_CONFIG_VERSION",
+      "."
+    ]
     dir: .cloudbuild/graalvm
     id: graalvm-a-build
     waitFor: ["-"]

--- a/.cloudbuild/graalvm/cloudbuild-test-b.yaml
+++ b/.cloudbuild/graalvm/cloudbuild-test-b.yaml
@@ -18,9 +18,14 @@ substitutions:
   _JAVA_SHARED_CONFIG_VERSION: '1.7.7'
 
 steps:
-  # GraalVM A build
   - name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:${_SHARED_DEPENDENCIES_VERSION}", "--file", "graalvm_b.Dockerfile", "--build-arg", "JAVA_SHARED_CONFIG_VERSION=$_JAVA_SHARED_CONFIG_VERSION", "."]
+    args: [
+      "build",
+      "-t", "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:${_SHARED_DEPENDENCIES_VERSION}",
+      "--file", "graalvm_b.Dockerfile",
+      "--build-arg", "JAVA_SHARED_CONFIG_VERSION=$_JAVA_SHARED_CONFIG_VERSION",
+      "."
+    ]
     dir: .cloudbuild/graalvm
     id: graalvm-b-build
     waitFor: ["-"]

--- a/.cloudbuild/graalvm/cloudbuild.yaml
+++ b/.cloudbuild/graalvm/cloudbuild.yaml
@@ -19,14 +19,26 @@ substitutions:
 steps:
   # GraalVM A build
   - name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:${_SHARED_DEPENDENCIES_VERSION}", "--file", "graalvm_a.Dockerfile", "--build-arg", "JAVA_SHARED_CONFIG_VERSION=$_JAVA_SHARED_CONFIG_VERSION", "."]
+    args: [
+      "build",
+      "-t", "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:${_SHARED_DEPENDENCIES_VERSION}",
+      "--file", "graalvm_a.Dockerfile",
+      "--build-arg", "JAVA_SHARED_CONFIG_VERSION=$_JAVA_SHARED_CONFIG_VERSION",
+      "."
+    ]
     dir: .cloudbuild/graalvm
     id: graalvm-a-build
-    waitFor: ["-"]
+    waitFor: [ "-" ]
 
   # GraalVM B build
   - name: gcr.io/cloud-builders/docker
-    args: [ "build", "-t", "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:${_SHARED_DEPENDENCIES_VERSION}", "--file", "graalvm_b.Dockerfile",  "--build-arg", "JAVA_SHARED_CONFIG_VERSION=$_JAVA_SHARED_CONFIG_VERSION", "." ]
+    args: [
+      "build",
+      "-t", "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:${_SHARED_DEPENDENCIES_VERSION}",
+      "--file", "graalvm_b.Dockerfile",
+      "--build-arg", "JAVA_SHARED_CONFIG_VERSION=$_JAVA_SHARED_CONFIG_VERSION",
+      "."
+    ]
     dir: .cloudbuild/graalvm
     id: graalvm-b-build
     waitFor: [ "-" ]

--- a/.kokoro/presubmit/downstream-build.sh
+++ b/.kokoro/presubmit/downstream-build.sh
@@ -36,8 +36,13 @@ cp settings.xml "${HOME}/.m2"
 
 ### Round 1
 # Publish this repo's modules to local maven to make them available for downstream libraries
-mvn -B -ntp install --projects '!gapic-generator-java' \
-  -Dcheckstyle.skip -Dfmt.skip -DskipTests
+mvn install --projects '!gapic-generator-java' \
+  -Dcheckstyle.skip \
+  -Dfmt.skip \
+  -DskipTests \
+  -B -ntp \
+  -Dorg.slf4j.simpleLogger.showDateTime=true \
+  -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss:SSS
 
 SHARED_DEPS_VERSION=$(parse_pom_version java-shared-dependencies)
 
@@ -47,14 +52,22 @@ SHOWCASE_VERSION=$(mvn help:evaluate -Dexpression=gapic-showcase.version -q -Dfo
 popd
 # Start showcase server
 mkdir -p /usr/src/showcase
-curl --location https://github.com/googleapis/gapic-showcase/releases/download/v"${SHOWCASE_VERSION}"/gapic-showcase-"${SHOWCASE_VERSION}"-linux-amd64.tar.gz --output /usr/src/showcase/showcase-"${SHOWCASE_VERSION}"-linux-amd64.tar.gz
+curl \
+  --location https://github.com/googleapis/gapic-showcase/releases/download/v"${SHOWCASE_VERSION}"/gapic-showcase-"${SHOWCASE_VERSION}"-linux-amd64.tar.gz \
+  --output /usr/src/showcase/showcase-"${SHOWCASE_VERSION}"-linux-amd64.tar.gz
 pushd /usr/src/showcase/
 tar -xf showcase-*
 ./gapic-showcase run &
 popd
 # Run showcase tests with `native` profile
 pushd showcase
-mvn test -Pnative,-showcase -Denforcer.skip=true -ntp -B
+mvn test -Pnative,-showcase \
+  -Denforcer.skip=true \
+  -Dcheckstyle.skip \
+  -Dfmt.skip \
+  -ntp -B \
+  -Dorg.slf4j.simpleLogger.showDateTime=true \
+  -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss:SSS
 popd
 
 ### Round 3


### PR DESCRIPTION
Adds timestamps to the mvn build output, plus minor formatting for shorter lines / easier readability.