### PR TITLE
ci: increase graalvm ci machine type

### DIFF
--- a/.cloudbuild/graalvm/cloudbuild-test-a-downstream-kms.yaml
+++ b/.cloudbuild/graalvm/cloudbuild-test-a-downstream-kms.yaml
@@ -16,7 +16,8 @@ timeout: 7200s # 2 hours
 substitutions:
   _SHARED_DEPENDENCIES_VERSION: '3.30.1-SNAPSHOT' # {x-version-update:google-cloud-shared-dependencies:current}
   _JAVA_SHARED_CONFIG_VERSION: '1.7.7'
-
+options:
+  machineType: 'E2_HIGHCPU_8'
 steps:
   - name: gcr.io/cloud-builders/docker
     args: [

--- a/.cloudbuild/graalvm/cloudbuild-test-a-downstream-kmsinventory.yaml
+++ b/.cloudbuild/graalvm/cloudbuild-test-a-downstream-kmsinventory.yaml
@@ -16,7 +16,8 @@ timeout: 7200s # 2 hours
 substitutions:
   _SHARED_DEPENDENCIES_VERSION: '3.30.1-SNAPSHOT' # {x-version-update:google-cloud-shared-dependencies:current}
   _JAVA_SHARED_CONFIG_VERSION: '1.7.7'
-
+options:
+  machineType: 'E2_HIGHCPU_8'
 steps:
   - name: gcr.io/cloud-builders/docker
     args: [

--- a/.cloudbuild/graalvm/cloudbuild-test-a.yaml
+++ b/.cloudbuild/graalvm/cloudbuild-test-a.yaml
@@ -16,7 +16,8 @@ timeout: 7200s # 2 hours
 substitutions:
   _SHARED_DEPENDENCIES_VERSION: '3.30.1-SNAPSHOT' # {x-version-update:google-cloud-shared-dependencies:current}
   _JAVA_SHARED_CONFIG_VERSION: '1.7.7'
-
+options:
+  machineType: 'E2_HIGHCPU_8'
 steps:
   - name: gcr.io/cloud-builders/docker
     args: [

--- a/.cloudbuild/graalvm/cloudbuild-test-b-downstream-kms.yaml
+++ b/.cloudbuild/graalvm/cloudbuild-test-b-downstream-kms.yaml
@@ -16,7 +16,8 @@ timeout: 7200s # 2 hours
 substitutions:
   _SHARED_DEPENDENCIES_VERSION: '3.30.1-SNAPSHOT' # {x-version-update:google-cloud-shared-dependencies:current}
   _JAVA_SHARED_CONFIG_VERSION: '1.7.7'
-
+options:
+  machineType: 'E2_HIGHCPU_8'
 steps:
   - name: gcr.io/cloud-builders/docker
     args: [

--- a/.cloudbuild/graalvm/cloudbuild-test-b-downstream-kmsinventory.yaml
+++ b/.cloudbuild/graalvm/cloudbuild-test-b-downstream-kmsinventory.yaml
@@ -16,7 +16,8 @@ timeout: 7200s # 2 hours
 substitutions:
   _SHARED_DEPENDENCIES_VERSION: '3.30.1-SNAPSHOT' # {x-version-update:google-cloud-shared-dependencies:current}
   _JAVA_SHARED_CONFIG_VERSION: '1.7.7'
-
+options:
+  machineType: 'E2_HIGHCPU_8'
 steps:
   - name: gcr.io/cloud-builders/docker
     args: [

--- a/.cloudbuild/graalvm/cloudbuild-test-b.yaml
+++ b/.cloudbuild/graalvm/cloudbuild-test-b.yaml
@@ -16,7 +16,8 @@ timeout: 7200s # 2 hours
 substitutions:
   _SHARED_DEPENDENCIES_VERSION: '3.30.1-SNAPSHOT' # {x-version-update:google-cloud-shared-dependencies:current}
   _JAVA_SHARED_CONFIG_VERSION: '1.7.7'
-
+options:
+  machineType: 'E2_HIGHCPU_8'
 steps:
   - name: gcr.io/cloud-builders/docker
     args: [


### PR DESCRIPTION
8m33s, 8m44s, 10m43s, 11m28s, 9m41s, 10m47s

These test times are all shorter than the ci / build (11) check, making these checks no longer the bottle neck.