### PR TITLE
feat: throw exception when user attempt to override api-version header.

### DIFF
--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/ApiClientHeaderProvider.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/ApiClientHeaderProvider.java
@@ -42,7 +42,7 @@ public class ApiClientHeaderProvider implements HeaderProvider, Serializable {
   private static final long serialVersionUID = -8876627296793342119L;
   static final String QUOTA_PROJECT_ID_HEADER_KEY = "x-goog-user-project";
 
-  static final String API_VERSION_HEADER_KEY = "x-goog-api-version";
+  public static final String API_VERSION_HEADER_KEY = "x-goog-api-version";
 
   private final Map<String, String> headers;
 

--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
@@ -290,6 +290,13 @@ public abstract class ClientContext {
     Map<String, String> internalHeaders = settings.getInternalHeaderProvider().getHeaders();
     Map<String, String> conflictResolution = new HashMap<>();
 
+    // api version header user override is not allowed, even when not set by internal headers
+    if (userHeaders.keySet().contains(ApiClientHeaderProvider.API_VERSION_HEADER_KEY)) {
+      throw new IllegalArgumentException(
+          "Header provider can't override the header: "
+              + ApiClientHeaderProvider.API_VERSION_HEADER_KEY);
+    }
+
     Set<String> conflicts = Sets.intersection(userHeaders.keySet(), internalHeaders.keySet());
     for (String key : conflicts) {
       if ("user-agent".equals(key)) {

--- a/gax-java/gax/src/test/java/com/google/api/gax/rpc/ClientContextTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/rpc/ClientContextTest.java
@@ -64,7 +64,9 @@ import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
@@ -679,6 +681,109 @@ public class ClientContextTest {
 
     assertThat(transportChannel.getHeaders())
         .containsEntry("user-agent", "user-supplied-agent internal-agent");
+  }
+
+  @Rule public ExpectedException apiVersionExceptionRule = ExpectedException.none();
+
+  @Test
+  public void testApiVersionHeaderConflictShouldThrowException() throws Exception {
+
+    apiVersionExceptionRule.expect(IllegalArgumentException.class);
+    apiVersionExceptionRule.expectMessage(
+        "Header provider can't override the header: "
+            + ApiClientHeaderProvider.API_VERSION_HEADER_KEY);
+
+    TransportChannelProvider transportChannelProvider =
+        new FakeTransportProvider(
+            FakeTransportChannel.create(new FakeChannel()),
+            null,
+            true,
+            null,
+            null,
+            DEFAULT_ENDPOINT);
+
+    ClientSettings.Builder builder =
+        new FakeClientSettings.Builder()
+            .setExecutorProvider(
+                FixedExecutorProvider.create(Mockito.mock(ScheduledExecutorService.class)))
+            .setTransportChannelProvider(transportChannelProvider)
+            .setCredentialsProvider(
+                FixedCredentialsProvider.create(Mockito.mock(GoogleCredentials.class)));
+
+    builder.setHeaderProvider(
+        FixedHeaderProvider.create(
+            ApiClientHeaderProvider.API_VERSION_HEADER_KEY, "user-supplied-version"));
+    builder.setInternalHeaderProvider(
+        FixedHeaderProvider.create(
+            ApiClientHeaderProvider.API_VERSION_HEADER_KEY, "internal-version"));
+
+    ClientContext.create(builder.build());
+  }
+
+  @Test
+  public void testApiVersionHeaderEmptyConflictShouldThrowException() throws Exception {
+
+    apiVersionExceptionRule.expect(IllegalArgumentException.class);
+    apiVersionExceptionRule.expectMessage(
+        "Header provider can't override the header: "
+            + ApiClientHeaderProvider.API_VERSION_HEADER_KEY);
+
+    TransportChannelProvider transportChannelProvider =
+        new FakeTransportProvider(
+            FakeTransportChannel.create(new FakeChannel()),
+            null,
+            true,
+            null,
+            null,
+            DEFAULT_ENDPOINT);
+
+    ClientSettings.Builder builder =
+        new FakeClientSettings.Builder()
+            .setExecutorProvider(
+                FixedExecutorProvider.create(Mockito.mock(ScheduledExecutorService.class)))
+            .setTransportChannelProvider(transportChannelProvider)
+            .setCredentialsProvider(
+                FixedCredentialsProvider.create(Mockito.mock(GoogleCredentials.class)));
+
+    builder.setHeaderProvider(
+        FixedHeaderProvider.create(
+            ApiClientHeaderProvider.API_VERSION_HEADER_KEY, "user-supplied-version"));
+    builder.setInternalHeaderProvider(
+        FixedHeaderProvider.create(ApiClientHeaderProvider.API_VERSION_HEADER_KEY, ""));
+
+    ClientContext.create(builder.build());
+  }
+
+  @Test
+  public void testUserApiVersionHeaderOnlyShouldThrowException() throws Exception {
+
+    apiVersionExceptionRule.expect(IllegalArgumentException.class);
+    apiVersionExceptionRule.expectMessage(
+        "Header provider can't override the header: "
+            + ApiClientHeaderProvider.API_VERSION_HEADER_KEY);
+
+    TransportChannelProvider transportChannelProvider =
+        new FakeTransportProvider(
+            FakeTransportChannel.create(new FakeChannel()),
+            null,
+            true,
+            null,
+            null,
+            DEFAULT_ENDPOINT);
+
+    ClientSettings.Builder builder =
+        new FakeClientSettings.Builder()
+            .setExecutorProvider(
+                FixedExecutorProvider.create(Mockito.mock(ScheduledExecutorService.class)))
+            .setTransportChannelProvider(transportChannelProvider)
+            .setCredentialsProvider(
+                FixedCredentialsProvider.create(Mockito.mock(GoogleCredentials.class)));
+
+    builder.setHeaderProvider(
+        FixedHeaderProvider.create(
+            ApiClientHeaderProvider.API_VERSION_HEADER_KEY, "user-supplied-version"));
+
+    ClientContext.create(builder.build());
   }
 
   private static String endpoint = "https://foo.googleapis.com";

--- a/gax-java/gax/src/test/java/com/google/api/gax/rpc/ClientContextTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/rpc/ClientContextTest.java
@@ -685,14 +685,8 @@ public class ClientContextTest {
 
   @Rule public ExpectedException apiVersionExceptionRule = ExpectedException.none();
 
-  @Test
-  public void testApiVersionHeaderConflictShouldThrowException() throws Exception {
-
-    apiVersionExceptionRule.expect(IllegalArgumentException.class);
-    apiVersionExceptionRule.expectMessage(
-        "Header provider can't override the header: "
-            + ApiClientHeaderProvider.API_VERSION_HEADER_KEY);
-
+  private void createClientContextAndSetApiVersionHeaders(
+      String internalVersion, String userVersion) throws IOException {
     TransportChannelProvider transportChannelProvider =
         new FakeTransportProvider(
             FakeTransportChannel.create(new FakeChannel()),
@@ -713,11 +707,24 @@ public class ClientContextTest {
     builder.setHeaderProvider(
         FixedHeaderProvider.create(
             ApiClientHeaderProvider.API_VERSION_HEADER_KEY, "user-supplied-version"));
-    builder.setInternalHeaderProvider(
-        FixedHeaderProvider.create(
-            ApiClientHeaderProvider.API_VERSION_HEADER_KEY, "internal-version"));
+    if (internalVersion != null) {
+      builder.setInternalHeaderProvider(
+          FixedHeaderProvider.create(
+              ApiClientHeaderProvider.API_VERSION_HEADER_KEY, "internal-version"));
+    }
 
     ClientContext.create(builder.build());
+  }
+
+  @Test
+  public void testApiVersionHeaderConflictShouldThrowException() throws Exception {
+
+    apiVersionExceptionRule.expect(IllegalArgumentException.class);
+    apiVersionExceptionRule.expectMessage(
+        "Header provider can't override the header: "
+            + ApiClientHeaderProvider.API_VERSION_HEADER_KEY);
+
+    createClientContextAndSetApiVersionHeaders("internal-version", "user-supplied-version");
   }
 
   @Test
@@ -728,30 +735,7 @@ public class ClientContextTest {
         "Header provider can't override the header: "
             + ApiClientHeaderProvider.API_VERSION_HEADER_KEY);
 
-    TransportChannelProvider transportChannelProvider =
-        new FakeTransportProvider(
-            FakeTransportChannel.create(new FakeChannel()),
-            null,
-            true,
-            null,
-            null,
-            DEFAULT_ENDPOINT);
-
-    ClientSettings.Builder builder =
-        new FakeClientSettings.Builder()
-            .setExecutorProvider(
-                FixedExecutorProvider.create(Mockito.mock(ScheduledExecutorService.class)))
-            .setTransportChannelProvider(transportChannelProvider)
-            .setCredentialsProvider(
-                FixedCredentialsProvider.create(Mockito.mock(GoogleCredentials.class)));
-
-    builder.setHeaderProvider(
-        FixedHeaderProvider.create(
-            ApiClientHeaderProvider.API_VERSION_HEADER_KEY, "user-supplied-version"));
-    builder.setInternalHeaderProvider(
-        FixedHeaderProvider.create(ApiClientHeaderProvider.API_VERSION_HEADER_KEY, ""));
-
-    ClientContext.create(builder.build());
+    createClientContextAndSetApiVersionHeaders("", "user-supplied-version");
   }
 
   @Test
@@ -762,28 +746,7 @@ public class ClientContextTest {
         "Header provider can't override the header: "
             + ApiClientHeaderProvider.API_VERSION_HEADER_KEY);
 
-    TransportChannelProvider transportChannelProvider =
-        new FakeTransportProvider(
-            FakeTransportChannel.create(new FakeChannel()),
-            null,
-            true,
-            null,
-            null,
-            DEFAULT_ENDPOINT);
-
-    ClientSettings.Builder builder =
-        new FakeClientSettings.Builder()
-            .setExecutorProvider(
-                FixedExecutorProvider.create(Mockito.mock(ScheduledExecutorService.class)))
-            .setTransportChannelProvider(transportChannelProvider)
-            .setCredentialsProvider(
-                FixedCredentialsProvider.create(Mockito.mock(GoogleCredentials.class)));
-
-    builder.setHeaderProvider(
-        FixedHeaderProvider.create(
-            ApiClientHeaderProvider.API_VERSION_HEADER_KEY, "user-supplied-version"));
-
-    ClientContext.create(builder.build());
+    createClientContextAndSetApiVersionHeaders(null, "user-supplied-version");
   }
 
   private static String endpoint = "https://foo.googleapis.com";


### PR DESCRIPTION
As discussed offline, amend behavior so that if user code attempt to override api-version header via user header, conflict resolution in ClientContext would throw exception. This is consistent whether service itself sets api-version in proto or not (or empty).