### PR TITLE
chore: Migrate Gapic-Generator-Java to JUnit5

### DIFF
--- a/gapic-generator-java/pom.xml
+++ b/gapic-generator-java/pom.xml
@@ -476,5 +476,17 @@
       <version>4.12</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/JavaCodeGeneratorTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/JavaCodeGeneratorTest.java
@@ -60,9 +60,9 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Stack;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class JavaCodeGeneratorTest {
+class JavaCodeGeneratorTest {
 
   private static final String GOLDENFILES_DIRECTORY =
       "src/test/java/com/google/api/generator/engine/goldens/";
@@ -101,7 +101,7 @@ public class JavaCodeGeneratorTest {
   private static final Variable bookKindVar = createVarFromVaporRef(bookKindRef, "bookKind");
 
   @Test
-  public void validJavaClass() {
+  void validJavaClass() {
     // Create outer class variableDecls.
     // [code] private static final String serviceName = "LibraryServiceStub";
     VariableExpr serviceName = createServiceNameVarExpr();

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/AnonymousClassExprTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/AnonymousClassExprTest.java
@@ -20,11 +20,11 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.common.base.Function;
 import java.util.Arrays;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class AnonymousClassExprTest {
+class AnonymousClassExprTest {
   @Test
-  public void validAnonymousClass_basic() {
+  void validAnonymousClass_basic() {
     ConcreteReference ref = ConcreteReference.withClazz(Runnable.class);
     TypeNode type = TypeNode.withReference(ref);
     AssignmentExpr assignmentExpr = createAssignmentExpr("foobar", "false", TypeNode.BOOLEAN);
@@ -45,7 +45,7 @@ public class AnonymousClassExprTest {
   }
 
   @Test
-  public void validAnonymousClass_genericAndVariableExpr() {
+  void validAnonymousClass_genericAndVariableExpr() {
     // [Constructing] new Function<String, String>()
     ConcreteReference ref =
         ConcreteReference.builder()
@@ -100,14 +100,14 @@ public class AnonymousClassExprTest {
   }
 
   @Test
-  public void invalidAnonymousClass_primitiveType() {
+  void invalidAnonymousClass_primitiveType() {
     assertThrows(
         IllegalStateException.class,
         () -> AnonymousClassExpr.builder().setType(TypeNode.INT).build());
   }
 
   @Test
-  public void invalidAnonymousClass_staticMethod() {
+  void invalidAnonymousClass_staticMethod() {
     ConcreteReference ref = ConcreteReference.withClazz(Runnable.class);
     TypeNode type = TypeNode.withReference(ref);
     MethodDefinition method =
@@ -127,7 +127,7 @@ public class AnonymousClassExprTest {
   }
 
   @Test
-  public void invalidAnonymousClass_explicitConstructor() {
+  void invalidAnonymousClass_explicitConstructor() {
     TypeNode type = TypeNode.withReference(ConcreteReference.withClazz(Runnable.class));
     TypeNode returnType =
         TypeNode.withReference(
@@ -143,7 +143,7 @@ public class AnonymousClassExprTest {
   }
 
   @Test
-  public void invalidAnonymousClass_staticVariableExpr() {
+  void invalidAnonymousClass_staticVariableExpr() {
     ConcreteReference ref = ConcreteReference.withClazz(Runnable.class);
     TypeNode type = TypeNode.withReference(ref);
     Variable variable = createVariable("s", TypeNode.STRING);

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/ArithmeticOperationExprTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/ArithmeticOperationExprTest.java
@@ -16,11 +16,11 @@ package com.google.api.generator.engine.ast;
 
 import static org.junit.Assert.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ArithmeticOperationExprTest {
+class ArithmeticOperationExprTest {
   @Test
-  public void concatOperator_validBasic() {
+  void concatOperator_validBasic() {
     // valid type-checking for x + getSomeString()
     VariableExpr lhsExpr =
         VariableExpr.withVariable(Variable.builder().setType(TypeNode.INT).setName("x").build());
@@ -34,7 +34,7 @@ public class ArithmeticOperationExprTest {
   }
 
   @Test
-  public void concatOperator_validWithNull() {
+  void concatOperator_validWithNull() {
     // Type-checking for String variable x and null object value.
     VariableExpr lhsExpr =
         VariableExpr.withVariable(Variable.builder().setType(TypeNode.STRING).setName("x").build());
@@ -44,7 +44,7 @@ public class ArithmeticOperationExprTest {
   }
 
   @Test
-  public void concatOperator_validWithReferenceType() {
+  void concatOperator_validWithReferenceType() {
     // Type-checking for String variable x, Expr variable y.
     VariableExpr lhsExpr =
         VariableExpr.withVariable(Variable.builder().setType(TypeNode.STRING).setName("x").build());
@@ -59,7 +59,7 @@ public class ArithmeticOperationExprTest {
   }
 
   @Test
-  public void concatOperator_invalidVoidType() {
+  void concatOperator_invalidVoidType() {
     // throw exception if one of expr is void-type
     VariableExpr lhsExpr =
         VariableExpr.withVariable(Variable.builder().setType(TypeNode.STRING).setName("x").build());
@@ -74,7 +74,7 @@ public class ArithmeticOperationExprTest {
   }
 
   @Test
-  public void concatString_invalidNonStringType() {
+  void concatString_invalidNonStringType() {
     // throw exception for concat usage if none of exprs is String-type
     VariableExpr lhsExpr =
         VariableExpr.withVariable(Variable.builder().setType(TypeNode.INT).setName("x").build());

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/ArrayExprTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/ArrayExprTest.java
@@ -18,12 +18,12 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import com.google.api.generator.test.utils.TestExprBuilder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ArrayExprTest {
+class ArrayExprTest {
 
   @Test
-  public void validAnonymousArray_sametype() {
+  void validAnonymousArray_sametype() {
     ArrayExpr.Builder exprBuilder =
         ArrayExpr.builder()
             .setType(TypeNode.createArrayTypeOf(TypeNode.STRING))
@@ -41,7 +41,7 @@ public class ArrayExprTest {
   }
 
   @Test
-  public void validAnonymousArray_unsetTypeThrows() {
+  void validAnonymousArray_unsetTypeThrows() {
     ArrayExpr.Builder exprBuilder = ArrayExpr.builder();
     IllegalStateException thrown =
         assertThrows(IllegalStateException.class, () -> exprBuilder.build());
@@ -49,7 +49,7 @@ public class ArrayExprTest {
   }
 
   @Test
-  public void validAnonymousArray_onlyVariableAndValueExprs() {
+  void validAnonymousArray_onlyVariableAndValueExprs() {
     ArrayExpr.Builder exprBuilder =
         ArrayExpr.builder().setType(TypeNode.createArrayTypeOf(TypeNode.INT));
     Variable variable = Variable.builder().setName("x").setType(TypeNode.INT).build();

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/AssignmentExprTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/AssignmentExprTest.java
@@ -19,11 +19,11 @@ import static org.junit.Assert.assertThrows;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class AssignmentExprTest {
+class AssignmentExprTest {
   @Test
-  public void assignMatchingValue() {
+  void assignMatchingValue() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.INT).build();
     VariableExpr variableExpr =
         VariableExpr.builder().setVariable(variable).setIsDecl(true).build();
@@ -35,7 +35,7 @@ public class AssignmentExprTest {
   }
 
   @Test
-  public void assignMismatchedValue() {
+  void assignMismatchedValue() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.BOOLEAN).build();
     VariableExpr variableExpr =
         VariableExpr.builder().setVariable(variable).setIsDecl(true).build();
@@ -47,7 +47,7 @@ public class AssignmentExprTest {
   }
 
   @Test
-  public void assignSubtypeValue() {
+  void assignSubtypeValue() {
     Variable variable =
         Variable.builder()
             .setName("x")
@@ -66,7 +66,7 @@ public class AssignmentExprTest {
   }
 
   @Test
-  public void assignMatchingVariable() {
+  void assignMatchingVariable() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.INT).build();
     VariableExpr variableExpr =
         VariableExpr.builder().setVariable(variable).setIsDecl(true).build();
@@ -78,7 +78,7 @@ public class AssignmentExprTest {
   }
 
   @Test
-  public void assignNullObjectValue() {
+  void assignNullObjectValue() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.STRING).build();
     VariableExpr variableExpr =
         VariableExpr.builder().setVariable(variable).setIsDecl(true).build();
@@ -90,7 +90,7 @@ public class AssignmentExprTest {
   }
 
   @Test
-  public void writeAssignmentExpr_nullObjectValuePrimitiveType() {
+  void writeAssignmentExpr_nullObjectValuePrimitiveType() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.INT).build();
     VariableExpr variableExpr =
         VariableExpr.builder().setVariable(variable).setIsDecl(true).build();
@@ -102,7 +102,7 @@ public class AssignmentExprTest {
   }
 
   @Test
-  public void writeAssignmentExpr_primitiveToBoxedType() {
+  void writeAssignmentExpr_primitiveToBoxedType() {
     // [Constructing] `Boolean x = (boolean) true`
     Variable variable = Variable.builder().setName("x").setType(TypeNode.BOOLEAN_OBJECT).build();
     VariableExpr variableExpr =
@@ -114,7 +114,7 @@ public class AssignmentExprTest {
   }
 
   @Test
-  public void writeAssignmentExpr_boxedToPrimitiveType() {
+  void writeAssignmentExpr_boxedToPrimitiveType() {
     // [Constructing] `double x = (Double) y`
     Variable lVariable = Variable.builder().setName("x").setType(TypeNode.DOUBLE).build();
     VariableExpr lVariableExpr =
@@ -126,7 +126,7 @@ public class AssignmentExprTest {
   }
 
   @Test
-  public void writeAssignmentExpr_invalidBoxedPrimitiveType() {
+  void writeAssignmentExpr_invalidBoxedPrimitiveType() {
     // [Constructing] `double x = (Integer) y`
     Variable lVariable = Variable.builder().setName("x").setType(TypeNode.DOUBLE).build();
     VariableExpr lVariableExpr =
@@ -138,7 +138,7 @@ public class AssignmentExprTest {
   }
 
   @Test
-  public void writeAssignmentExpr_validIsDeclFinalVariableExpr() {
+  void writeAssignmentExpr_validIsDeclFinalVariableExpr() {
     Variable lVariable = Variable.builder().setName("x").setType(TypeNode.INT).build();
     VariableExpr lVariableExpr =
         VariableExpr.builder().setVariable(lVariable).setIsDecl(true).setIsFinal(true).build();
@@ -149,7 +149,7 @@ public class AssignmentExprTest {
   }
 
   @Test
-  public void writeAssignmentExpr_invalidIsNotDeclFinalVariableExpr() {
+  void writeAssignmentExpr_invalidIsNotDeclFinalVariableExpr() {
     Variable lVariable = Variable.builder().setName("x").setType(TypeNode.INT).build();
     VariableExpr lVariableExpr =
         VariableExpr.builder().setVariable(lVariable).setIsDecl(false).setIsFinal(true).build();

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/AssignmentOperationExprTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/AssignmentOperationExprTest.java
@@ -16,12 +16,12 @@ package com.google.api.generator.engine.ast;
 
 import static org.junit.Assert.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class AssignmentOperationExprTest {
+class AssignmentOperationExprTest {
   /** ========= Multiply And Assignment Operators: VariableExpr is numeric types ============== */
   @Test
-  public void validMultiplyAndAssignmentOperationExpr_numericMatched() {
+  void validMultiplyAndAssignmentOperationExpr_numericMatched() {
     // No need swap test case.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.INT, "y");
@@ -30,7 +30,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validMultiplyAndAssignmentOperationExpr_numericUnmatched() {
+  void validMultiplyAndAssignmentOperationExpr_numericUnmatched() {
     // No need swap test case.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT, "x");
     ValueExpr rhsExpr = createValueExpr(TypeNode.INT, "5");
@@ -39,7 +39,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validMultiplyAndAssignmentOperationExpr_numericMatchedBoxedType() {
+  void validMultiplyAndAssignmentOperationExpr_numericMatchedBoxedType() {
     // Swap test case in "validMultiplyAndAssignmentOperationExpr_integerMatchedBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "y");
@@ -48,7 +48,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validMultiplyAndAssignmentOperationExpr_numericUnmatchedBoxedType() {
+  void validMultiplyAndAssignmentOperationExpr_numericUnmatchedBoxedType() {
     // Swap test case in "validMultiplyAndAssignmentOperationExpr_integerBoxedWithShortType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.FLOAT_OBJECT, "y");
@@ -57,7 +57,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validMultiplyAndAssignmentOperationExpr_numericWithFloatType() {
+  void validMultiplyAndAssignmentOperationExpr_numericWithFloatType() {
     // Swap test case in "validMultiplyAndAssignmentOperationExpr_integerBoxedWithFloatType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.FLOAT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "y");
@@ -66,7 +66,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validMultiplyAndAssignmentOperationExpr_doubleWithIntegerBoxedType() {
+  void validMultiplyAndAssignmentOperationExpr_doubleWithIntegerBoxedType() {
     // Swap test case in "validMultiplyAndAssignmentOperationExpr_integerBoxedWithDoubleType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.DOUBLE, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "y");
@@ -75,7 +75,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validMultiplyAndAssignmentOperationExpr_doubleWithLongBoxedType() {
+  void validMultiplyAndAssignmentOperationExpr_doubleWithLongBoxedType() {
     // Swap test case in "invalidMultiplyAndAssignmentOperationExpr_longBoxedWithDoubleType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.DOUBLE, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.LONG_OBJECT, "y");
@@ -84,7 +84,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validMultiplyAndAssignmentOperationExpr_longWithIntegerBoxedType() {
+  void validMultiplyAndAssignmentOperationExpr_longWithIntegerBoxedType() {
     // Swap test case in "invalidMultiplyAndAssignmentOperationExpr_integerBoxedWithLongType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.LONG, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "y");
@@ -93,7 +93,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validMultiplyAndAssignmentOperationExpr_integerWithFloatBoxedType() {
+  void validMultiplyAndAssignmentOperationExpr_integerWithFloatBoxedType() {
     // Swap test case in "validMultiplyAndAssignmentOperationExpr_floatBoxedWithIntegerType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.FLOAT_OBJECT, "y");
@@ -102,7 +102,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validMultiplyAndAssignmentOperationExpr_validFloatWithLongBoxedType() {
+  void validMultiplyAndAssignmentOperationExpr_validFloatWithLongBoxedType() {
     // Swap test case in "invalidMultiplyAndAssignmentOperationExpr_longBoxedWithFloatType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.FLOAT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.LONG_OBJECT, "y");
@@ -111,7 +111,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_numericWithBooleanBoxedType() {
+  void invalidMultiplyAndAssignmentOperationExpr_numericWithBooleanBoxedType() {
     // Swap test case in "invalidMultiplyAndAssignmentOperationExpr_booleanBoxedWithNumericType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.BOOLEAN_OBJECT, "y");
@@ -121,7 +121,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_numericWithBooleanType() {
+  void invalidMultiplyAndAssignmentOperationExpr_numericWithBooleanType() {
     // Swap test case in "invalidMultiplyAndAssignmentOperationExpr_numericWithBooleanType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.BOOLEAN, "y");
@@ -131,7 +131,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_numericWithReferenceType() {
+  void invalidMultiplyAndAssignmentOperationExpr_numericWithReferenceType() {
     // Swap test case in "invalidMultiplyAndAssignmentOperationExpr_referencedWithNumericType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.STRING, "y");
@@ -141,7 +141,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_NumericWithNewObject() {
+  void invalidMultiplyAndAssignmentOperationExpr_NumericWithNewObject() {
     // No Need swap case.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT, "x");
     NewObjectExpr rhsExpr = NewObjectExpr.withType(TypeNode.OBJECT);
@@ -152,7 +152,7 @@ public class AssignmentOperationExprTest {
 
   /** ==== Multiply And Assignment Operators: LHS data type is boolean and its boxed type ===== */
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_booleanWithNumericType() {
+  void invalidMultiplyAndAssignmentOperationExpr_booleanWithNumericType() {
     // Swap test case in "invalidMultiplyAndAssignmentOperationExpr_numericWithBooleanType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.BOOLEAN, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.INT, "y");
@@ -162,7 +162,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_booleanBoxedWithNumericType() {
+  void invalidMultiplyAndAssignmentOperationExpr_booleanBoxedWithNumericType() {
     // Swap test case in "invalidMultiplyAndAssignmentOperationExpr_numericWithBooleanBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.BOOLEAN_OBJECT, "x");
     ValueExpr rhsExpr = createValueExpr(TypeNode.INT, "5");
@@ -174,7 +174,7 @@ public class AssignmentOperationExprTest {
   /** ======== Multiply And Assignment Operators: LHS data type is Integer Box Type ============ */
   // RHS should be int, char, short, byte or these types' boxed types.
   @Test
-  public void validMultiplyAndAssignmentOperationExpr_integerMatchedBoxedType() {
+  void validMultiplyAndAssignmentOperationExpr_integerMatchedBoxedType() {
     // Swap test case in "validMultiplyAndAssignmentOperationExpr_numericMatchedBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "x");
     ValueExpr rhsExpr = createValueExpr(TypeNode.INT, "5");
@@ -183,7 +183,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validMultiplyAndAssignmentOperationExpr_integerBoxedWithShortType() {
+  void validMultiplyAndAssignmentOperationExpr_integerBoxedWithShortType() {
     // Swap test case in "validMultiplyAndAssignmentOperationExpr_numericUnmatchedBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.SHORT, "y");
@@ -192,7 +192,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validMultiplyAndAssignmentOperationExpr_integerBoxedWithShortBoxedType() {
+  void validMultiplyAndAssignmentOperationExpr_integerBoxedWithShortBoxedType() {
     // Swap test case in "validMultiplyAndAssignmentOperationExpr_shortBoxedWithIntegerBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.SHORT_OBJECT, "y");
@@ -201,7 +201,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validMultiplyAndAssignmentOperationExpr_integerBoxedWithCharacterBoxedType() {
+  void validMultiplyAndAssignmentOperationExpr_integerBoxedWithCharacterBoxedType() {
     // Swap test case in "validMultiplyAndAssignmentOperationExpr_shortBoxedWithIntegerBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.CHAR_OBJECT, "y");
@@ -210,7 +210,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validMultiplyAndAssignmentOperationExpr_integerBoxedWithByteBoxedType() {
+  void validMultiplyAndAssignmentOperationExpr_integerBoxedWithByteBoxedType() {
     // Swap test case in "validMultiplyAndAssignmentOperationExpr_byteBoxedWithIntegerBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.BYTE_OBJECT, "y");
@@ -219,7 +219,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_integerBoxedWithFloatType() {
+  void invalidMultiplyAndAssignmentOperationExpr_integerBoxedWithFloatType() {
     // Swap test case in "validMultiplyAndAssignmentOperationExpr_numericWithFloatType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.FLOAT, "y");
@@ -229,7 +229,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_integerBoxedWithFloatBoxedType() {
+  void invalidMultiplyAndAssignmentOperationExpr_integerBoxedWithFloatBoxedType() {
     // Swap test case in "validMultiplyAndAssignmentOperationExpr_floatBoxedWithIntegerBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.FLOAT_OBJECT, "y");
@@ -239,7 +239,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_integerBoxedWithDoubleType() {
+  void invalidMultiplyAndAssignmentOperationExpr_integerBoxedWithDoubleType() {
     // Swap test case in "validMultiplyAndAssignmentOperationExpr_doubleWithIntegerBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.DOUBLE, "y");
@@ -249,7 +249,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_integerBoxedWithDoubleBoxedType() {
+  void invalidMultiplyAndAssignmentOperationExpr_integerBoxedWithDoubleBoxedType() {
     // Swap test case in "validMultiplyAndAssignmentOperationExpr_doubleBoxedWithIntegerBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.DOUBLE_OBJECT, "y");
@@ -259,7 +259,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_integerBoxedWithLongType() {
+  void invalidMultiplyAndAssignmentOperationExpr_integerBoxedWithLongType() {
     // Swap test case in "validMultiplyAndAssignmentOperationExpr_longWithIntegerBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.LONG, "y");
@@ -269,7 +269,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_integerBoxedWithLongBoxedType() {
+  void invalidMultiplyAndAssignmentOperationExpr_integerBoxedWithLongBoxedType() {
     // Swap test case in "validMultiplyAndAssignmentOperationExpr_longBoxedWithIntegerBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.LONG_OBJECT, "y");
@@ -281,7 +281,7 @@ public class AssignmentOperationExprTest {
   /** ==== Multiply And Assignment Operators: LHS data type is Float boxed type ====== */
   // RHS could be numeric or numeric boxed type, beside double and its boxed type.
   @Test
-  public void validMultiplyAndAssignmentOperationExpr_floatBoxedWithIntegerType() {
+  void validMultiplyAndAssignmentOperationExpr_floatBoxedWithIntegerType() {
     // Swap test case in "validMultiplyAndAssignmentOperationExpr_integerWithFloatBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.FLOAT_OBJECT, "x");
     ValueExpr rhsExpr = createValueExpr(TypeNode.INT, "5");
@@ -290,7 +290,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validMultiplyAndAssignmentOperationExpr_floatBoxedWithIntegerBoxedType() {
+  void validMultiplyAndAssignmentOperationExpr_floatBoxedWithIntegerBoxedType() {
     // Swap test case in "invalidMultiplyAndAssignmentOperationExpr_integerBoxedWithFloatBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.FLOAT_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "y");
@@ -299,7 +299,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validMultiplyAndAssignmentOperationExpr_floatBoxedWithCharBoxedType() {
+  void validMultiplyAndAssignmentOperationExpr_floatBoxedWithCharBoxedType() {
     // Swap test case in "invalidMultiplyAndAssignmentOperationExpr_charBoxedWithFloatBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.FLOAT_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.CHAR_OBJECT, "y");
@@ -308,7 +308,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validMultiplyAndAssignmentOperationExpr_floatBoxedWithByteBoxedType() {
+  void validMultiplyAndAssignmentOperationExpr_floatBoxedWithByteBoxedType() {
     // Swap test case in "invalidMultiplyAndAssignmentOperationExpr_byteBoxedWithFloatBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.FLOAT_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.BYTE_OBJECT, "y");
@@ -317,7 +317,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validMultiplyAndAssignmentOperationExpr_floatBoxedWithLongBoxedType() {
+  void validMultiplyAndAssignmentOperationExpr_floatBoxedWithLongBoxedType() {
     // Swap test case in "invalidMultiplyAndAssignmentOperationExpr_longBoxedWithFloatBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.FLOAT_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.LONG_OBJECT, "y");
@@ -326,7 +326,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validMultiplyAndAssignmentOperationExpr_floatBoxedWithDoubleBoxedType() {
+  void validMultiplyAndAssignmentOperationExpr_floatBoxedWithDoubleBoxedType() {
     // Swap test case in "validMultiplyAndAssignmentOperationExpr_doubleBoxedWithFloatBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.FLOAT_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.DOUBLE_OBJECT, "y");
@@ -336,7 +336,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_floatBoxedWithObjectType() {
+  void invalidMultiplyAndAssignmentOperationExpr_floatBoxedWithObjectType() {
     // No need swap case.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.FLOAT_OBJECT, "x");
     NewObjectExpr rhsExpr = NewObjectExpr.withType(TypeNode.OBJECT);
@@ -346,7 +346,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_floatBoxedWithNullType() {
+  void invalidMultiplyAndAssignmentOperationExpr_floatBoxedWithNullType() {
     // No need swap case.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.FLOAT_OBJECT, "x");
     ValueExpr rhsExpr = ValueExpr.createNullExpr();
@@ -356,7 +356,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_floatBoxedWithReferenceType() {
+  void invalidMultiplyAndAssignmentOperationExpr_floatBoxedWithReferenceType() {
     // Swap test case in "invalidMultiplyAndAssignmentOperationExpr_referenceWithFloatBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.FLOAT_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.STRING, "y");
@@ -368,7 +368,7 @@ public class AssignmentOperationExprTest {
   /** ==== Multiply And Assignment Operators: LHS data type is Short/Char/Byte Boxed Type ====== */
   // RHS has no valid type.
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_byteBoxedWithIntegerBoxedType() {
+  void invalidMultiplyAndAssignmentOperationExpr_byteBoxedWithIntegerBoxedType() {
     // Swap test case in "validMultiplyAndAssignmentOperationExpr_integerBoxedWithByteBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.BYTE_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "y");
@@ -378,7 +378,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_shortBoxedWithIntegerBoxedType() {
+  void invalidMultiplyAndAssignmentOperationExpr_shortBoxedWithIntegerBoxedType() {
     // Swap test case in
     // "validMultiplyAndAssignmentOperationExpr_validCharacterBoxedWithIntegerBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.SHORT_OBJECT, "x");
@@ -389,7 +389,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validMultiplyAndAssignmentOperationExpr_characterBoxedWithIntegerBoxedType() {
+  void validMultiplyAndAssignmentOperationExpr_characterBoxedWithIntegerBoxedType() {
     // Swap test case in
     // "validMultiplyAndAssignmentOperationExpr_integerBoxedWithCharacterBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.CHAR_OBJECT, "x");
@@ -400,7 +400,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_charBoxedWithFloatBoxedType() {
+  void invalidMultiplyAndAssignmentOperationExpr_charBoxedWithFloatBoxedType() {
     // Swap test case in "invalidMultiplyAndAssignmentOperationExpr_integerBoxedWithFloatBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.CHAR_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.FLOAT_OBJECT, "y");
@@ -410,7 +410,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_byteBoxedWithFloatBoxedType() {
+  void invalidMultiplyAndAssignmentOperationExpr_byteBoxedWithFloatBoxedType() {
     // Swap test case in "validMultiplyAndAssignmentOperationExpr_floatBoxedWithByteBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.BYTE_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.FLOAT_OBJECT, "y");
@@ -422,7 +422,7 @@ public class AssignmentOperationExprTest {
   /** ======== Multiply And Assignment Operators: LHS data type is Double Boxed Type ============ */
   // RHS could be any numeric type or numeric boxed type.
   @Test
-  public void validMultiplyAndAssignmentOperationExpr_doubleBoxedWithIntegerBoxedType() {
+  void validMultiplyAndAssignmentOperationExpr_doubleBoxedWithIntegerBoxedType() {
     // Swap test case in
     // "invalidMultiplyAndAssignmentOperationExpr_integerBoxedWithDoubleBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.DOUBLE_OBJECT, "x");
@@ -432,7 +432,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validMultiplyAndAssignmentOperationExpr_doubleBoxedWithFloatBoxedType() {
+  void validMultiplyAndAssignmentOperationExpr_doubleBoxedWithFloatBoxedType() {
     // Swap test case in "invalidMultiplyAndAssignmentOperationExpr_floatBoxedWithDoubleBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.DOUBLE_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.FLOAT_OBJECT, "y");
@@ -441,7 +441,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validMultiplyAndAssignmentOperationExpr_doubleBoxedWithLongBoxedType() {
+  void validMultiplyAndAssignmentOperationExpr_doubleBoxedWithLongBoxedType() {
     // Swap test case in "invalidMultiplyAndAssignmentOperationExpr_longBoxedWithDoubleBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.DOUBLE_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.LONG_OBJECT, "y");
@@ -450,7 +450,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_doubleBoxedWithReferenceType() {
+  void invalidMultiplyAndAssignmentOperationExpr_doubleBoxedWithReferenceType() {
     // Swap test case in "invalidMultiplyAndAssignmentOperationExpr_referenceWithDoubleBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.DOUBLE_OBJECT, "x");
     ValueExpr valueExpr = ValueExpr.withValue(StringObjectValue.withValue("abc"));
@@ -460,7 +460,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_doubleBoxedWithNullType() {
+  void invalidMultiplyAndAssignmentOperationExpr_doubleBoxedWithNullType() {
     // No need swap case.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.DOUBLE_OBJECT, "x");
     ValueExpr valueExprExpr = ValueExpr.createNullExpr();
@@ -470,7 +470,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_doubleBoxedWithObjectType() {
+  void invalidMultiplyAndAssignmentOperationExpr_doubleBoxedWithObjectType() {
     // No need swap test.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.DOUBLE_OBJECT, "x");
     NewObjectExpr rhsExpr = NewObjectExpr.withType(TypeNode.OBJECT);
@@ -481,7 +481,7 @@ public class AssignmentOperationExprTest {
 
   /** ======== Multiply And Assignment Operators: LHS data type is Long boxed type ============ */
   @Test
-  public void validMultiplyAndAssignmentOperationExpr_longBoxedWithIntegerBoxedType() {
+  void validMultiplyAndAssignmentOperationExpr_longBoxedWithIntegerBoxedType() {
     // Swap test case in "invalidMultiplyAndAssignmentOperationExpr_integerBoxedWithLongBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.LONG_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "y");
@@ -490,7 +490,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_longBoxedWithFloatBoxedType() {
+  void invalidMultiplyAndAssignmentOperationExpr_longBoxedWithFloatBoxedType() {
     // Swap test case in "validMultiplyAndAssignmentOperationExpr_floatBoxedWithLongBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.LONG_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.FLOAT_OBJECT, "y");
@@ -500,7 +500,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_longBoxedWithFloatType() {
+  void invalidMultiplyAndAssignmentOperationExpr_longBoxedWithFloatType() {
     // Swap test case in "validMultiplyAndAssignmentOperationExpr_floatWithLongBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.LONG_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.FLOAT, "y");
@@ -510,7 +510,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_longBoxedWithDoubleBoxedType() {
+  void invalidMultiplyAndAssignmentOperationExpr_longBoxedWithDoubleBoxedType() {
     // Swap test case in "validMultiplyAndAssignmentOperationExpr_doubleBoxedWithLongBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.LONG_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.DOUBLE_OBJECT, "y");
@@ -520,7 +520,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_longBoxedWithDoubleType() {
+  void invalidMultiplyAndAssignmentOperationExpr_longBoxedWithDoubleType() {
     // Swap test case in "validMultiplyAndAssignmentOperationExpr_doubleWithLongBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.LONG_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.DOUBLE, "y");
@@ -530,7 +530,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_longBoxedWithNullType() {
+  void invalidMultiplyAndAssignmentOperationExpr_longBoxedWithNullType() {
     // Swap test case in "invalidMultiplyAndAssignmentOperationExpr_nullWithLongBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.LONG_OBJECT, "x");
     ValueExpr rhsExpr = ValueExpr.createNullExpr();
@@ -540,7 +540,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_longBoxedWithObjectType() {
+  void invalidMultiplyAndAssignmentOperationExpr_longBoxedWithObjectType() {
     // No need swap case.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.LONG_OBJECT, "x");
     NewObjectExpr rhsExpr = NewObjectExpr.withType(TypeNode.OBJECT);
@@ -550,7 +550,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_longBoxedWithReferenceType() {
+  void invalidMultiplyAndAssignmentOperationExpr_longBoxedWithReferenceType() {
     // Swap test case in "invalidMultiplyAndAssignmentOperationExpr_referenceWithLongBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.LONG_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.STRING, "y");
@@ -561,7 +561,7 @@ public class AssignmentOperationExprTest {
 
   /** ======== Multiply And Assignment Operators: LHS data type is Reference Type ============ */
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_referencedWithNumericType() {
+  void invalidMultiplyAndAssignmentOperationExpr_referencedWithNumericType() {
     // Swap test case in "invalidMultiplyAndAssignmentOperationExpr_numericWithReferenceType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.STRING, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.DOUBLE, "y");
@@ -571,7 +571,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_referenceWithFloatBoxedType() {
+  void invalidMultiplyAndAssignmentOperationExpr_referenceWithFloatBoxedType() {
     // Swap test case in "invalidMultiplyAndAssignmentOperationExpr_floatBoxedWithReferenceType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.STRING, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.FLOAT_OBJECT, "y");
@@ -581,7 +581,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_referenceWithLongBoxedType() {
+  void invalidMultiplyAndAssignmentOperationExpr_referenceWithLongBoxedType() {
     // Swap test case in "invalidMultiplyAndAssignmentOperationExpr_longBoxedWithReferenceType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.STRING, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.LONG_OBJECT, "y");
@@ -591,7 +591,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_referenceWithDoubleBoxedType() {
+  void invalidMultiplyAndAssignmentOperationExpr_referenceWithDoubleBoxedType() {
     // Swap test case in "invalidMultiplyAndAssignmentOperationExpr_doubleBoxedWithReferenceType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.STRING, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.DOUBLE_OBJECT, "y");
@@ -602,7 +602,7 @@ public class AssignmentOperationExprTest {
 
   /** =========== Multiply And Assignment Operators: Variable is declaration ================ */
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_variableExprIsDecl() {
+  void invalidMultiplyAndAssignmentOperationExpr_variableExprIsDecl() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.INT).build();
     VariableExpr lhsExpr = VariableExpr.builder().setVariable(variable).setIsDecl(true).build();
     VariableExpr rhsExpr = createVariableExpr(TypeNode.INT, "y");
@@ -612,7 +612,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_valueExprIsDecl() {
+  void invalidMultiplyAndAssignmentOperationExpr_valueExprIsDecl() {
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT, "x");
     Variable variable = Variable.builder().setName("x").setType(TypeNode.INT).build();
     VariableExpr rhsExpr = VariableExpr.builder().setVariable(variable).setIsDecl(true).build();
@@ -622,7 +622,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_variableExprAndValueExprIsDecl() {
+  void invalidMultiplyAndAssignmentOperationExpr_variableExprAndValueExprIsDecl() {
     Variable lVariable = Variable.builder().setName("x").setType(TypeNode.INT).build();
     VariableExpr lhsExpr = VariableExpr.builder().setVariable(lVariable).setIsDecl(true).build();
     Variable rVariable = Variable.builder().setName("y").setType(TypeNode.INT).build();
@@ -634,7 +634,7 @@ public class AssignmentOperationExprTest {
 
   /** ======================= Multiply And Assignment Operators: Void type ===================== */
   @Test
-  public void invalidMultiplyAndAssignmentOperationExpr_voidType() {
+  void invalidMultiplyAndAssignmentOperationExpr_voidType() {
     // No need swap case.
     VariableExpr lhsExprExpr = createVariableExpr(TypeNode.FLOAT_OBJECT, "x");
     MethodInvocationExpr rhsExpr =
@@ -646,7 +646,7 @@ public class AssignmentOperationExprTest {
 
   /** =================== XOR Assignment Operators: boolean type ======================= */
   @Test
-  public void validXorAssignmentOperationExpr_booleanType() {
+  void validXorAssignmentOperationExpr_booleanType() {
     // No need swap case.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.BOOLEAN, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.BOOLEAN, "y");
@@ -655,7 +655,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validXorAssignmentOperationExpr_booleanWithBooleanBoxedType() {
+  void validXorAssignmentOperationExpr_booleanWithBooleanBoxedType() {
     // Swap case in "validXorAssignmentOperationExpr_booleanBoxedTypeWithUnboxedType.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.BOOLEAN, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.BOOLEAN_OBJECT, "y");
@@ -664,7 +664,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validXorAssignmentOperationExpr_booleanBoxedTypeWithUnboxedType() {
+  void validXorAssignmentOperationExpr_booleanBoxedTypeWithUnboxedType() {
     // Swap case in "validXorAssignmentOperationExpr_booleanWithBooleanBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.BOOLEAN_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.BOOLEAN, "y");
@@ -673,7 +673,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validXorAssignmentOperationExpr_booleanBoxedType() {
+  void validXorAssignmentOperationExpr_booleanBoxedType() {
     // No need swap case.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.BOOLEAN_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.BOOLEAN_OBJECT, "y");
@@ -682,7 +682,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidXorAssignmentOperationExpr_booleanWithNumericTypes() {
+  void invalidXorAssignmentOperationExpr_booleanWithNumericTypes() {
     // Swap case in "invalidXorAssignmentOperationExpr_integerWithBooleanTypes".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.BOOLEAN, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.INT, "y");
@@ -692,7 +692,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidXorAssignmentOperationExpr_booleanWithIntegerBoxedTypes() {
+  void invalidXorAssignmentOperationExpr_booleanWithIntegerBoxedTypes() {
     // Swap case in "invalidXorAssignmentOperationExpr_integerBoxedTypeWithBooleanTypes".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.BOOLEAN, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "y");
@@ -702,7 +702,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidXorAssignmentOperationExpr_booleanWithReferencedTypes() {
+  void invalidXorAssignmentOperationExpr_booleanWithReferencedTypes() {
     // Swap case in "invalidXorAssignmentOperationExpr_referencedTypeWithBooleanTypes".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.BOOLEAN, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.STRING, "y");
@@ -712,7 +712,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidXorAssignmentOperationExpr_booleanWithNullTypes() {
+  void invalidXorAssignmentOperationExpr_booleanWithNullTypes() {
     // No valid swap case.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.BOOLEAN, "x");
     ValueExpr rhsExpr = ValueExpr.createNullExpr();
@@ -722,7 +722,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidXorAssignmentOperationExpr_booleanWithNewObjectTypes() {
+  void invalidXorAssignmentOperationExpr_booleanWithNewObjectTypes() {
     // No valid swap case.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.BOOLEAN, "x");
     NewObjectExpr rhsExpr = NewObjectExpr.withType(TypeNode.OBJECT);
@@ -733,7 +733,7 @@ public class AssignmentOperationExprTest {
 
   /** ======= XOR Assignment Operators: LHS is non-floating-point numeric types ========= */
   @Test
-  public void validXorAssignmentOperationExpr_integerWithCharType() {
+  void validXorAssignmentOperationExpr_integerWithCharType() {
     // No need swap case.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.CHAR, "y");
@@ -742,7 +742,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validXorAssignmentOperationExpr_integerWithIntegerType() {
+  void validXorAssignmentOperationExpr_integerWithIntegerType() {
     // No need swap case.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.INT, "y");
@@ -751,7 +751,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validXorAssignmentOperationExpr_integerWithByteType() {
+  void validXorAssignmentOperationExpr_integerWithByteType() {
     // No need swap case.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.BYTE, "y");
@@ -760,7 +760,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validXorAssignmentOperationExpr_integerWithShortType() {
+  void validXorAssignmentOperationExpr_integerWithShortType() {
     // No need swap case.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.SHORT, "y");
@@ -769,7 +769,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validXorAssignmentOperationExpr_integerWithLongType() {
+  void validXorAssignmentOperationExpr_integerWithLongType() {
     // No need swap case.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.LONG, "y");
@@ -778,7 +778,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validXorAssignmentOperationExpr_byteWithIntegerBoxedType() {
+  void validXorAssignmentOperationExpr_byteWithIntegerBoxedType() {
     // Swap case in "validXorAssignmentOperationExpr_integerBoxedTypeWithByteType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.BYTE, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "y");
@@ -787,7 +787,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validXorAssignmentOperationExpr_charWithIntegerType() {
+  void validXorAssignmentOperationExpr_charWithIntegerType() {
     // No need swap case.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.CHAR, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.INT, "y");
@@ -796,7 +796,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validXorAssignmentOperationExpr_shortWithIntegerType() {
+  void validXorAssignmentOperationExpr_shortWithIntegerType() {
     // No need swap case.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.SHORT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.INT, "y");
@@ -805,7 +805,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validXorAssignmentOperationExpr_longWithIntegerType() {
+  void validXorAssignmentOperationExpr_longWithIntegerType() {
     // No need swap case.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.LONG, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.INT, "y");
@@ -814,7 +814,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validXorAssignmentOperationExpr_charWithIntegerBoxedType() {
+  void validXorAssignmentOperationExpr_charWithIntegerBoxedType() {
     // Swap case in .
     VariableExpr lhsExpr = createVariableExpr(TypeNode.CHAR, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "y");
@@ -823,7 +823,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validXorAssignmentOperationExpr_longWithByteBoxedType() {
+  void validXorAssignmentOperationExpr_longWithByteBoxedType() {
     // Swap case in .
     VariableExpr lhsExpr = createVariableExpr(TypeNode.LONG, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.BYTE_OBJECT, "y");
@@ -832,7 +832,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validXorAssignmentOperationExpr_integerWithLongBoxedType() {
+  void validXorAssignmentOperationExpr_integerWithLongBoxedType() {
     // Swap case in .
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.LONG_OBJECT, "y");
@@ -841,7 +841,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidXorAssignmentOperationExpr_integerWithDoubleTypes() {
+  void invalidXorAssignmentOperationExpr_integerWithDoubleTypes() {
     // Swap case in "invalidXorAssignmentOperationExpr_doubleWithIntegerTypes".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.DOUBLE, "y");
@@ -851,7 +851,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidXorAssignmentOperationExpr_integerWithDoubleBoxedTypes() {
+  void invalidXorAssignmentOperationExpr_integerWithDoubleBoxedTypes() {
     // Swap case in "invalidXorAssignmentOperationExpr_doubleBoxedWithIntegerTypes".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.DOUBLE_OBJECT, "y");
@@ -861,7 +861,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidXorAssignmentOperationExpr_charWithFloatTypes() {
+  void invalidXorAssignmentOperationExpr_charWithFloatTypes() {
     // Swap case in "invalidXorAssignmentOperationExpr_floatWithCharTypes".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.CHAR, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.FLOAT, "y");
@@ -871,7 +871,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidXorAssignmentOperationExpr_charWithFloatBoxedTypes() {
+  void invalidXorAssignmentOperationExpr_charWithFloatBoxedTypes() {
     // Swap case in "invalidXorAssignmentOperationExpr_floatBoxedWithCharTypes".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.CHAR, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.FLOAT_OBJECT, "y");
@@ -881,7 +881,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidXorAssignmentOperationExpr_integerWithBooleanTypes() {
+  void invalidXorAssignmentOperationExpr_integerWithBooleanTypes() {
     // Swap case in "invalidXorAssignmentOperationExpr_booleanWithNumericTypes".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.BOOLEAN, "y");
@@ -891,7 +891,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidXorAssignmentOperationExpr_integerWithNullTypes() {
+  void invalidXorAssignmentOperationExpr_integerWithNullTypes() {
     // No need swap case.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT, "x");
     ValueExpr rhsExpr = ValueExpr.createNullExpr();
@@ -901,7 +901,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidXorAssignmentOperationExpr_integerWithReferenceTypes() {
+  void invalidXorAssignmentOperationExpr_integerWithReferenceTypes() {
     // Swap case in invalidXorAssignmentOperationExpr_referenceWithCharTypes.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.STRING, "y");
@@ -912,7 +912,7 @@ public class AssignmentOperationExprTest {
 
   /** ============= XOR Assignment Operators: LHS is integer boxed type ================= */
   @Test
-  public void validXorAssignmentOperationExpr_integerBoxedTypeWithIntegerType() {
+  void validXorAssignmentOperationExpr_integerBoxedTypeWithIntegerType() {
     // Swap case in "validXorAssignmentOperationExpr_charWithIntegerBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.INT, "y");
@@ -921,7 +921,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validXorAssignmentOperationExpr_integerBoxedTypeWithCharType() {
+  void validXorAssignmentOperationExpr_integerBoxedTypeWithCharType() {
     // Swap case in validXorAssignmentOperationExpr_charWithIntegerBoxedType.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.CHAR, "y");
@@ -930,7 +930,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validXorAssignmentOperationExpr_integerBoxedTypeWithByteType() {
+  void validXorAssignmentOperationExpr_integerBoxedTypeWithByteType() {
     // Swap case in "validXorAssignmentOperationExpr_byteWithIntegerBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.BYTE, "y");
@@ -939,7 +939,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validXorAssignmentOperationExpr_integerBoxedTypeWithLongBoxedType() {
+  void validXorAssignmentOperationExpr_integerBoxedTypeWithLongBoxedType() {
     // Swap case in "invalidXorAssignmentOperationExpr_longBoxedTypeWithIntegerBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.LONG_OBJECT, "y");
@@ -948,7 +948,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void validXorAssignmentOperationExpr_integerBoxedTypeWithShortBoxedType() {
+  void validXorAssignmentOperationExpr_integerBoxedTypeWithShortBoxedType() {
     // Swap case in "invalidXorAssignmentOperationExpr_shortBoxedTypeWithIntegerBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.SHORT_OBJECT, "y");
@@ -957,7 +957,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidXorAssignmentOperationExpr_integerBoxedTypeWithFloatType() {
+  void invalidXorAssignmentOperationExpr_integerBoxedTypeWithFloatType() {
     // Swap case in "invalidXorAssignmentOperationExpr_floatWithIntegerBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.FLOAT, "y");
@@ -967,7 +967,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidXorAssignmentOperationExpr_integerBoxedTypeWithFloatBoxedType() {
+  void invalidXorAssignmentOperationExpr_integerBoxedTypeWithFloatBoxedType() {
     // Swap case in "invalidXorAssignmentOperationExpr_floatBoxedWithIntegerBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.FLOAT_OBJECT, "y");
@@ -977,7 +977,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidXorAssignmentOperationExpr_integerBoxedTypeWithDoubleType() {
+  void invalidXorAssignmentOperationExpr_integerBoxedTypeWithDoubleType() {
     // Swap case in "invalidXorAssignmentOperationExpr_doubleWithIntegerBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.DOUBLE, "y");
@@ -987,7 +987,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidXorAssignmentOperationExpr_integerBoxedTypeWithDoubleBoxedType() {
+  void invalidXorAssignmentOperationExpr_integerBoxedTypeWithDoubleBoxedType() {
     // Swap case in "invalidXorAssignmentOperationExpr_doubleBoxedWithIntegerBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.DOUBLE_OBJECT, "y");
@@ -998,7 +998,7 @@ public class AssignmentOperationExprTest {
 
   /** =========== XOR Assignment Operators: LHS is floating-point type =============== */
   @Test
-  public void invalidXorAssignmentOperationExpr_floatWithIntegerBoxedType() {
+  void invalidXorAssignmentOperationExpr_floatWithIntegerBoxedType() {
     // Swap case in "invalidXorAssignmentOperationExpr_integerBoxedTypeWithFloatType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.FLOAT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "y");
@@ -1008,7 +1008,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidXorAssignmentOperationExpr_floatBoxedWithIntegerBoxedType() {
+  void invalidXorAssignmentOperationExpr_floatBoxedWithIntegerBoxedType() {
     // Swap case in "invalidXorAssignmentOperationExpr_integerBoxedTypeWithFloatBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.FLOAT_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "y");
@@ -1018,7 +1018,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidXorAssignmentOperationExpr_doubleWithIntegerBoxedType() {
+  void invalidXorAssignmentOperationExpr_doubleWithIntegerBoxedType() {
     // Swap case in "invalidXorAssignmentOperationExpr_integerBoxedTypeWithDoubleType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.DOUBLE, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "y");
@@ -1028,7 +1028,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidXorAssignmentOperationExpr_doubleBoxedWithIntegerBoxedType() {
+  void invalidXorAssignmentOperationExpr_doubleBoxedWithIntegerBoxedType() {
     // Swap case in "invalidXorAssignmentOperationExpr_integerBoxedTypeWithDoubleBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.DOUBLE_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "y");
@@ -1038,7 +1038,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidXorAssignmentOperationExpr_doubleWithIntegerTypes() {
+  void invalidXorAssignmentOperationExpr_doubleWithIntegerTypes() {
     // Swap case in "invalidXorAssignmentOperationExpr_integerWithDoubleTypes".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.DOUBLE, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.INT, "y");
@@ -1048,7 +1048,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidXorAssignmentOperationExpr_doubleBoxedWithIntegerTypes() {
+  void invalidXorAssignmentOperationExpr_doubleBoxedWithIntegerTypes() {
     // Swap case in "invalidXorAssignmentOperationExpr_integerWithDoubleBoxedTypes".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.DOUBLE_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.INT, "y");
@@ -1058,7 +1058,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidXorAssignmentOperationExpr_floatWithCharTypes() {
+  void invalidXorAssignmentOperationExpr_floatWithCharTypes() {
     // Swap case in "invalidXorAssignmentOperationExpr_charWithFloatTypes".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.FLOAT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.CHAR, "y");
@@ -1068,7 +1068,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidXorAssignmentOperationExpr_floatBoxedTypeWithCharTypes() {
+  void invalidXorAssignmentOperationExpr_floatBoxedTypeWithCharTypes() {
     // Swap case in "invalidXorAssignmentOperationExpr_charWithFloatBoxedTypes".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.FLOAT_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.CHAR, "y");
@@ -1078,7 +1078,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidXorAssignmentOperationExpr_integerBoxedTypeWithBooleanTypes() {
+  void invalidXorAssignmentOperationExpr_integerBoxedTypeWithBooleanTypes() {
     // Swap case in "invalidXorAssignmentOperationExpr_booleanWithIntegerBoxedTypes".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.BOOLEAN, "y");
@@ -1088,7 +1088,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidXorAssignmentOperationExpr_integerBoxedWithNullTypes() {
+  void invalidXorAssignmentOperationExpr_integerBoxedWithNullTypes() {
     // No need swap case.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "x");
     ValueExpr rhsExpr = ValueExpr.createNullExpr();
@@ -1098,7 +1098,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidXorAssignmentOperationExpr_integerBoxedWithReferenceTypes() {
+  void invalidXorAssignmentOperationExpr_integerBoxedWithReferenceTypes() {
     // Swap case in invalidXorAssignmentOperationExpr_referenceWithIntegerBoxedTypes.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.STRING, "y");
@@ -1108,7 +1108,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidXorAssignmentOperationExpr_integerBoxedWithNewObjectTypes() {
+  void invalidXorAssignmentOperationExpr_integerBoxedWithNewObjectTypes() {
     // No swap case.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "x");
     NewObjectExpr rhsExpr = NewObjectExpr.withType(TypeNode.OBJECT);
@@ -1119,7 +1119,7 @@ public class AssignmentOperationExprTest {
 
   /** ======= XOR Assignment Operators: LHS is non integer numeric boxed type =========== */
   @Test
-  public void invalidXorAssignmentOperationExpr_longBoxedTypeWithIntegerBoxedType() {
+  void invalidXorAssignmentOperationExpr_longBoxedTypeWithIntegerBoxedType() {
     // Swap case in "validXorAssignmentOperationExpr_integerBoxedTypeWithLongBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.LONG_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "y");
@@ -1129,7 +1129,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidXorAssignmentOperationExpr_shortBoxedTypeWithIntegerBoxedType() {
+  void invalidXorAssignmentOperationExpr_shortBoxedTypeWithIntegerBoxedType() {
     // Swap case in "validXorAssignmentOperationExpr_integerBoxedTypeWithShortBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.SHORT_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "y");
@@ -1139,7 +1139,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidXorAssignmentOperationExpr_charBoxedTypeWithIntegerType() {
+  void invalidXorAssignmentOperationExpr_charBoxedTypeWithIntegerType() {
     // No swap case need.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.CHAR_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.INT, "y");
@@ -1149,7 +1149,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidXorAssignmentOperationExpr_byteBoxedTypeWithIntegerType() {
+  void invalidXorAssignmentOperationExpr_byteBoxedTypeWithIntegerType() {
     // No swap case need.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.BYTE_OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.INT, "y");
@@ -1160,7 +1160,7 @@ public class AssignmentOperationExprTest {
 
   /** ============= XOR Assignment Operators: LHS is non primitive type ================= */
   @Test
-  public void invalidXorAssignmentOperationExpr_referencedTypeWithBooleanTypes() {
+  void invalidXorAssignmentOperationExpr_referencedTypeWithBooleanTypes() {
     // Swap case in "invalidXorAssignmentOperationExpr_booleanWithReferencedTypes".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.STRING, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.BOOLEAN, "y");
@@ -1170,7 +1170,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidXorAssignmentOperationExpr_referencedTypeWithCharTypes() {
+  void invalidXorAssignmentOperationExpr_referencedTypeWithCharTypes() {
     // Swap case in "invalidXorAssignmentOperationExpr_integerWithReferencedTypes".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.STRING, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.CHAR, "y");
@@ -1180,7 +1180,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidXorAssignmentOperationExpr_ReferenceTypeWithIntegerBoxedType() {
+  void invalidXorAssignmentOperationExpr_ReferenceTypeWithIntegerBoxedType() {
     // Swap case in "invalidXorAssignmentOperationExpr_referenceWithIntegerBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.STRING, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "y");
@@ -1190,7 +1190,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidXorAssignmentOperationExpr_voidType() {
+  void invalidXorAssignmentOperationExpr_voidType() {
     // No need swap case.
     VariableExpr lhsExprExpr = createVariableExpr(TypeNode.BOOLEAN, "x");
     MethodInvocationExpr rhsExpr =
@@ -1202,7 +1202,7 @@ public class AssignmentOperationExprTest {
 
   /** =========== XOR Assignment Operators: Variable is declaration ================ */
   @Test
-  public void invalidXorAssignmentOperationExpr_variableExprIsDecl() {
+  void invalidXorAssignmentOperationExpr_variableExprIsDecl() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.INT).build();
     VariableExpr lhsExpr = VariableExpr.builder().setVariable(variable).setIsDecl(true).build();
     VariableExpr rhsExpr = createVariableExpr(TypeNode.INT, "y");
@@ -1212,7 +1212,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidXorAssignmentOperationExpr_valueExprIsDecl() {
+  void invalidXorAssignmentOperationExpr_valueExprIsDecl() {
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT, "x");
     Variable variable = Variable.builder().setName("x").setType(TypeNode.INT).build();
     VariableExpr rhsExpr = VariableExpr.builder().setVariable(variable).setIsDecl(true).build();
@@ -1222,7 +1222,7 @@ public class AssignmentOperationExprTest {
   }
 
   @Test
-  public void invalidXorAssignmentOperationExpr_variableExprAndValueExprIsDecl() {
+  void invalidXorAssignmentOperationExpr_variableExprAndValueExprIsDecl() {
     Variable lVariable = Variable.builder().setName("x").setType(TypeNode.INT).build();
     VariableExpr lhsExpr = VariableExpr.builder().setVariable(lVariable).setIsDecl(true).build();
     Variable rVariable = Variable.builder().setName("y").setType(TypeNode.INT).build();

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/CastExprTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/CastExprTest.java
@@ -16,11 +16,11 @@ package com.google.api.generator.engine.ast;
 
 import static org.junit.Assert.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class CastExprTest {
+class CastExprTest {
   @Test
-  public void validCastExpr_basic() {
+  void validCastExpr_basic() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.STRING).build();
     VariableExpr variableExpr = VariableExpr.builder().setVariable(variable).build();
     CastExpr.builder()
@@ -31,7 +31,7 @@ public class CastExprTest {
   }
 
   @Test
-  public void validCastExpr_basicNull() {
+  void validCastExpr_basicNull() {
     CastExpr.builder()
         .setType(TypeNode.withReference(ConcreteReference.withClazz(Object.class)))
         .setExpr(ValueExpr.createNullExpr())
@@ -40,7 +40,7 @@ public class CastExprTest {
   }
 
   @Test
-  public void validCastExpr_basicPrimitiveSame() {
+  void validCastExpr_basicPrimitiveSame() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.LONG).build();
     VariableExpr variableExpr = VariableExpr.builder().setVariable(variable).build();
     CastExpr.builder().setType(TypeNode.LONG).setExpr(variableExpr).build();
@@ -48,7 +48,7 @@ public class CastExprTest {
   }
 
   @Test
-  public void validCastExpr_basicPrimitiveBoolean() {
+  void validCastExpr_basicPrimitiveBoolean() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.BOOLEAN).build();
     VariableExpr variableExpr = VariableExpr.builder().setVariable(variable).build();
     CastExpr.builder().setType(TypeNode.BOOLEAN).setExpr(variableExpr).build();
@@ -56,7 +56,7 @@ public class CastExprTest {
   }
 
   @Test
-  public void validCastExpr_basicPrimitiveNarrowing() {
+  void validCastExpr_basicPrimitiveNarrowing() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.LONG).build();
     VariableExpr variableExpr = VariableExpr.builder().setVariable(variable).build();
     CastExpr.builder().setType(TypeNode.INT).setExpr(variableExpr).build();
@@ -70,7 +70,7 @@ public class CastExprTest {
   }
 
   @Test
-  public void validCastExpr_basicPrimitiveWidening() {
+  void validCastExpr_basicPrimitiveWidening() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.INT).build();
     VariableExpr variableExpr = VariableExpr.builder().setVariable(variable).build();
     CastExpr.builder().setType(TypeNode.LONG).setExpr(variableExpr).build();
@@ -83,21 +83,21 @@ public class CastExprTest {
   }
 
   @Test
-  public void validCastExpr_castPrimitiveToBoxedType() {
+  void validCastExpr_castPrimitiveToBoxedType() {
     PrimitiveValue intValue = PrimitiveValue.builder().setValue("3").setType(TypeNode.INT).build();
     ValueExpr valueExpr = ValueExpr.withValue(intValue);
     CastExpr.builder().setType(TypeNode.INT_OBJECT).setExpr(valueExpr).build();
   }
 
   @Test
-  public void validCastExpr_castBoxedTypeToPrimitive() {
+  void validCastExpr_castBoxedTypeToPrimitive() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.DOUBLE_OBJECT).build();
     VariableExpr variableExpr = VariableExpr.builder().setVariable(variable).build();
     CastExpr.builder().setType(TypeNode.DOUBLE).setExpr(variableExpr).build();
   }
 
   @Test
-  public void validCastExpr_booleanToBoxedType() {
+  void validCastExpr_booleanToBoxedType() {
     PrimitiveValue booleanValue =
         PrimitiveValue.builder().setValue("true").setType(TypeNode.BOOLEAN).build();
     ValueExpr valueExpr = ValueExpr.withValue(booleanValue);
@@ -105,14 +105,14 @@ public class CastExprTest {
   }
 
   @Test
-  public void validCastExpr_castBooleanToPrimitive() {
+  void validCastExpr_castBooleanToPrimitive() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.BOOLEAN_OBJECT).build();
     VariableExpr variableExpr = VariableExpr.builder().setVariable(variable).build();
     CastExpr.builder().setType(TypeNode.BOOLEAN).setExpr(variableExpr).build();
   }
 
   @Test
-  public void invalidCastExpr_castBoxedPrimitiveArray() {
+  void invalidCastExpr_castBoxedPrimitiveArray() {
     TypeNode intArray =
         TypeNode.builder().setTypeKind(TypeNode.TypeKind.INT).setIsArray(true).build();
     TypeNode integerArray =
@@ -129,7 +129,7 @@ public class CastExprTest {
   }
 
   @Test
-  public void invalidCastExpr_castObjectToPrimitive() {
+  void invalidCastExpr_castObjectToPrimitive() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.STRING).build();
     VariableExpr variableExpr = VariableExpr.builder().setVariable(variable).build();
     assertThrows(
@@ -138,7 +138,7 @@ public class CastExprTest {
   }
 
   @Test
-  public void invalidCastExpr_castPrimitiveToObject() {
+  void invalidCastExpr_castPrimitiveToObject() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.INT).build();
     VariableExpr variableExpr = VariableExpr.builder().setVariable(variable).build();
     assertThrows(
@@ -151,7 +151,7 @@ public class CastExprTest {
   }
 
   @Test
-  public void invalidCastExpr_castBooleanToNumeric() {
+  void invalidCastExpr_castBooleanToNumeric() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.BOOLEAN).build();
     VariableExpr variableExpr = VariableExpr.builder().setVariable(variable).build();
     assertThrows(
@@ -160,7 +160,7 @@ public class CastExprTest {
   }
 
   @Test
-  public void invalidCastExpr_castNumericToBoolean() {
+  void invalidCastExpr_castNumericToBoolean() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.INT).build();
     VariableExpr variableExpr = VariableExpr.builder().setVariable(variable).build();
     assertThrows(
@@ -169,7 +169,7 @@ public class CastExprTest {
   }
 
   @Test
-  public void invalidCastExpr_castToVoidType() {
+  void invalidCastExpr_castToVoidType() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.INT).build();
     VariableExpr variableExpr = VariableExpr.builder().setVariable(variable).build();
     assertThrows(

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/ClassDefinitionTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/ClassDefinitionTest.java
@@ -18,12 +18,12 @@ import static org.junit.Assert.assertThrows;
 
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ClassDefinitionTest {
+class ClassDefinitionTest {
 
   @Test
-  public void validClassDefinition_basicWithCommentsAndHeader() {
+  void validClassDefinition_basicWithCommentsAndHeader() {
     LineComment lineComment = LineComment.withComment("AUTO-GENERATED DOCUMENTATION AND CLASS");
     JavaDocComment javaDocComment =
         JavaDocComment.builder()
@@ -45,7 +45,7 @@ public class ClassDefinitionTest {
   }
 
   @Test
-  public void validClassDefinition_exprCommentAndBlockStatements() {
+  void validClassDefinition_exprCommentAndBlockStatements() {
     ClassDefinition.builder()
         .setName("LibraryServiceStub")
         .setIsNested(true)
@@ -74,7 +74,7 @@ public class ClassDefinitionTest {
   }
 
   @Test
-  public void validClassDefinition_nestedBasic() {
+  void validClassDefinition_nestedBasic() {
     ClassDefinition.builder()
         .setName("LibraryServiceStub")
         .setIsNested(true)
@@ -92,7 +92,7 @@ public class ClassDefinitionTest {
   }
 
   @Test
-  public void validClassDefinition_withAnnotationsExtendsAndImplements() {
+  void validClassDefinition_withAnnotationsExtendsAndImplements() {
     ClassDefinition.builder()
         .setPackageString("com.google.example.library.v1.stub")
         .setName("LibraryServiceStub")
@@ -110,7 +110,7 @@ public class ClassDefinitionTest {
   }
 
   @Test
-  public void validClassDefinition_statementsAndMethods() {
+  void validClassDefinition_statementsAndMethods() {
     List<Statement> statements =
         Arrays.asList(
             ExprStatement.withExpr(createAssignmentExpr()),
@@ -149,7 +149,7 @@ public class ClassDefinitionTest {
   }
 
   @Test
-  public void invalidClassDefinition_nestedWithFileHeader() {
+  void invalidClassDefinition_nestedWithFileHeader() {
     assertThrows(
         IllegalStateException.class,
         () -> {
@@ -164,7 +164,7 @@ public class ClassDefinitionTest {
   }
 
   @Test
-  public void invalidClassDefinition_implementsNullType() {
+  void invalidClassDefinition_implementsNullType() {
     assertThrows(
         IllegalStateException.class,
         () -> {
@@ -178,7 +178,7 @@ public class ClassDefinitionTest {
   }
 
   @Test
-  public void invalidClassDefinition_outerClassMissingPackage() {
+  void invalidClassDefinition_outerClassMissingPackage() {
     assertThrows(
         NullPointerException.class,
         () -> {
@@ -190,7 +190,7 @@ public class ClassDefinitionTest {
   }
 
   @Test
-  public void invalidClassDefinition_outerClassStatic() {
+  void invalidClassDefinition_outerClassStatic() {
     assertThrows(
         IllegalStateException.class,
         () -> {
@@ -204,7 +204,7 @@ public class ClassDefinitionTest {
   }
 
   @Test
-  public void invalidClassDefinition_outerClassPrivate() {
+  void invalidClassDefinition_outerClassPrivate() {
     assertThrows(
         IllegalStateException.class,
         () -> {
@@ -217,7 +217,7 @@ public class ClassDefinitionTest {
   }
 
   @Test
-  public void invalidClassDefinition_extendsPrimitiveType() {
+  void invalidClassDefinition_extendsPrimitiveType() {
     assertThrows(
         IllegalStateException.class,
         () -> {
@@ -231,7 +231,7 @@ public class ClassDefinitionTest {
   }
 
   @Test
-  public void invalidClassDefinition_extendsNullType() {
+  void invalidClassDefinition_extendsNullType() {
     assertThrows(
         IllegalStateException.class,
         () -> {
@@ -245,7 +245,7 @@ public class ClassDefinitionTest {
   }
 
   @Test
-  public void invalidClassDefinition_abstractFinal() {
+  void invalidClassDefinition_abstractFinal() {
     assertThrows(
         IllegalStateException.class,
         () -> {
@@ -261,7 +261,7 @@ public class ClassDefinitionTest {
   }
 
   @Test
-  public void invalidClassDefinition_implementsPrimtiveType() {
+  void invalidClassDefinition_implementsPrimtiveType() {
     assertThrows(
         IllegalStateException.class,
         () -> {
@@ -275,7 +275,7 @@ public class ClassDefinitionTest {
   }
 
   @Test
-  public void invalidClassDefinition_extendsImplementsSameType() {
+  void invalidClassDefinition_extendsImplementsSameType() {
     TypeNode cloneableType = TypeNode.withReference(ConcreteReference.withClazz(Cloneable.class));
     assertThrows(
         IllegalStateException.class,
@@ -294,7 +294,7 @@ public class ClassDefinitionTest {
   }
 
   @Test
-  public void invalidClassDefinition_assignmentWithUnscopedVariableExprStatement() {
+  void invalidClassDefinition_assignmentWithUnscopedVariableExprStatement() {
     Variable variable = createVariable("x", TypeNode.INT);
     VariableExpr variableExpr =
         VariableExpr.builder().setVariable(variable).setIsDecl(true).build();
@@ -319,7 +319,7 @@ public class ClassDefinitionTest {
   }
 
   @Test
-  public void invalidClassDefinition_unscopedVariableExprStatement() {
+  void invalidClassDefinition_unscopedVariableExprStatement() {
     List<Statement> statements =
         Arrays.asList(
             ExprStatement.withExpr(createAssignmentExpr()),
@@ -341,7 +341,7 @@ public class ClassDefinitionTest {
   }
 
   @Test
-  public void invalidClassDefinition_badStatementType() {
+  void invalidClassDefinition_badStatementType() {
     List<Statement> statements = Arrays.asList(createForStatement());
     assertThrows(
         IllegalStateException.class,

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/ConcreteReferenceTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/ConcreteReferenceTest.java
@@ -23,18 +23,18 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ConcreteReferenceTest {
+class ConcreteReferenceTest {
   @Test
-  public void basicConcreteReference() {
+  void basicConcreteReference() {
     Reference reference = ConcreteReference.builder().setClazz(Integer.class).build();
     assertEquals(Integer.class.getSimpleName(), reference.name());
     assertFalse(reference.isStaticImport());
   }
 
   @Test
-  public void basicConcreteReference_setIsStaticImport() {
+  void basicConcreteReference_setIsStaticImport() {
     Reference reference =
         ConcreteReference.builder().setClazz(Integer.class).setIsStaticImport(true).build();
     assertEquals(Integer.class.getSimpleName(), reference.name());
@@ -42,14 +42,14 @@ public class ConcreteReferenceTest {
   }
 
   @Test
-  public void basicConcreteReference_nested() {
+  void basicConcreteReference_nested() {
     Reference reference = ConcreteReference.builder().setClazz(Map.Entry.class).build();
     assertEquals("Map.Entry", reference.name());
     assertFalse(reference.isStaticImport());
   }
 
   @Test
-  public void basicConcreteReference_nestedAndStaticImport() {
+  void basicConcreteReference_nestedAndStaticImport() {
     Reference reference =
         ConcreteReference.builder().setClazz(Map.Entry.class).setIsStaticImport(true).build();
     assertEquals(Map.Entry.class.getSimpleName(), reference.name());
@@ -57,7 +57,7 @@ public class ConcreteReferenceTest {
   }
 
   @Test
-  public void parameterizedConcreteReference() {
+  void parameterizedConcreteReference() {
     Reference reference =
         ConcreteReference.builder()
             .setClazz(HashMap.class)
@@ -71,7 +71,7 @@ public class ConcreteReferenceTest {
   }
 
   @Test
-  public void nestedParameterizedConcreteReference() {
+  void nestedParameterizedConcreteReference() {
     Reference mapReference =
         ConcreteReference.builder()
             .setClazz(HashMap.class)
@@ -96,7 +96,7 @@ public class ConcreteReferenceTest {
   }
 
   @Test
-  public void isSupertype_basic() {
+  void isSupertype_basic() {
     assertTrue(TypeNode.STRING.isSupertypeOrEquals(TypeNode.STRING));
     assertFalse(TypeNode.INT.isSupertypeOrEquals(TypeNode.STRING));
     assertFalse(TypeNode.STRING.isSupertypeOrEquals(TypeNode.INT));
@@ -109,7 +109,7 @@ public class ConcreteReferenceTest {
   }
 
   @Test
-  public void isSupertype_nestedGenerics() {
+  void isSupertype_nestedGenerics() {
     Reference stringRef = ConcreteReference.withClazz(String.class);
     TypeNode typeOne =
         TypeNode.withReference(
@@ -142,7 +142,7 @@ public class ConcreteReferenceTest {
   }
 
   @Test
-  public void wildcards() {
+  void wildcards() {
     assertEquals(ConcreteReference.wildcard().name(), "?");
     assertEquals(
         "? extends String",
@@ -150,7 +150,7 @@ public class ConcreteReferenceTest {
   }
 
   @Test
-  public void isAssignableFrom_concreteRef() {
+  void isAssignableFrom_concreteRef() {
     assertFalse(
         ConcreteReference.withClazz(List.class)
             .isAssignableFrom(ConcreteReference.withClazz(Map.class)));
@@ -195,7 +195,7 @@ public class ConcreteReferenceTest {
   }
 
   @Test
-  public void isAssignableFrom_vaporRef() {
+  void isAssignableFrom_vaporRef() {
     assertFalse(
         ConcreteReference.withClazz(List.class)
             .isAssignableFrom(
@@ -207,7 +207,7 @@ public class ConcreteReferenceTest {
   }
 
   @Test
-  public void isAssignableFrom_vaporRefWithConcreteRefSupertype() {
+  void isAssignableFrom_vaporRefWithConcreteRefSupertype() {
     assertTrue(
         ConcreteReference.withClazz(List.class)
             .isAssignableFrom(

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/EnumRefExprTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/EnumRefExprTest.java
@@ -16,25 +16,25 @@ package com.google.api.generator.engine.ast;
 
 import static org.junit.Assert.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class EnumRefExprTest {
+class EnumRefExprTest {
   @Test
-  public void validEnumRefExpr_basic() {
+  void validEnumRefExpr_basic() {
     TypeNode enumType =
         TypeNode.withReference(ConcreteReference.withClazz(TypeNode.TypeKind.class));
     EnumRefExpr.builder().setName("VOID").setType(enumType).build();
   }
 
   @Test
-  public void invalidEnumRefExpr_primitiveType() {
+  void invalidEnumRefExpr_primitiveType() {
     assertThrows(
         IllegalStateException.class,
         () -> EnumRefExpr.builder().setName("VOID").setType(TypeNode.INT).build());
   }
 
   @Test
-  public void invalidEnumRefExpr_nullType() {
+  void invalidEnumRefExpr_nullType() {
     assertThrows(
         IllegalStateException.class,
         () -> EnumRefExpr.builder().setName("VOID").setType(TypeNode.NULL).build());

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/ExprStatementTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/ExprStatementTest.java
@@ -17,12 +17,12 @@ package com.google.api.generator.engine.ast;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ExprStatementTest {
+class ExprStatementTest {
 
   @Test
-  public void validExprStatement_method() {
+  void validExprStatement_method() {
     TypeNode someType =
         TypeNode.withReference(
             VaporReference.builder()
@@ -39,13 +39,13 @@ public class ExprStatementTest {
   }
 
   @Test
-  public void validExprStatement_variable() {
+  void validExprStatement_variable() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.INT).build();
     assertValidExprStatement(VariableExpr.builder().setVariable(variable).setIsDecl(true).build());
   }
 
   @Test
-  public void validExprStatement_assignment() {
+  void validExprStatement_assignment() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.INT).build();
     VariableExpr variableExpr =
         VariableExpr.builder().setVariable(variable).setIsDecl(true).build();
@@ -59,20 +59,20 @@ public class ExprStatementTest {
   }
 
   @Test
-  public void validExprStatement_throw() {
+  void validExprStatement_throw() {
     TypeNode npeType =
         TypeNode.withReference(ConcreteReference.withClazz(NullPointerException.class));
     assertValidExprStatement(ThrowExpr.builder().setType(npeType).build());
   }
 
   @Test
-  public void validExprStatement_return() {
+  void validExprStatement_return() {
     assertValidExprStatement(
         ReturnExpr.withExpr(ValueExpr.withValue(StringObjectValue.withValue("asdf"))));
   }
 
   @Test
-  public void validExprStatement_unaryOperation() {
+  void validExprStatement_unaryOperation() {
     assertValidExprStatement(
         UnaryOperationExpr.postfixIncrementWithExpr(
             VariableExpr.withVariable(
@@ -80,7 +80,7 @@ public class ExprStatementTest {
   }
 
   @Test
-  public void validExprStatement_assignmentOperationExpr() {
+  void validExprStatement_assignmentOperationExpr() {
     VariableExpr lhsExpr =
         VariableExpr.withVariable(Variable.builder().setName("i").setType(TypeNode.INT).build());
     ValueExpr rhsExpr =
@@ -89,21 +89,21 @@ public class ExprStatementTest {
   }
 
   @Test
-  public void invalidExprStatement_variable() {
+  void invalidExprStatement_variable() {
     Variable variable = Variable.builder().setType(TypeNode.INT).setName("libraryClient").build();
     VariableExpr varExpr = VariableExpr.builder().setVariable(variable).build();
     assertInvalidExprStatement(varExpr);
   }
 
   @Test
-  public void invalidExprStatement_value() {
+  void invalidExprStatement_value() {
     Value value = PrimitiveValue.builder().setType(TypeNode.INT).setValue("3").build();
     ValueExpr valueExpr = ValueExpr.builder().setValue(value).build();
     assertInvalidExprStatement(valueExpr);
   }
 
   @Test
-  public void invalidExprStatement_logicalNotUnaryOperator() {
+  void invalidExprStatement_logicalNotUnaryOperator() {
     Expr logicalNotExpr =
         UnaryOperationExpr.logicalNotWithExpr(
             VariableExpr.withVariable(

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/ForStatementTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/ForStatementTest.java
@@ -18,12 +18,12 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import java.util.Arrays;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ForStatementTest {
+class ForStatementTest {
 
   @Test
-  public void validForStatement() {
+  void validForStatement() {
     Variable variable = Variable.builder().setName("str").setType(TypeNode.STRING).build();
     VariableExpr variableExpr =
         VariableExpr.builder().setVariable(variable).setIsDecl(true).build();
@@ -41,7 +41,7 @@ public class ForStatementTest {
   }
 
   @Test
-  public void invalidForStatement() {
+  void invalidForStatement() {
     Variable variable = Variable.builder().setName("str").setType(TypeNode.STRING).build();
     VariableExpr variableExpr = VariableExpr.builder().setVariable(variable).build();
 

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/GeneralForStatementTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/GeneralForStatementTest.java
@@ -18,13 +18,13 @@ import static org.junit.Assert.assertThrows;
 
 import java.util.Arrays;
 import java.util.Collections;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class GeneralForStatementTest {
+class GeneralForStatementTest {
   /** ============================== incrementWith ====================================== */
   @Test
   // validGeneralForStatement_basicIsDecl tests declare a variable inside in initialization expr.
-  public void validGeneralForStatement_basicIsDecl() {
+  void validGeneralForStatement_basicIsDecl() {
     Variable variable = Variable.builder().setName("i").setType(TypeNode.INT).build();
     VariableExpr variableExpr =
         VariableExpr.builder().setVariable(variable).setIsDecl(true).build();
@@ -41,7 +41,7 @@ public class GeneralForStatementTest {
   @Test
   // validGeneralForStatement_basicIsNotDecl tests assigning a method-level local variable in
   // initialization expr.
-  public void validGeneralForStatement_basicIsNotDecl() {
+  void validGeneralForStatement_basicIsNotDecl() {
     Variable variable = Variable.builder().setName("i").setType(TypeNode.INT).build();
     VariableExpr variableExpr =
         VariableExpr.builder().setVariable(variable).setIsDecl(false).build();
@@ -57,7 +57,7 @@ public class GeneralForStatementTest {
 
   @Test
   // validGeneralForStatement_emptyBody tests set empty body in update expr.
-  public void validGeneralForStatement_emptyBody() {
+  void validGeneralForStatement_emptyBody() {
     Variable variable = Variable.builder().setName("i").setType(TypeNode.INT).build();
     VariableExpr variableExpr =
         VariableExpr.builder().setVariable(variable).setIsDecl(false).build();
@@ -74,7 +74,7 @@ public class GeneralForStatementTest {
   @Test
   // validForStatement_privateNotIsDeclVariable tests assigning an instance variable with private
   // scope.
-  public void validForStatement_privateNotIsDeclVariable() {
+  void validForStatement_privateNotIsDeclVariable() {
     Variable variable = Variable.builder().setName("i").setType(TypeNode.INT).build();
     VariableExpr variableExpr =
         VariableExpr.builder()
@@ -91,9 +91,9 @@ public class GeneralForStatementTest {
   }
 
   @Test
-  // validForStatement_instanceStaticVariable tests assigning an instance variable with public scope
+  // validForStatement_instanceStaticVariable tests assigning an instance variable with scope
   // and static modifier.
-  public void validForStatement_instanceStaticVariable() {
+  void validForStatement_instanceStaticVariable() {
     Variable variable = Variable.builder().setName("i").setType(TypeNode.INT).build();
     VariableExpr variableExpr =
         VariableExpr.builder()
@@ -113,7 +113,7 @@ public class GeneralForStatementTest {
   @Test
   // invalidForStatement_privateIsDeclVariable tests declaring a non-local variable inside of
   // for-loop.
-  public void invalidForStatement_privateIsDeclVariable() {
+  void invalidForStatement_privateIsDeclVariable() {
     Variable variable = Variable.builder().setName("i").setType(TypeNode.INT).build();
     VariableExpr variableExpr =
         VariableExpr.builder()
@@ -136,7 +136,7 @@ public class GeneralForStatementTest {
   @Test
   // invalidForStatement_staticIsDeclVariable tests declare a static local variable in
   // initialization expr.
-  public void invalidForStatement_staticIsDeclVariable() {
+  void invalidForStatement_staticIsDeclVariable() {
     Variable variable = Variable.builder().setName("i").setType(TypeNode.INT).build();
     VariableExpr variableExpr =
         VariableExpr.builder().setVariable(variable).setIsDecl(true).setIsStatic(true).build();
@@ -155,7 +155,7 @@ public class GeneralForStatementTest {
   @Test
   // invalidForStatement_finalIsNotDeclVariable tests invalid case of assigning the initial value to
   // a variable which is declared as a final instance variable.
-  public void invalidForStatement_finalIsNotDeclVariable() {
+  void invalidForStatement_finalIsNotDeclVariable() {
     Variable variable = Variable.builder().setName("i").setType(TypeNode.INT).build();
     VariableExpr variableExpr =
         VariableExpr.builder()
@@ -179,7 +179,7 @@ public class GeneralForStatementTest {
   @Test
   // invalidForStatement_localFinalVariable tests declare a final variable in initialization expr,
   // updateExpr should throw error.
-  public void invalidForStatement_localFinalVariable() {
+  void invalidForStatement_localFinalVariable() {
     Variable variable = Variable.builder().setName("i").setType(TypeNode.INT).build();
     VariableExpr variableExpr =
         VariableExpr.builder().setVariable(variable).setIsDecl(true).setIsFinal(true).build();

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/IdentifierNodeTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/IdentifierNodeTest.java
@@ -18,11 +18,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 import com.google.api.generator.engine.ast.IdentifierNode.InvalidIdentifierException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class IdentifierNodeTest {
+class IdentifierNodeTest {
   @Test
-  public void createIdentifier_basic() {
+  void createIdentifier_basic() {
     assertValidIdentifier("foobar");
     assertValidIdentifier("x");
     assertValidIdentifier("afalse");
@@ -34,7 +34,7 @@ public class IdentifierNodeTest {
   }
 
   @Test
-  public void createIdentifier_nameHasLiteral() {
+  void createIdentifier_nameHasLiteral() {
     assertValidIdentifier("a123L");
     assertValidIdentifier("a10e3");
     assertValidIdentifier("anull");
@@ -51,7 +51,7 @@ public class IdentifierNodeTest {
   }
 
   @Test
-  public void createIdentifier_namdHasInvalidSymbols() {
+  void createIdentifier_namdHasInvalidSymbols() {
     assertInvalidIdentifier("a.b");
     assertInvalidIdentifier("a,b");
     assertInvalidIdentifier("a-b");
@@ -81,7 +81,7 @@ public class IdentifierNodeTest {
   }
 
   @Test
-  public void createIdentifier_nameHasKeyword() {
+  void createIdentifier_nameHasKeyword() {
     assertValidIdentifier("aclass");
 
     // Random sampling of keywords.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/IfStatementTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/IfStatementTest.java
@@ -18,11 +18,11 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class IfStatementTest {
+class IfStatementTest {
   @Test
-  public void validIfStatement_simple() {
+  void validIfStatement_simple() {
     IfStatement ifStatement =
         IfStatement.builder()
             .setConditionExpr(createConditionExpr("condition"))
@@ -32,7 +32,7 @@ public class IfStatementTest {
   }
 
   @Test
-  public void validIfStatement_booleanObjectCondition() {
+  void validIfStatement_booleanObjectCondition() {
     // The condition expression type can be boolean or its boxed type.
     VariableExpr condExpr =
         VariableExpr.withVariable(
@@ -47,7 +47,7 @@ public class IfStatementTest {
   }
 
   @Test
-  public void validIfStatement_elseIfsAndElse() {
+  void validIfStatement_elseIfsAndElse() {
     VariableExpr condExpr = createConditionExpr("condition");
     VariableExpr secondCondExpr = createConditionExpr("secondCondExpr");
     VariableExpr thirdCondExpr = createConditionExpr("thirdCondExpr");
@@ -64,7 +64,7 @@ public class IfStatementTest {
   }
 
   @Test
-  public void validIfStatement_nested() {
+  void validIfStatement_nested() {
     VariableExpr condExpr = createConditionExpr("condition");
     VariableExpr nestedCondExpr = createConditionExpr("nestedCondition");
     IfStatement nestedIfStatement =

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/InstanceofExprTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/InstanceofExprTest.java
@@ -17,11 +17,11 @@ package com.google.api.generator.engine.ast;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class InstanceofExprTest {
+class InstanceofExprTest {
   @Test
-  public void validInstanceofExpr_basicExprPrimitiveType() {
+  void validInstanceofExpr_basicExprPrimitiveType() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.INT).build();
     VariableExpr variableExpr = VariableExpr.builder().setVariable(variable).build();
     InstanceofExpr expr =
@@ -32,7 +32,7 @@ public class InstanceofExprTest {
   }
 
   @Test
-  public void validInstanceofExpr_basicExprObjectType() {
+  void validInstanceofExpr_basicExprObjectType() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.STRING).build();
     VariableExpr variableExpr = VariableExpr.builder().setVariable(variable).build();
     InstanceofExpr.builder().setCheckType(TypeNode.STRING).setExpr(variableExpr).build();
@@ -40,7 +40,7 @@ public class InstanceofExprTest {
   }
 
   @Test
-  public void invalidInstanceofExpr_primitiveObjectType() {
+  void invalidInstanceofExpr_primitiveObjectType() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.STRING).build();
     VariableExpr variableExpr = VariableExpr.builder().setVariable(variable).build();
     assertThrows(

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/JavaDocCommentTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/JavaDocCommentTest.java
@@ -19,11 +19,11 @@ import static org.junit.Assert.assertEquals;
 import com.google.api.generator.test.utils.LineFormatter;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class JavaDocCommentTest {
+class JavaDocCommentTest {
   @Test
-  public void emptyJavaDocComment() {
+  void emptyJavaDocComment() {
     JavaDocComment.Builder javaDocCommentBuilder = JavaDocComment.builder();
     assertEquals(true, javaDocCommentBuilder.emptyComments());
 
@@ -33,14 +33,14 @@ public class JavaDocCommentTest {
   }
 
   @Test
-  public void createJavaDocComment_basic() {
+  void createJavaDocComment_basic() {
     String content = "this is a test comment";
     JavaDocComment javaDocComment = JavaDocComment.builder().addComment(content).build();
     assertEquals(content, javaDocComment.comment());
   }
 
   @Test
-  public void createJavaDocComment_specialCharacter() {
+  void createJavaDocComment_specialCharacter() {
     // Check that we handle special characters correctly which includes escape characters,
     // html escape characters and unexpected block end `*/`.
     JavaDocComment javaDocComment =
@@ -67,7 +67,7 @@ public class JavaDocCommentTest {
   }
 
   @Test
-  public void createJavaDocComment_sampleCode() {
+  void createJavaDocComment_sampleCode() {
     String comment = "sample codes:";
     String sampleCode = "resource = project/{project}/shelfId/{shelfId}";
     JavaDocComment javaDocComment =
@@ -82,7 +82,7 @@ public class JavaDocCommentTest {
   }
 
   @Test
-  public void createJavaDocComment_sampleCodePreserveIndentAndLineBreaks() {
+  void createJavaDocComment_sampleCodePreserveIndentAndLineBreaks() {
     String comment = "sample codes:";
     String formattedSampleCode =
         LineFormatter.lines(
@@ -107,7 +107,7 @@ public class JavaDocCommentTest {
   }
 
   @Test
-  public void createJavaDocComment_multipleComments() {
+  void createJavaDocComment_multipleComments() {
     // Add methods, like `addComment()`, should add components at any place,
     // and they will get printed in order.
     String comment1 = "This is a test comment.";
@@ -142,7 +142,7 @@ public class JavaDocCommentTest {
   }
 
   @Test
-  public void createJavaDocComment_multipleParams() {
+  void createJavaDocComment_multipleParams() {
     // Parameters should be grouped together and get printed after block comments.
     String comment = "This is a block comment.";
     String paramName1 = "shelfName";
@@ -163,7 +163,7 @@ public class JavaDocCommentTest {
   }
 
   @Test
-  public void createJavaDocComment_multipleParamsAndReturn() {
+  void createJavaDocComment_multipleParamsAndReturn() {
     // Parameters should be grouped together and get printed after block comments.
     // Return text should get printed at the very end.
     String comment = "This is a block comment.";
@@ -188,7 +188,7 @@ public class JavaDocCommentTest {
   }
 
   @Test
-  public void createJavaDocComment_throwsAndDeprecatedAndReturn() {
+  void createJavaDocComment_throwsAndDeprecatedAndReturn() {
     // No matter how many times or order `setThrows`, `setDeprecated`, `setReturn` are called,
     // only one @throws, @deprecated, and @return will be printed.
     String throwsType = "com.google.api.gax.rpc.ApiException";
@@ -220,7 +220,7 @@ public class JavaDocCommentTest {
   }
 
   @Test
-  public void createJavaDocComment_allComponents() {
+  void createJavaDocComment_allComponents() {
     // No matter what order `setThrows`, `setDeprecated`, and `setReturn` are called,
     // They will be printed at the end. And `@param` should be grouped,
     // they should always be printed right before `@throws`, `@deprecated`, and `@return`.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/LambdaExprTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/LambdaExprTest.java
@@ -18,18 +18,18 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 import java.util.Arrays;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class LambdaExprTest {
+class LambdaExprTest {
   @Test
-  public void validLambdaExpr_noArguments() {
+  void validLambdaExpr_noArguments() {
     LambdaExpr.builder()
         .setReturnExpr(ValueExpr.withValue(StringObjectValue.withValue("foo")))
         .build();
   }
 
   @Test
-  public void validLambdaExpr_inferTypeFromReturnExpr() {
+  void validLambdaExpr_inferTypeFromReturnExpr() {
     LambdaExpr lambdaExpr =
         LambdaExpr.builder()
             .setReturnExpr(ValueExpr.withValue(StringObjectValue.withValue("foo")))
@@ -38,7 +38,7 @@ public class LambdaExprTest {
   }
 
   @Test
-  public void validLambdaExpr_severalArguments() {
+  void validLambdaExpr_severalArguments() {
     VariableExpr argOneVarExpr =
         VariableExpr.builder()
             .setVariable(Variable.builder().setName("arg").setType(TypeNode.INT).build())
@@ -62,7 +62,7 @@ public class LambdaExprTest {
   }
 
   @Test
-  public void validLambdaExpr_withBody() {
+  void validLambdaExpr_withBody() {
     VariableExpr fooVarExpr =
         VariableExpr.builder()
             .setVariable(Variable.builder().setName("foo").setType(TypeNode.INT).build())
@@ -85,7 +85,7 @@ public class LambdaExprTest {
   }
 
   @Test
-  public void validLambdaExpr_returnsVoid() {
+  void validLambdaExpr_returnsVoid() {
     LambdaExpr voidLambda =
         LambdaExpr.builder()
             .setReturnExpr(
@@ -98,7 +98,7 @@ public class LambdaExprTest {
   }
 
   @Test
-  public void invalidLambdaExpr_undeclaredArgVarExpr() {
+  void invalidLambdaExpr_undeclaredArgVarExpr() {
     VariableExpr argVarExpr =
         VariableExpr.builder()
             .setVariable(Variable.builder().setName("arg").setType(TypeNode.INT).build())
@@ -114,7 +114,7 @@ public class LambdaExprTest {
   }
 
   @Test
-  public void invalidLambdaExpr_argVarExprWithModifiers() {
+  void invalidLambdaExpr_argVarExprWithModifiers() {
     VariableExpr argVarExpr =
         VariableExpr.builder()
             .setVariable(Variable.builder().setName("arg").setType(TypeNode.INT).build())
@@ -132,7 +132,7 @@ public class LambdaExprTest {
   }
 
   @Test
-  public void invalidLambdaExpr_argVarExprWithNonLocalScope() {
+  void invalidLambdaExpr_argVarExprWithNonLocalScope() {
     VariableExpr argVarExpr =
         VariableExpr.builder()
             .setVariable(Variable.builder().setName("arg").setType(TypeNode.INT).build())
@@ -150,7 +150,7 @@ public class LambdaExprTest {
   }
 
   @Test
-  public void invalidLambdaExpr_repeatedArgName() {
+  void invalidLambdaExpr_repeatedArgName() {
     VariableExpr argOneVarExpr =
         VariableExpr.builder()
             .setVariable(Variable.builder().setName("arg").setType(TypeNode.INT).build())

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/LogicalOperationExprTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/LogicalOperationExprTest.java
@@ -16,12 +16,12 @@ package com.google.api.generator.engine.ast;
 
 import static org.junit.Assert.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class LogicalOperationExprTest {
+class LogicalOperationExprTest {
   /** =============================== Logic And Operation Expr =============================== */
   @Test
-  public void logicalAnd_validBasic() {
+  void logicalAnd_validBasic() {
     VariableExpr lhsExpr =
         VariableExpr.withVariable(
             Variable.builder().setType(TypeNode.BOOLEAN).setName("isGood").build());
@@ -33,7 +33,7 @@ public class LogicalOperationExprTest {
   }
 
   @Test
-  public void logicalAnd_validBoxedBoolean() {
+  void logicalAnd_validBoxedBoolean() {
     VariableExpr lhsExpr =
         VariableExpr.withVariable(
             Variable.builder().setType(TypeNode.BOOLEAN).setName("isGood").build());
@@ -45,7 +45,7 @@ public class LogicalOperationExprTest {
   }
 
   @Test
-  public void logicalAnd_invalidNumericType() {
+  void logicalAnd_invalidNumericType() {
     VariableExpr lhsExpr =
         VariableExpr.withVariable(Variable.builder().setType(TypeNode.INT).setName("x").build());
     VariableExpr rhsExpr =
@@ -57,7 +57,7 @@ public class LogicalOperationExprTest {
   }
 
   @Test
-  public void logicalAnd_invalidStringType() {
+  void logicalAnd_invalidStringType() {
     VariableExpr lhsExpr =
         VariableExpr.withVariable(
             Variable.builder().setType(TypeNode.BOOLEAN_OBJECT).setName("x").build());
@@ -71,7 +71,7 @@ public class LogicalOperationExprTest {
 
   /** =============================== Logic Or Operation Expr =============================== */
   @Test
-  public void logicalOr_validBoxedBoolean() {
+  void logicalOr_validBoxedBoolean() {
     VariableExpr lhsExpr =
         VariableExpr.withVariable(
             Variable.builder().setType(TypeNode.BOOLEAN_OBJECT).setName("isGood").build());
@@ -83,7 +83,7 @@ public class LogicalOperationExprTest {
   }
 
   @Test
-  public void logicalOr_invalidVoidType() {
+  void logicalOr_invalidVoidType() {
     VariableExpr lhsExpr =
         VariableExpr.withVariable(
             Variable.builder().setType(TypeNode.BOOLEAN).setName("x").build());
@@ -95,7 +95,7 @@ public class LogicalOperationExprTest {
   }
 
   @Test
-  public void logicalOr_invalidNullType() {
+  void logicalOr_invalidNullType() {
     VariableExpr lhsExpr =
         VariableExpr.withVariable(
             Variable.builder().setType(TypeNode.BOOLEAN).setName("x").build());

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/MethodDefinitionTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/MethodDefinitionTest.java
@@ -21,11 +21,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class MethodDefinitionTest {
+class MethodDefinitionTest {
   @Test
-  public void validMethodDefinition_basicWithComments() {
+  void validMethodDefinition_basicWithComments() {
     MethodDefinition.builder()
         .setHeaderCommentStatements(createCommentStatements())
         .setName("close")
@@ -37,7 +37,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void validMethodDefinition_emptyBody() {
+  void validMethodDefinition_emptyBody() {
     MethodDefinition.builder()
         .setHeaderCommentStatements(createCommentStatements())
         .setName("close")
@@ -47,7 +47,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void validMethodDefinition_repeatedAnnotations() {
+  void validMethodDefinition_repeatedAnnotations() {
     MethodDefinition method =
         MethodDefinition.builder()
             .setName("close")
@@ -65,7 +65,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void validMethodDefinition_basicWithReturnType() {
+  void validMethodDefinition_basicWithReturnType() {
     MethodDefinition.builder()
         .setName("close")
         .setScope(ScopeNode.PUBLIC)
@@ -81,7 +81,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void validMethodDefinition_throwInsteadOfReturnType() {
+  void validMethodDefinition_throwInsteadOfReturnType() {
     MethodDefinition.builder()
         .setName("foobar")
         .setScope(ScopeNode.PUBLIC)
@@ -99,7 +99,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void validMethodDefinition_voidThrowInsteadOfReturnType() {
+  void validMethodDefinition_voidThrowInsteadOfReturnType() {
     MethodDefinition.builder()
         .setName("foobar")
         .setScope(ScopeNode.PUBLIC)
@@ -117,7 +117,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void validMethodDefinition_subtyping() {
+  void validMethodDefinition_subtyping() {
     Reference stringRef = ConcreteReference.withClazz(String.class);
     TypeNode returnType =
         TypeNode.withReference(
@@ -149,7 +149,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void validMethodDefinition_basicAbstract() {
+  void validMethodDefinition_basicAbstract() {
     MethodDefinition.builder()
         .setName("close")
         .setIsAbstract(true)
@@ -160,7 +160,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void validMethodDefinition_constructor() {
+  void validMethodDefinition_constructor() {
     TypeNode returnType =
         TypeNode.withReference(
             VaporReference.builder()
@@ -174,7 +174,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void validMethodDefinition_withArgumentsAndReturnExpr() {
+  void validMethodDefinition_withArgumentsAndReturnExpr() {
     ValueExpr returnExpr =
         ValueExpr.builder()
             .setValue(PrimitiveValue.builder().setType(TypeNode.INT).setValue("3").build())
@@ -201,7 +201,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void validMethodDefinition_nonRuntimeException() {
+  void validMethodDefinition_nonRuntimeException() {
     MethodDefinition.builder()
         .setName("close")
         .setScope(ScopeNode.PUBLIC)
@@ -213,7 +213,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void validMethodDefinition_templateBasic() {
+  void validMethodDefinition_templateBasic() {
     TypeNode returnType = TypeNode.withReference(ConcreteReference.withClazz(Map.class));
     MethodDefinition.builder()
         .setName("close")
@@ -231,7 +231,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void validMethodDefinition_templateOnArguments() {
+  void validMethodDefinition_templateOnArguments() {
     Reference listRef = ConcreteReference.withClazz(List.class);
     List<VariableExpr> arguments =
         Arrays.asList(
@@ -263,7 +263,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void validMethodDefinition_primitiveReturnTypeWithoutTemplates() {
+  void validMethodDefinition_primitiveReturnTypeWithoutTemplates() {
     // Not valid Java. Please change this test if you are trying to prevent this case.
     MethodDefinition.builder()
         .setName("close")
@@ -275,7 +275,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void validMethodDefinition_boxedReturnType() {
+  void validMethodDefinition_boxedReturnType() {
     MethodDefinition.builder()
         .setName("foobar")
         .setScope(ScopeNode.PUBLIC)
@@ -288,7 +288,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void validMethodDefinition_setReturnExprUsingReturnExpr() {
+  void validMethodDefinition_setReturnExprUsingReturnExpr() {
     ReturnExpr returnExpr =
         ReturnExpr.withExpr(
             ValueExpr.withValue(
@@ -303,7 +303,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void invalidMethodDefinition_badTemplateName() {
+  void invalidMethodDefinition_badTemplateName() {
     assertThrows(
         IdentifierNode.InvalidIdentifierException.class,
         () ->
@@ -317,7 +317,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void invalidMethodDefinition_primitiveReturnType() {
+  void invalidMethodDefinition_primitiveReturnType() {
     assertThrows(
         IllegalStateException.class,
         () ->
@@ -332,7 +332,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void invalidMethodDefinition_emptyTemplatesOnMethod() {
+  void invalidMethodDefinition_emptyTemplatesOnMethod() {
     assertThrows(
         IllegalStateException.class,
         () ->
@@ -348,7 +348,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void invalidMethodDefinition_returnTemplatesNotPresent() {
+  void invalidMethodDefinition_returnTemplatesNotPresent() {
     assertThrows(
         IllegalStateException.class,
         () ->
@@ -365,7 +365,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void invalidMethodDefinition_noName() {
+  void invalidMethodDefinition_noName() {
     assertThrows(
         NullPointerException.class,
         () -> {
@@ -378,7 +378,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void invalidMethodDefinition_runtimeException() {
+  void invalidMethodDefinition_runtimeException() {
     assertThrows(
         IllegalStateException.class,
         () -> {
@@ -394,7 +394,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void invalidMethodDefinition_abstractStatic() {
+  void invalidMethodDefinition_abstractStatic() {
     assertThrows(
         IllegalStateException.class,
         () -> {
@@ -409,7 +409,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void invalidMethodDefinition_localScope() {
+  void invalidMethodDefinition_localScope() {
     assertThrows(
         IllegalStateException.class,
         () -> {
@@ -422,7 +422,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void invalidMethodDefinition_constructorOverride() {
+  void invalidMethodDefinition_constructorOverride() {
     TypeNode returnType =
         TypeNode.withReference(
             VaporReference.builder()
@@ -441,7 +441,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void invalidMethodDefinition_constructorFinalOrStatic() {
+  void invalidMethodDefinition_constructorFinalOrStatic() {
     TypeNode returnType =
         TypeNode.withReference(
             VaporReference.builder()
@@ -469,7 +469,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void invalidMethodDefinition_constructorHasReturnExpr() {
+  void invalidMethodDefinition_constructorHasReturnExpr() {
     TypeNode returnType =
         TypeNode.withReference(
             VaporReference.builder()
@@ -492,7 +492,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void invalidMethodDefinition_objectPrimitiveTypeMismatch() {
+  void invalidMethodDefinition_objectPrimitiveTypeMismatch() {
     Value value = PrimitiveValue.builder().setType(TypeNode.INT).setValue("3").build();
     ValueExpr valueExpr = ValueExpr.builder().setValue(value).build();
 
@@ -510,7 +510,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void invalidMethodDefinition_mismatchedTypes() {
+  void invalidMethodDefinition_mismatchedTypes() {
     Reference stringRef = ConcreteReference.withClazz(String.class);
     TypeNode returnType =
         TypeNode.withReference(
@@ -539,7 +539,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void invalidMethodDefinition_abstractFinal() {
+  void invalidMethodDefinition_abstractFinal() {
     assertThrows(
         IllegalStateException.class,
         () -> {
@@ -554,7 +554,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void invalidMethodDefinition_abstractPrivate() {
+  void invalidMethodDefinition_abstractPrivate() {
     assertThrows(
         IllegalStateException.class,
         () -> {
@@ -568,7 +568,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void invalidMethodDefinition_invalidException() {
+  void invalidMethodDefinition_invalidException() {
     assertThrows(
         IllegalStateException.class,
         () -> {
@@ -583,7 +583,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void invalidMethodDefinition_missingNonVoidReturnType() {
+  void invalidMethodDefinition_missingNonVoidReturnType() {
     assertThrows(
         NullPointerException.class,
         () -> {
@@ -597,7 +597,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void invalidMethodDefinition_mismatchedPrimitiveReturnType() {
+  void invalidMethodDefinition_mismatchedPrimitiveReturnType() {
     ValueExpr booleanValueExpr =
         ValueExpr.builder()
             .setValue(PrimitiveValue.builder().setType(TypeNode.BOOLEAN).setValue("false").build())
@@ -616,7 +616,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void invalidMethodDefinition_mismatchedObjectReturnType() {
+  void invalidMethodDefinition_mismatchedObjectReturnType() {
     assertThrows(
         IllegalStateException.class,
         () -> {
@@ -635,7 +635,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void invalidMethodDefinition_mismatchedPrimitiveToObjectReturnType() {
+  void invalidMethodDefinition_mismatchedPrimitiveToObjectReturnType() {
     assertThrows(
         IllegalStateException.class,
         () -> {
@@ -654,7 +654,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void invalidMethodDefinition_repeatedArgumentName() {
+  void invalidMethodDefinition_repeatedArgumentName() {
     ValueExpr returnValueExpr =
         ValueExpr.builder()
             .setValue(PrimitiveValue.builder().setType(TypeNode.INT).setValue("3").build())
@@ -678,7 +678,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void invalidMethodDefinition_nonDeclArguments() {
+  void invalidMethodDefinition_nonDeclArguments() {
     ValueExpr returnValueExpr =
         ValueExpr.builder()
             .setValue(PrimitiveValue.builder().setType(TypeNode.INT).setValue("3").build())
@@ -702,7 +702,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void invalidMethodDefinition_argumentsWithModifiers() {
+  void invalidMethodDefinition_argumentsWithModifiers() {
     ValueExpr returnValueExpr =
         ValueExpr.builder()
             .setValue(PrimitiveValue.builder().setType(TypeNode.INT).setValue("3").build())
@@ -729,7 +729,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void invalidMethodDefinition_argumentsWithScope() {
+  void invalidMethodDefinition_argumentsWithScope() {
     ValueExpr returnValueExpr =
         ValueExpr.builder()
             .setValue(PrimitiveValue.builder().setType(TypeNode.INT).setValue("3").build())
@@ -755,7 +755,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void invalidMethodDefinition_nullReturnType() {
+  void invalidMethodDefinition_nullReturnType() {
     assertThrows(
         IllegalStateException.class,
         () -> {
@@ -768,7 +768,7 @@ public class MethodDefinitionTest {
   }
 
   @Test
-  public void invalidMethodDefinition_missingReturnType() {
+  void invalidMethodDefinition_missingReturnType() {
     assertThrows(
         NullPointerException.class,
         () -> {

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/MethodInvocationExprTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/MethodInvocationExprTest.java
@@ -18,12 +18,12 @@ import static org.junit.Assert.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class MethodInvocationExprTest {
+class MethodInvocationExprTest {
 
   @Test
-  public void validBuildMethodInvocationExpr() {
+  void validBuildMethodInvocationExpr() {
     Reference stringRef = ConcreteReference.withClazz(String.class);
     TypeNode returnType =
         TypeNode.withReference(
@@ -37,7 +37,7 @@ public class MethodInvocationExprTest {
   }
 
   @Test
-  public void validBuildMethodInvocationExpr_hasArguments() {
+  void validBuildMethodInvocationExpr_hasArguments() {
     Reference stringRef = ConcreteReference.withClazz(String.class);
     TypeNode returnType =
         TypeNode.withReference(
@@ -59,7 +59,7 @@ public class MethodInvocationExprTest {
   }
 
   @Test
-  public void validBuildMethodInvocationExpr_staticReference() {
+  void validBuildMethodInvocationExpr_staticReference() {
     TypeNode someType =
         TypeNode.withReference(
             VaporReference.builder()
@@ -75,7 +75,7 @@ public class MethodInvocationExprTest {
   }
 
   @Test
-  public void invalidBuildMethodInvocationExpr_nullReturnType() {
+  void invalidBuildMethodInvocationExpr_nullReturnType() {
     assertThrows(
         IllegalStateException.class,
         () -> {
@@ -87,7 +87,7 @@ public class MethodInvocationExprTest {
   }
 
   @Test
-  public void invalidBuildMethodInvocationExpr_staticAndExprBoth() {
+  void invalidBuildMethodInvocationExpr_staticAndExprBoth() {
     TypeNode someType =
         TypeNode.withReference(
             VaporReference.builder()
@@ -110,7 +110,7 @@ public class MethodInvocationExprTest {
   }
 
   @Test
-  public void invalidBuildMethodInvocationExpr_nullArgument() {
+  void invalidBuildMethodInvocationExpr_nullArgument() {
     Reference stringRef = ConcreteReference.withClazz(String.class);
     TypeNode returnType =
         TypeNode.withReference(

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/NewObjectExprTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/NewObjectExprTest.java
@@ -21,11 +21,11 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class NewObjectExprTest {
+class NewObjectExprTest {
   @Test
-  public void validNewObjectValue_basic() {
+  void validNewObjectValue_basic() {
     // isGeneric() is true and generics() is not empty.
     // [Constructing] `new List<String>()`, no exception should be thrown.
     ConcreteReference ref =
@@ -40,7 +40,7 @@ public class NewObjectExprTest {
   }
 
   @Test
-  public void validNewObjectValue_hasArgument() {
+  void validNewObjectValue_hasArgument() {
     VaporReference ref =
         VaporReference.builder()
             .setName("Student")
@@ -58,7 +58,7 @@ public class NewObjectExprTest {
   }
 
   @Test
-  public void validNewObjectExpr_edgeCase() {
+  void validNewObjectExpr_edgeCase() {
     // isGeneric() is false, but generics() is not empty.
     // The expression is still valid, we will set isGeneric() as true for the users.
     // [Constructing] `new List<String>()`, no exception should be thrown.
@@ -74,7 +74,7 @@ public class NewObjectExprTest {
   }
 
   @Test
-  public void validNewObjectExpr_noGenericWithArgs() {
+  void validNewObjectExpr_noGenericWithArgs() {
     // isGeneric() is false, and generics() is empty.
     // [Constructing] `new Integer(123)` no exception should be thrown.
     ConcreteReference ref = ConcreteReference.builder().setClazz(Integer.class).build();
@@ -88,7 +88,7 @@ public class NewObjectExprTest {
   }
 
   @Test
-  public void validNewObjectExpr_emptyGeneric() {
+  void validNewObjectExpr_emptyGeneric() {
     // isGeneric() is true, but generics() is empty.
     // [Constructing] `new LinkedList<>()` no exception should be thrown.
     ConcreteReference ref = ConcreteReference.builder().setClazz(LinkedList.class).build();
@@ -99,7 +99,7 @@ public class NewObjectExprTest {
   }
 
   @Test
-  public void validNewObjectExpr_genericsAndArgs() {
+  void validNewObjectExpr_genericsAndArgs() {
     // isGeneric() is true, generics() is not empty, and argument list is also not empty.
     // [Constructing] `new HashMap<List<String>, Integer>>(initialCapacity, loadFactor)`.
     ConcreteReference listRef =
@@ -130,7 +130,7 @@ public class NewObjectExprTest {
   }
 
   @Test
-  public void invalidNewObjectExpr_primitiveType() {
+  void invalidNewObjectExpr_primitiveType() {
     // New object expressions should be reference types.
     assertThrows(
         IllegalStateException.class,
@@ -140,7 +140,7 @@ public class NewObjectExprTest {
   }
 
   @Test
-  public void invalidNewObjectExpr_nullType() {
+  void invalidNewObjectExpr_nullType() {
     // New object expressions cannot be null type.
     assertThrows(
         IllegalStateException.class,
@@ -150,7 +150,7 @@ public class NewObjectExprTest {
   }
 
   @Test
-  public void invalidNewObjectValue_nullArgument() {
+  void invalidNewObjectValue_nullArgument() {
     VaporReference ref =
         VaporReference.builder()
             .setName("Student")

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/NullObjectValueTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/NullObjectValueTest.java
@@ -17,13 +17,13 @@ package com.google.api.generator.engine.ast;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class NullObjectValueTest {
+class NullObjectValueTest {
   private static final String NULL_VALUE = "null";
 
   @Test
-  public void createNullObjectValue_valid() {
+  void createNullObjectValue_valid() {
     NullObjectValue nullValue = NullObjectValue.create();
     assertEquals(NULL_VALUE, nullValue.value());
     assertThat(nullValue.type()).isEqualTo(TypeNode.NULL);

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/PrimitiveValueTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/PrimitiveValueTest.java
@@ -19,11 +19,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 import com.google.api.generator.engine.ast.TypeNode.TypeKind;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class PrimitiveValueTest {
+class PrimitiveValueTest {
   @Test
-  public void createPrimitiveValue_basic() {
+  void createPrimitiveValue_basic() {
     assertValidValue(TypeKind.INT, "3");
     assertValidValue(TypeKind.BOOLEAN, "false");
     assertValidValue(TypeKind.LONG, "123");
@@ -32,7 +32,7 @@ public class PrimitiveValueTest {
   }
 
   @Test
-  public void createPrimitiveValue_invalid() {
+  void createPrimitiveValue_invalid() {
     assertInvalidValue(TypeKind.INT, "123.f");
     assertInvalidValue(TypeKind.INT, "false");
     assertInvalidValue(TypeKind.BOOLEAN, "False");
@@ -40,7 +40,7 @@ public class PrimitiveValueTest {
   }
 
   @Test
-  public void createPrimitiveValue_unsupported() {
+  void createPrimitiveValue_unsupported() {
     assertInvalidValue(TypeKind.BYTE, "0x2");
     assertInvalidValue(TypeKind.SHORT, "1");
     assertInvalidValue(TypeKind.CHAR, "a");

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/ReferenceConstructorExprTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/ReferenceConstructorExprTest.java
@@ -16,12 +16,12 @@ package com.google.api.generator.engine.ast;
 
 import static org.junit.Assert.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ReferenceConstructorExprTest {
+class ReferenceConstructorExprTest {
 
   @Test
-  public void validReferenceConstructorExpr_thisConstructorBasic() {
+  void validReferenceConstructorExpr_thisConstructorBasic() {
     VaporReference ref =
         VaporReference.builder()
             .setName("Student")
@@ -33,7 +33,7 @@ public class ReferenceConstructorExprTest {
   }
 
   @Test
-  public void validReferenceConstructorExpr_hasArguments() {
+  void validReferenceConstructorExpr_hasArguments() {
     VaporReference ref =
         VaporReference.builder()
             .setName("Student")
@@ -51,7 +51,7 @@ public class ReferenceConstructorExprTest {
   }
 
   @Test
-  public void validReferenceConstructorExpr_superConstructorBasic() {
+  void validReferenceConstructorExpr_superConstructorBasic() {
     VaporReference ref =
         VaporReference.builder()
             .setName("Student")
@@ -63,7 +63,7 @@ public class ReferenceConstructorExprTest {
   }
 
   @Test
-  public void invalidReferenceConstructorExpr_nonReferenceType() {
+  void invalidReferenceConstructorExpr_nonReferenceType() {
     assertThrows(
         IllegalStateException.class,
         () -> {
@@ -72,7 +72,7 @@ public class ReferenceConstructorExprTest {
   }
 
   @Test
-  public void invalidReferenceConstructorExpr_nullType() {
+  void invalidReferenceConstructorExpr_nullType() {
     assertThrows(
         IllegalStateException.class,
         () -> {
@@ -81,7 +81,7 @@ public class ReferenceConstructorExprTest {
   }
 
   @Test
-  public void invalidReferenceConstructorExpr_nullArgument() {
+  void invalidReferenceConstructorExpr_nullArgument() {
     VaporReference ref =
         VaporReference.builder()
             .setName("Student")

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/ReferenceTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/ReferenceTest.java
@@ -20,11 +20,11 @@ import static org.junit.Assert.assertFalse;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ReferenceTest {
+class ReferenceTest {
   @Test
-  public void nestedGenerics_concreteReferenceOuter() {
+  void nestedGenerics_concreteReferenceOuter() {
     Reference mapReference =
         VaporReference.builder()
             .setName("HashMap")
@@ -50,7 +50,7 @@ public class ReferenceTest {
   }
 
   @Test
-  public void nestedGenerics_vaporReferenceOuter() {
+  void nestedGenerics_vaporReferenceOuter() {
     Reference mapReference =
         ConcreteReference.builder()
             .setClazz(HashMap.class)
@@ -77,7 +77,7 @@ public class ReferenceTest {
   }
 
   @Test
-  public void mixedConcreteVaporReferenceEquals() {
+  void mixedConcreteVaporReferenceEquals() {
     Reference mapReferenceVaporOuter =
         ConcreteReference.builder()
             .setClazz(HashMap.class)

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/RelationalOperationExprTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/RelationalOperationExprTest.java
@@ -17,12 +17,12 @@ package com.google.api.generator.engine.ast;
 import static org.junit.Assert.assertThrows;
 
 import com.google.api.generator.engine.ast.TypeNode.TypeKind;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class RelationalOperationExprTest {
+class RelationalOperationExprTest {
   /** ==================== Equality Operators: LHS data type is numeric ======================= */
   @Test
-  public void equalToOperationExpr_validBasic() {
+  void equalToOperationExpr_validBasic() {
     // LHS: numeric type, RHS: matched numeric type.
     // No need swap LHS and RHS test case.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT, "x");
@@ -32,7 +32,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_validNumericTYpe() {
+  void equalToOperationExpr_validNumericTYpe() {
     // LHS: numeric type, RHS: unmatched numeric type.
     // No need swap LHS and RHS test case.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.CHAR, "x");
@@ -42,7 +42,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void notEqualToOperationExpr_validMatchedNumericBoxTYpe() {
+  void notEqualToOperationExpr_validMatchedNumericBoxTYpe() {
     // LHS: numeric type, RHS: matched numeric Boxed type.
     // Swapping LHS and RHS test case is covered in
     // "equalToOperationExpr_validBoxedWithMatchedUnBoxedType".
@@ -53,7 +53,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void notEqualToOperationExpr_validNumericBoxTYpe() {
+  void notEqualToOperationExpr_validNumericBoxTYpe() {
     // LHS: numeric type, RHS: unmatched numeric Boxed type.
     // Swapping LHS and RHS test case is covered in
     // equalToOperationExpr_validBoxedWithUnmatchedUnBoxedType".
@@ -64,7 +64,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_invalidNumericBooleanBoxedType() {
+  void equalToOperationExpr_invalidNumericBooleanBoxedType() {
     // LHS: numeric type, RHS: boolean boxed Type.
     // Swapping LHS and RHS test case is covered in
     // "equalToOperationExpr_invalidBoxedBooleanWithNumericType".
@@ -76,7 +76,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void notEqualToOperationExpr_invalidNumericStringType() {
+  void notEqualToOperationExpr_invalidNumericStringType() {
     // LHS: numeric type, RHS: referenced type.
     // Swapping LHS and RHS test case is covered in
     // "equalToOperationExpr_invalidReferenceWithNumericType".
@@ -88,7 +88,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void notEqualToOperationExpr_invalidNumericNullType() {
+  void notEqualToOperationExpr_invalidNumericNullType() {
     // LHS: numeric type, RHS: null.
     // Swapping LHS and RHS test case is covered in
     // "equalToOperationExpr_invalidNullWithNumericType".
@@ -100,7 +100,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_invalidNumericBooleanType() {
+  void equalToOperationExpr_invalidNumericBooleanType() {
     // LHS: numeric type, RHS: boolean boxed Type.
     // Swapping LHS and RHS test case is covered in
     // notEqualToOperationExpr_invalidBooleanToNumericType.
@@ -112,7 +112,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_invalidNumericTypeWithArrayType() {
+  void equalToOperationExpr_invalidNumericTypeWithArrayType() {
     // LHS: Numeric Type, RHS: Array with numeric type.
     // Swapping LHS and RHS test case is covered in
     // "equalToOperationExpr_invalidArrayWithNotArrayType".
@@ -127,7 +127,7 @@ public class RelationalOperationExprTest {
 
   /** =============== Equality Operators: LHS data type is numeric boxed type ================ */
   @Test
-  public void equalToOperationExpr_validBoxedWithMatchedBoxedType() {
+  void equalToOperationExpr_validBoxedWithMatchedBoxedType() {
     // LHS: Boxed type, RHS: Matched Boxed.
     // No need swap LHS and RHS test case.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "x");
@@ -137,7 +137,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_validBoxedWithMatchedUnBoxedType() {
+  void equalToOperationExpr_validBoxedWithMatchedUnBoxedType() {
     // LHS: Boxed type, RHS: Unmatched Boxed.
     // Swapping LHS and RHS test case is covered in
     // "notEqualToOperationExpr_validMatchedNumericBoxTYpe".
@@ -148,7 +148,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_validBoxedWithUnmatchedUnBoxedType() {
+  void equalToOperationExpr_validBoxedWithUnmatchedUnBoxedType() {
     // LHS: Numeric boxed type, RHS: other numeric type.
     // Swapping LHS and RHS test case is covered in "notEqualToOperationExpr_validNumericBoxTYpe".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.FLOAT_OBJECT, "x");
@@ -158,7 +158,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_validNumericBoxedWithNullType() {
+  void equalToOperationExpr_validNumericBoxedWithNullType() {
     // LHS: Boxed type, RHS: Null.
     // Swapping LHS and RHS test case is covered in
     // "equalToOperationExpr_validNullWithNumericBoxedType".
@@ -169,7 +169,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_validNumericBoxedWithNewObjectType() {
+  void equalToOperationExpr_validNumericBoxedWithNewObjectType() {
     // LHS: Numeric boxed type, RHS: new object.
     // Swapping LHS and RHS test case is covered in
     // "equalToOperationExpr_validObjectWithNumericBoxedType".
@@ -180,7 +180,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_invalidNumericBoxedWithBooleanType() {
+  void equalToOperationExpr_invalidNumericBoxedWithBooleanType() {
     // LHS: Numeric boxed type, RHS: Boolean type.
     // Swapping LHS and RHS test case is covered in
     // "notEqualToOperationExpr_invalidBooleanToOtherBoxedType".
@@ -192,7 +192,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_invalidNumericBoxedWithBooleanBoxedType() {
+  void equalToOperationExpr_invalidNumericBoxedWithBooleanBoxedType() {
     // LHS: Numeric boxed type, RHS: Boolean Boxed type.
     // Swapping LHS and RHS test case is covered in
     // "equalToOperationExpr_invalidBooleanBoxedWithNumericBoxedType".
@@ -204,7 +204,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_invalidNumericBoxedWithReferenceType() {
+  void equalToOperationExpr_invalidNumericBoxedWithReferenceType() {
     // LHS: Numeric boxed type, RHS: Reference type.
     // Swapping LHS and RHS test case is covered in
     // "equalToOperationExpr_invalidReferenceWithNumericBoxedType".
@@ -217,7 +217,7 @@ public class RelationalOperationExprTest {
 
   /** ============= Equality Operators: LHS data type is boolean or its boxed type ============== */
   @Test
-  public void equalToOperationExpr_validBooleanType() {
+  void equalToOperationExpr_validBooleanType() {
     // LHS: boolean type, RHS: boolean Type.
     // No need swap LHS and RHS test case.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.BOOLEAN, "x");
@@ -227,7 +227,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_validRHSBooleanBoxedType() {
+  void equalToOperationExpr_validRHSBooleanBoxedType() {
     // LHS: boolean type, RHS: boolean boxed Type.
     // Swapping LHS and RHS test case is covered in "equalToOperationExpr_validLHSBooleanBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.BOOLEAN, "x");
@@ -237,7 +237,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_validLHSBooleanBoxedType() {
+  void equalToOperationExpr_validLHSBooleanBoxedType() {
     // LHS: boolean boxed type, RHS: boolean Type.
     // Swapping LHS and RHS test case is covered in "equalToOperationExpr_validRHSBooleanBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.BOOLEAN_OBJECT, "x");
@@ -247,7 +247,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void notEqualToOperationExpr_validBooleanBoxedToNullType() {
+  void notEqualToOperationExpr_validBooleanBoxedToNullType() {
     // LHS: boolean boxed type, RHS: null.
     // Swapping LHS and RHS test case is covered in
     // "equalToOperationExpr_validNullWithBooleanBoxedType".
@@ -258,7 +258,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void notEqualToOperationExpr_validBooleanBoxedToObjectType() {
+  void notEqualToOperationExpr_validBooleanBoxedToObjectType() {
     // LHS: boolean boxed type, RHS: null.
     // Swapping LHS and RHS test case is covered in
     // "equalToOperationExpr_validObjectWithBooleanBoxedType".
@@ -269,7 +269,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void notEqualToOperationExpr_invalidBooleanToNumericType() {
+  void notEqualToOperationExpr_invalidBooleanToNumericType() {
     // LHS: boolean type, RHS: char boxed type.
     // Swapping LHS and RHS test case is covered in
     // "equalToOperationExpr_invalidNumericBooleanType".
@@ -281,7 +281,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void notEqualToOperationExpr_invalidBooleanToOtherBoxedType() {
+  void notEqualToOperationExpr_invalidBooleanToOtherBoxedType() {
     // LHS: boolean type, RHS: numeric boxed type.
     // Swapping LHS and RHS test case is covered in
     // "equalToOperationExpr_invalidNumericBoxedWithBooleanType".
@@ -293,7 +293,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void notEqualToOperationExpr_invalidBooleanToReferenceType() {
+  void notEqualToOperationExpr_invalidBooleanToReferenceType() {
     // LHS: boolean type, RHS: object type.
     // Swapping LHS and RHS test case is covered in
     // "equalToOperationExpr_invalidReferenceWithBooleanType".
@@ -305,7 +305,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_invalidBooleanWithNullType() {
+  void equalToOperationExpr_invalidBooleanWithNullType() {
     // LHS: boolean type, RHS: null type.
     // Swapping LHS and RHS test case is covered in
     // "equalToOperationExpr_invalidNullWithBooleanType".
@@ -317,7 +317,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_invalidBooleanWithObjectType() {
+  void equalToOperationExpr_invalidBooleanWithObjectType() {
     // LHS: boolean type, RHS: object type.
     // Swapping LHS and RHS test case is covered in
     // "equalToOperationExpr_invalidObjectWithBooleanType".
@@ -329,7 +329,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_invalidBoxedBooleanWithNumericType() {
+  void equalToOperationExpr_invalidBoxedBooleanWithNumericType() {
     // LHS: boolean boxed type, RHS: numeric
     // Swapping LHS and RHS test case is covered in
     // "equalToOperationExpr_invalidNumericBooleanBoxedType".
@@ -341,7 +341,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_invalidBooleanBoxedWithNumericBoxedType() {
+  void equalToOperationExpr_invalidBooleanBoxedWithNumericBoxedType() {
     // LHS: boolean boxed type, RHS: numeric
     // Swapping LHS and RHS test case is covered in
     // "equalToOperationExpr_invalidNumericBoxedWithBooleanBoxedType".
@@ -353,7 +353,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_invalidBoxedBooleanWithReferencedType() {
+  void equalToOperationExpr_invalidBoxedBooleanWithReferencedType() {
     // LHS: boolean boxed type, RHS: reference type.
     // Swapping LHS and RHS test case is covered in
     // "equalToOperationExpr_invalidReferenceWithBooleanBoxedType".
@@ -366,7 +366,7 @@ public class RelationalOperationExprTest {
 
   /** ===================== Equality Operators: LHS data type is Array ======================== */
   @Test
-  public void equalToOperationExpr_validArrayWithMatchedType() {
+  void equalToOperationExpr_validArrayWithMatchedType() {
     // LHS: Array with numeric type, RHS: Array with matched numeric type.
     // No need swap LHS and RHS test case.
     VariableExpr lhsExpr =
@@ -380,7 +380,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_validArrayWithNullType() {
+  void equalToOperationExpr_validArrayWithNullType() {
     // LHS: Array with numeric type, RHS: null
     // Swapping LHS and RHS test case is covered in "equalToOperationExpr_validANullWithArrayType".
     VariableExpr lhsExpr =
@@ -393,7 +393,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void notEqualToOperationExpr_invalidArrayWithUnmatchedType() {
+  void notEqualToOperationExpr_invalidArrayWithUnmatchedType() {
     // LHS: Array with numeric type, RHS: Array with unmatched numeric type.
     // No need swap LHS and RHS test case.
     VariableExpr lhsExpr =
@@ -408,7 +408,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_invalidArrayWithNotArrayType() {
+  void equalToOperationExpr_invalidArrayWithNotArrayType() {
     // LHS: Array with numeric type, RHS: not Array
     // Swapping LHS and RHS test case is covered in
     // "equalToOperationExpr_invalidNumericTypeWithArrayType".
@@ -422,7 +422,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_invalidArrayWithObjectType() {
+  void equalToOperationExpr_invalidArrayWithObjectType() {
     // LHS: Array with numeric type, RHS: New Object type.
     // Swapping LHS and RHS test case is covered in
     // "equalToOperationExpr_invalidObjectTypeWithArray".
@@ -437,7 +437,7 @@ public class RelationalOperationExprTest {
 
   /** ================== Equality Operators: LHS data type is reference type =================== */
   @Test
-  public void equalToOperationExpr_validReferenceWithMatchedType() {
+  void equalToOperationExpr_validReferenceWithMatchedType() {
     // LHS: String type, RHS: matched String type.
     // No need swap LHS and RHS test case.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.STRING, "x");
@@ -447,7 +447,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_validReferenceWithNullType() {
+  void equalToOperationExpr_validReferenceWithNullType() {
     // LHS: String type, RHS: null.
     // Swapping LHS and RHS test case is covered in
     // "equalToOperationExpr_validNullWithReferenceType".
@@ -458,7 +458,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_validReferenceWithObjectType() {
+  void equalToOperationExpr_validReferenceWithObjectType() {
     // LHS: String type, RHS: New object type.
     // Swapping LHS and RHS test case is covered in
     // "equalToOperationExpr_validObjectWithStringType".
@@ -469,7 +469,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_validAnyObjectTypeWithObject() {
+  void equalToOperationExpr_validAnyObjectTypeWithObject() {
     // LHS: Any reference type, RHS: Object type.
     // Swapping LHS and RHS test case is covered in
     // "equalToOperationExpr_validObjectWithAnyObjectType".
@@ -486,7 +486,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_validAnyReferenceTypeWithNull() {
+  void equalToOperationExpr_validAnyReferenceTypeWithNull() {
     // LHS: Any reference type, RHS: Null type.
     // Swapping LHS and RHS test case is covered in
     // "equalToOperationExpr_validNullWithAnyReferenceType".
@@ -503,7 +503,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_invalidReferenceWithUnmatchedReferenceType() {
+  void equalToOperationExpr_invalidReferenceWithUnmatchedReferenceType() {
     // LHS: String type, RHS: Unmatched reference type.
     // No need swap LHS and RHS test case.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.STRING, "x");
@@ -520,7 +520,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_invalidReferenceWithNumericType() {
+  void equalToOperationExpr_invalidReferenceWithNumericType() {
     // LHS: String type, RHS: Numeric type
     // Swapping LHS and RHS test case is covered in
     // "notEqualToOperationExpr_invalidNumericStringType".
@@ -532,7 +532,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_invalidReferenceWithNumericBoxedType() {
+  void equalToOperationExpr_invalidReferenceWithNumericBoxedType() {
     // LHS: String type, RHS: numeric boxed type.
     // Swapping LHS and RHS test case is covered in
     // "equalToOperationExpr_invalidNumericBoxedWithReferenceType".
@@ -544,7 +544,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_invalidReferenceWithBooleanType() {
+  void equalToOperationExpr_invalidReferenceWithBooleanType() {
     // LHS: String type, RHS: Boolean boxed type.
     // Swapping LHS and RHS test case is covered in
     // "notEqualToOperationExpr_invalidBooleanToReferenceType".
@@ -556,7 +556,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_invalidReferenceWithBooleanBoxedType() {
+  void equalToOperationExpr_invalidReferenceWithBooleanBoxedType() {
     // LHS: String type, RHS: Boolean boxed type.
     // Swapping LHS and RHS test case is covered in
     // "equalToOperationExpr_invalidBoxedBooleanWithReferencedType".
@@ -569,7 +569,7 @@ public class RelationalOperationExprTest {
 
   /** ================== Equality Operators: LHS data type is Object or null =================== */
   @Test
-  public void equalToOperationExpr_validObjectWithAnyObjectType() {
+  void equalToOperationExpr_validObjectWithAnyObjectType() {
     // LHS: Object type, RHS: Any reference type.
     // Swapping LHS and RHS test case is covered in
     // "equalToOperationExpr_validAnyObjectTypeWithObject".
@@ -586,7 +586,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_validNullWithAnyReferenceType() {
+  void equalToOperationExpr_validNullWithAnyReferenceType() {
     // LHS: Null type, RHS: any reference type
     // Swapping LHS and RHS test case is covered in
     // "equalToOperationExpr_validAnyReferenceTypeWithNull".
@@ -603,7 +603,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_validObjectWithNullType() {
+  void equalToOperationExpr_validObjectWithNullType() {
     // LHS: Object, RHS: Null.
     // Swapping LHS and RHS test case is covered in "equalToOperationExpr_validNullWithObjectType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.OBJECT, "x");
@@ -613,7 +613,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_validNullWithObjectType() {
+  void equalToOperationExpr_validNullWithObjectType() {
     // LHS: Null, RHS: Object.
     // Swapping LHS and RHS test case is covered in "equalToOperationExpr_validObjectWithNullType".
     VariableExpr rhsExpr = createVariableExpr(TypeNode.OBJECT, "x");
@@ -623,7 +623,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_validNullWithNullType() {
+  void equalToOperationExpr_validNullWithNullType() {
     // LHS: Null, RHS: Null.
     // No need swap LHS and RHS test case.
     ValueExpr lhsExpr = ValueExpr.createNullExpr();
@@ -633,7 +633,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_validObjectWithStringType() {
+  void equalToOperationExpr_validObjectWithStringType() {
     // LHS: Object type, RHS: Reference type.
     // Swapping LHS and RHS test case is covered in
     // "equalToOperationExpr_validReferenceWithObjectType".
@@ -644,7 +644,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_validObjectWithBooleanBoxedType() {
+  void equalToOperationExpr_validObjectWithBooleanBoxedType() {
     // LHS: Object type, RHS: Boolean boxed type.
     // Swapping LHS and RHS test case is covered in
     // "notEqualToOperationExpr_validBooleanBoxedToObjectType".
@@ -655,7 +655,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_validObjectWithNumericBoxedType() {
+  void equalToOperationExpr_validObjectWithNumericBoxedType() {
     // LHS: Object type, RHS: Any Boxed type.
     // Swapping LHS and RHS test case is covered in
     // "equalToOperationExpr_validNumericBoxedWithNewObjectType".
@@ -666,7 +666,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_validNullWithReferenceType() {
+  void equalToOperationExpr_validNullWithReferenceType() {
     // LHS: Null type, RHS: Reference type.
     // Swapping LHS and RHS test case is covered in
     // "equalToOperationExpr_validNullWithReferenceType".
@@ -677,7 +677,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_validNullWithBooleanBoxedType() {
+  void equalToOperationExpr_validNullWithBooleanBoxedType() {
     // LHS: Object type, RHS: Any Boxed type
     // Swapping LHS and RHS test case is covered in
     // "notEqualToOperationExpr_validBooleanBoxedToNullType".
@@ -688,7 +688,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_validNullWithNumericBoxedType() {
+  void equalToOperationExpr_validNullWithNumericBoxedType() {
     // LHS: Object type, RHS: Any Boxed type.
     // Swapping LHS and RHS test case is covered in
     // "equalToOperationExpr_validNumericBoxedWithNullType".
@@ -699,7 +699,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_validANullWithArrayType() {
+  void equalToOperationExpr_validANullWithArrayType() {
     // LHS: Null, RHS: Array with numeric type.
     // Swapping LHS and RHS test case is covered in "equalToOperationExpr_validArrayWithNullType".
     NullObjectValue nullObjectValue = NullObjectValue.create();
@@ -712,7 +712,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_invalidNullWithNumericType() {
+  void equalToOperationExpr_invalidNullWithNumericType() {
     // LHS: Null type, RHS: Nny Numeric type.
     // Swapping LHS and RHS test case is covered in
     // "notEqualToOperationExpr_invalidNumericNullType".
@@ -724,7 +724,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_invalidNullWithBooleanType() {
+  void equalToOperationExpr_invalidNullWithBooleanType() {
     // LHS: Null type, RHS: Boolean type.
     // Swapping LHS and RHS test case is covered in
     // "equalToOperationExpr_invalidBooleanWithNullType".
@@ -736,7 +736,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_invalidObjectWithNumericType() {
+  void equalToOperationExpr_invalidObjectWithNumericType() {
     // LHS: Object type, RHS: Any Numeric type.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.OBJECT, "x");
     VariableExpr rhsExpr = createVariableExpr(TypeNode.DOUBLE, "y");
@@ -746,7 +746,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_invalidObjectWithBooleanType() {
+  void equalToOperationExpr_invalidObjectWithBooleanType() {
     // LHS: Object type, RHS: Boolean type.
     // Swapping LHS and RHS test case is covered in
     // "equalToOperationExpr_invalidBooleanWithObjectType".
@@ -758,7 +758,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void equalToOperationExpr_invalidObjectTypeWithArray() {
+  void equalToOperationExpr_invalidObjectTypeWithArray() {
     // LHS: New Object type, RHS: Array with numeric type.
     // Swapping LHS and RHS test case is covered in
     // "equalToOperationExpr_invalidArrayWithObjectType".
@@ -774,7 +774,7 @@ public class RelationalOperationExprTest {
   /** ================== Less Than Operators: expr types are numeric types =================== */
   // The expression types on LHS or RHS could be any numeric type or any numeric boxed type.
   @Test
-  public void lessThanOperationExpr_validMatchedNumericType() {
+  void lessThanOperationExpr_validMatchedNumericType() {
     // LHS: Numeric type, RHS: Matched numeric type.
     // No need swap LHS and RHS test case.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT, "x");
@@ -784,7 +784,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void lessThanOperationExpr_validUnmatchedNumericType() {
+  void lessThanOperationExpr_validUnmatchedNumericType() {
     // LHS: Numeric type, RHS: Unmatched numeric type.
     // No need swap LHS and RHS test case.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT, "x");
@@ -794,7 +794,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void lessThanOperationExpr_validMatchedNumericBoxedType() {
+  void lessThanOperationExpr_validMatchedNumericBoxedType() {
     // LHS: Numeric type, RHS: Matched numeric type.
     // Swap case in "lessThanOperationExpr_validNumericBoxedTypeWithMatchedNumericType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.FLOAT, "x");
@@ -804,7 +804,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void lessThanOperationExpr_validNumericBoxedTypeWithMatchedNumericType() {
+  void lessThanOperationExpr_validNumericBoxedTypeWithMatchedNumericType() {
     // LHS: Numeric boxed type, RHS: Matched numeric type.
     // Swap case in "lessThanOperationExpr_validMatchedNumericBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.CHAR_OBJECT, "x");
@@ -814,7 +814,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void lessThanOperationExpr_validUnmatchedNumericBoxedType() {
+  void lessThanOperationExpr_validUnmatchedNumericBoxedType() {
     // LHS: Numeric type, RHS: Unmatched numeric boxed type.
     // Swap case in "lessThanOperationExpr_validNumericBoxedTypeWithUnmatchedUnBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.DOUBLE, "x");
@@ -824,7 +824,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void lessThanOperationExpr_validNumericBoxedTypeWithUnmatchedUnBoxedType() {
+  void lessThanOperationExpr_validNumericBoxedTypeWithUnmatchedUnBoxedType() {
     // LHS: Numeric boxed type, RHS: Unmatched numeric type.
     // Swap case in "lessThanOperationExpr_validUnmatchedNumericBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "x");
@@ -834,7 +834,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void lessThanOperationExpr_validNumericBoxedTypeWithMatchedBoxedType() {
+  void lessThanOperationExpr_validNumericBoxedTypeWithMatchedBoxedType() {
     // LHS: Numeric boxed type, RHS: Matched numeric boxed type.
     // No need swap case.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "x");
@@ -844,7 +844,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void lessThanOperationExpr_validNumericBoxedTypeWithUnmatchedBoxedType() {
+  void lessThanOperationExpr_validNumericBoxedTypeWithUnmatchedBoxedType() {
     // LHS: Numeric boxed type, RHS: Unmatched numeric boxed type.
     // No need swap case.
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "x");
@@ -856,7 +856,7 @@ public class RelationalOperationExprTest {
   /** ================= Less Than Operators: expr types are non-numeric types ================== */
   // Invalid if any of expression type on LHS or RHS is non-numeric type or non numeric boxed type.
   @Test
-  public void lessThanOperationExpr_invalidNumericTypeWithNullType() {
+  void lessThanOperationExpr_invalidNumericTypeWithNullType() {
     // LHS: Null type, RHS: Numeric type.
     // Swap case in "lessThanOperationExpr_invalidNumericWithNullType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT, "x");
@@ -867,7 +867,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void lessThanOperationExpr_invalidNumericBoxedTypeWithNullType() {
+  void lessThanOperationExpr_invalidNumericBoxedTypeWithNullType() {
     // LHS: Numeric boxed type, RHS: Null type.
     // Swap case in "lessThanOperationExpr_invalidNullWithNumericBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "x");
@@ -878,7 +878,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void lessThanOperationExpr_invalidNumericTypeWithObjectType() {
+  void lessThanOperationExpr_invalidNumericTypeWithObjectType() {
     // LHS: Numeric type, RHS: Object Type.
     // Swap case in "lessThanOperationExpr_invalidObjectNumericType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT, "x");
@@ -889,7 +889,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void lessThanOperationExpr_invalidNumericBoxedTypeWithObjectType() {
+  void lessThanOperationExpr_invalidNumericBoxedTypeWithObjectType() {
     // LHS: Numeric boxed type, RHS: Object Type.
     // Swap case in "lessThanOperationExpr_invalidObjectNumericBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "x");
@@ -900,7 +900,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void lessThanOperationExpr_invalidNumericBoxedTypeWithReferenceType() {
+  void lessThanOperationExpr_invalidNumericBoxedTypeWithReferenceType() {
     // LHS: Numeric boxed type, RHS: Reference Type.
     // Swap case in "lessThanOperationExpr_invalidReferenceTypeWithNumericBoxedType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.INT_OBJECT, "x");
@@ -911,7 +911,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void lessThanOperationExpr_invalidReferenceTypeWithNumericBoxedType() {
+  void lessThanOperationExpr_invalidReferenceTypeWithNumericBoxedType() {
     // LHS: Reference type, RHS: Numeric boxed Type.
     // Swap case in "lessThanOperationExpr_invalidNumericBoxedTypeWithReferenceType".
     VariableExpr lhsExpr = createVariableExpr(TypeNode.STRING, "x");
@@ -922,7 +922,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void lessThanOperationExpr_invalidObjectNumericType() {
+  void lessThanOperationExpr_invalidObjectNumericType() {
     // LHS: Object type, RHS: Numeric Type.
     // Swap case in "lessThanOperationExpr_invalidNumericTypeWithObjectType".
     NewObjectExpr lhsExpr = NewObjectExpr.withType(TypeNode.OBJECT);
@@ -933,7 +933,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void lessThanOperationExpr_invalidObjectNumericBoxedType() {
+  void lessThanOperationExpr_invalidObjectNumericBoxedType() {
     // LHS: Object type, RHS: Numeric boxed Type.
     // Swap case in "lessThanOperationExpr_invalidNumericBoxedTypeWithObjectType".
     NewObjectExpr lhsExpr = NewObjectExpr.withType(TypeNode.OBJECT);
@@ -944,7 +944,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void lessThanOperationExpr_invalidNumericWithNullType() {
+  void lessThanOperationExpr_invalidNumericWithNullType() {
     // LHS: Null type, RHS: Numeric box type.
 
     ValueExpr lhsExpr = ValueExpr.createNullExpr();
@@ -955,7 +955,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void lessThanOperationExpr_invalidNullWithNumericBoxedType() {
+  void lessThanOperationExpr_invalidNullWithNumericBoxedType() {
     // LHS: Null type, RHS: Numeric box type.
     // Swap case in "lessThanOperationExpr_invalidNumericTypeWithNullType".
     ValueExpr lhsExpr = ValueExpr.createNullExpr();
@@ -966,7 +966,7 @@ public class RelationalOperationExprTest {
   }
 
   @Test
-  public void lessThanOperationExpr_invalidVoidType() {
+  void lessThanOperationExpr_invalidVoidType() {
     // LHS: Null type, RHS: Numeric box type.
     // No need swap case
     MethodInvocationExpr lhsExpr =

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/ReturnExprTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/ReturnExprTest.java
@@ -16,17 +16,17 @@ package com.google.api.generator.engine.ast;
 
 import static org.junit.Assert.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ReturnExprTest {
+class ReturnExprTest {
   @Test
-  public void validReturnExpr_basic() {
+  void validReturnExpr_basic() {
     ReturnExpr.withExpr(ValueExpr.withValue(StringObjectValue.withValue("asdf")));
     // No exception thrown, we're good.
   }
 
   @Test
-  public void invalidReturnExpr_nestedReturnExpr() {
+  void invalidReturnExpr_nestedReturnExpr() {
     ReturnExpr returnExpr =
         ReturnExpr.withExpr(ValueExpr.withValue(StringObjectValue.withValue("asdf")));
     assertThrows(IllegalStateException.class, () -> ReturnExpr.withExpr(returnExpr));

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/StringObjectValueTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/StringObjectValueTest.java
@@ -16,19 +16,19 @@ package com.google.api.generator.engine.ast;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class StringObjectValueTest {
+class StringObjectValueTest {
 
   @Test
-  public void createStringObjectValue_basic() {
+  void createStringObjectValue_basic() {
     StringObjectValue s = StringObjectValue.builder().setValue("test").build();
     assertThat(s.value()).isEqualTo("\"test\"");
     assertThat(s.type()).isEqualTo(TypeNode.STRING);
   }
 
   @Test
-  public void createStringObjectValue_escapeCharacter() {
+  void createStringObjectValue_escapeCharacter() {
     StringObjectValue valueSpecialChar = StringObjectValue.withValue("\" \t \\ \b \r \f \n '");
     String expected = "\"\\\" \\t \\\\ \\b \\r \\f \\n '\"";
     assertThat(valueSpecialChar.value()).isEqualTo(expected);
@@ -36,7 +36,7 @@ public class StringObjectValueTest {
   }
 
   @Test
-  public void createStringObjectValue_specialCharacter() {
+  void createStringObjectValue_specialCharacter() {
     StringObjectValue valueSpecialChar = StringObjectValue.withValue("Tom said: \"Hi!\"; \n");
     String expected = "\"Tom said: \\\"Hi!\\\"; \\n\"";
     assertThat(valueSpecialChar.value()).isEqualTo(expected);
@@ -44,7 +44,7 @@ public class StringObjectValueTest {
   }
 
   @Test
-  public void createStringObjectValue_specialCharacterComment() {
+  void createStringObjectValue_specialCharacterComment() {
     StringObjectValue valueSpecialChar =
         StringObjectValue.withValue("Service comment may include special characters: <>&\"`'@");
     String expected = "\"Service comment may include special characters: <>&\\\"`'@\"";
@@ -53,7 +53,7 @@ public class StringObjectValueTest {
   }
 
   @Test
-  public void createStringObjectValue_usPunctuation() {
+  void createStringObjectValue_usPunctuation() {
     StringObjectValue valueSpecialChar =
         StringObjectValue.withValue("US Punctuation, one of !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~");
     String expected = "\"US Punctuation, one of !\\\"#$%&'()*+,-./:;<=>?@[\\\\]^_`{|}~\"";
@@ -62,7 +62,7 @@ public class StringObjectValueTest {
   }
 
   @Test
-  public void createStringObjectValue_htmlCharacterComment() {
+  void createStringObjectValue_htmlCharacterComment() {
     StringObjectValue valueSpecialChar =
         StringObjectValue.withValue("&nbsp; &#40 &#91 &ndash; &gt;:&lt;");
     String expected = "\"&nbsp; &#40 &#91 &ndash; &gt;:&lt;\"";

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/SuperObjectValueTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/SuperObjectValueTest.java
@@ -16,12 +16,12 @@ package com.google.api.generator.engine.ast;
 
 import static org.junit.Assert.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class SuperObjectValueTest {
+class SuperObjectValueTest {
 
   @Test
-  public void validSuperObjectValue_basic() {
+  void validSuperObjectValue_basic() {
     VaporReference ref =
         VaporReference.builder()
             .setName("Student")
@@ -33,7 +33,7 @@ public class SuperObjectValueTest {
   }
 
   @Test
-  public void invalidSuperObjectValue_nonReferenceType() {
+  void invalidSuperObjectValue_nonReferenceType() {
     assertThrows(
         IllegalStateException.class,
         () -> {
@@ -42,7 +42,7 @@ public class SuperObjectValueTest {
   }
 
   @Test
-  public void invalidSuperObjectValue_nullType() {
+  void invalidSuperObjectValue_nullType() {
     assertThrows(
         IllegalStateException.class,
         () -> {

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/SynchronizedStatementTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/SynchronizedStatementTest.java
@@ -16,11 +16,11 @@ package com.google.api.generator.engine.ast;
 
 import static org.junit.Assert.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class SynchronizedStatementTest {
+class SynchronizedStatementTest {
   @Test
-  public void validSynchronizedStatement_basicThis() {
+  void validSynchronizedStatement_basicThis() {
     SynchronizedStatement.builder()
         .setLock(
             ThisObjectValue.withType(
@@ -31,7 +31,7 @@ public class SynchronizedStatementTest {
   }
 
   @Test
-  public void validSynchronizedStatement_basicVariableExpr() {
+  void validSynchronizedStatement_basicVariableExpr() {
     SynchronizedStatement.builder()
         .setLock(
             VariableExpr.withVariable(
@@ -42,7 +42,7 @@ public class SynchronizedStatementTest {
   }
 
   @Test
-  public void invalidSynchronizedStatement_primitiveLock() {
+  void invalidSynchronizedStatement_primitiveLock() {
     assertThrows(
         IllegalStateException.class,
         () ->
@@ -57,7 +57,7 @@ public class SynchronizedStatementTest {
   }
 
   @Test
-  public void invalidSynchronizedStatement_declaredVariableExpr() {
+  void invalidSynchronizedStatement_declaredVariableExpr() {
     VariableExpr strVarExpr =
         VariableExpr.builder()
             .setVariable(Variable.builder().setName("str").setType(TypeNode.STRING).build())

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/TernaryExprTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/TernaryExprTest.java
@@ -17,11 +17,11 @@ package com.google.api.generator.engine.ast;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class TernaryExprTest {
+class TernaryExprTest {
   @Test
-  public void validTernaryExpr_primitiveType() {
+  void validTernaryExpr_primitiveType() {
     Variable conditionVariable =
         Variable.builder().setName("condition").setType(TypeNode.BOOLEAN).build();
     VariableExpr conditionExpr = VariableExpr.builder().setVariable(conditionVariable).build();
@@ -43,7 +43,7 @@ public class TernaryExprTest {
   }
 
   @Test
-  public void validTernaryExpr_objectType() {
+  void validTernaryExpr_objectType() {
     Variable conditionVariable =
         Variable.builder().setName("condition").setType(TypeNode.BOOLEAN).build();
     VariableExpr conditionExpr = VariableExpr.builder().setVariable(conditionVariable).build();
@@ -65,7 +65,7 @@ public class TernaryExprTest {
   }
 
   @Test
-  public void validTernaryExpr_primitiveAndBoxedType() {
+  void validTernaryExpr_primitiveAndBoxedType() {
     // [Constructing] `condition ? intValue : integerValue`
     // The type of whole expression should be Integer.
     Variable conditionVariable =
@@ -88,7 +88,7 @@ public class TernaryExprTest {
   }
 
   @Test
-  public void validTernaryExpr_boxedAndPrimitiveType() {
+  void validTernaryExpr_boxedAndPrimitiveType() {
     // [Constructing] `condition ? doubleObjectVariable : doubleVariable`
     // The type of whole expression should be Double.
     Variable conditionVariable =
@@ -112,7 +112,7 @@ public class TernaryExprTest {
   }
 
   @Test
-  public void validTernaryExpr_objectAndNull() {
+  void validTernaryExpr_objectAndNull() {
     TernaryExpr ternaryExpr =
         TernaryExpr.builder()
             .setConditionExpr(
@@ -126,7 +126,7 @@ public class TernaryExprTest {
   }
 
   @Test
-  public void validTernaryExpr_nullAndObject() {
+  void validTernaryExpr_nullAndObject() {
     TernaryExpr ternaryExpr =
         TernaryExpr.builder()
             .setConditionExpr(
@@ -140,7 +140,7 @@ public class TernaryExprTest {
   }
 
   @Test
-  public void validTernaryExpr_superAndSubtype() {
+  void validTernaryExpr_superAndSubtype() {
     TernaryExpr ternaryExpr =
         TernaryExpr.builder()
             .setConditionExpr(
@@ -156,7 +156,7 @@ public class TernaryExprTest {
   }
 
   @Test
-  public void validTernaryExpr_subAndSupertype() {
+  void validTernaryExpr_subAndSupertype() {
     TernaryExpr ternaryExpr =
         TernaryExpr.builder()
             .setConditionExpr(
@@ -172,7 +172,7 @@ public class TernaryExprTest {
   }
 
   @Test
-  public void invalidTernaryExpr_mismatchedPrimitiveTypes() {
+  void invalidTernaryExpr_mismatchedPrimitiveTypes() {
     Variable conditionVariable =
         Variable.builder().setName("condition").setType(TypeNode.BOOLEAN).build();
     VariableExpr conditionExpr = VariableExpr.builder().setVariable(conditionVariable).build();
@@ -193,7 +193,7 @@ public class TernaryExprTest {
   }
 
   @Test
-  public void invalidTernaryExpr_mismatchedBoxedAndPrimitiveTypes() {
+  void invalidTernaryExpr_mismatchedBoxedAndPrimitiveTypes() {
     Variable conditionVariable =
         Variable.builder().setName("condition").setType(TypeNode.BOOLEAN).build();
     VariableExpr conditionExpr = VariableExpr.builder().setVariable(conditionVariable).build();
@@ -216,7 +216,7 @@ public class TernaryExprTest {
   }
 
   @Test
-  public void invalidTernaryExpr_incompatibleThenElsePrimitiveTypes() {
+  void invalidTernaryExpr_incompatibleThenElsePrimitiveTypes() {
     assertThrows(
         IllegalStateException.class,
         () ->
@@ -238,7 +238,7 @@ public class TernaryExprTest {
   }
 
   @Test
-  public void invalidTernaryExpr_incompatibleThenElseObjectTypes() {
+  void invalidTernaryExpr_incompatibleThenElseObjectTypes() {
     assertThrows(
         IllegalStateException.class,
         () ->

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/ThisObjectValueTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/ThisObjectValueTest.java
@@ -16,11 +16,11 @@ package com.google.api.generator.engine.ast;
 
 import static org.junit.Assert.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ThisObjectValueTest {
+class ThisObjectValueTest {
   @Test
-  public void validThisObjectValue_basic() {
+  void validThisObjectValue_basic() {
     VaporReference ref =
         VaporReference.builder()
             .setName("Student")
@@ -32,7 +32,7 @@ public class ThisObjectValueTest {
   }
 
   @Test
-  public void invalidThisObjectValue_nonReferenceType() {
+  void invalidThisObjectValue_nonReferenceType() {
     assertThrows(
         IllegalStateException.class,
         () -> {
@@ -41,7 +41,7 @@ public class ThisObjectValueTest {
   }
 
   @Test
-  public void invalidThisObjectValue_nullType() {
+  void invalidThisObjectValue_nullType() {
     assertThrows(
         IllegalStateException.class,
         () -> {

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/ThrowExprTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/ThrowExprTest.java
@@ -17,18 +17,18 @@ package com.google.api.generator.engine.ast;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ThrowExprTest {
+class ThrowExprTest {
   @Test
-  public void createThrowExpr_basic() {
+  void createThrowExpr_basic() {
     TypeNode npeType = TypeNode.withExceptionClazz(NullPointerException.class);
     ThrowExpr.builder().setType(npeType).build();
     // No exception thrown, we're good.
   }
 
   @Test
-  public void createThrowExpr_basicExpr() {
+  void createThrowExpr_basicExpr() {
     TypeNode npeType = TypeNode.withExceptionClazz(NullPointerException.class);
     VariableExpr throwVarExpr =
         VariableExpr.builder()
@@ -46,14 +46,14 @@ public class ThrowExprTest {
   }
 
   @Test
-  public void createThrowExpr_basicWithStringMessage() {
+  void createThrowExpr_basicWithStringMessage() {
     TypeNode npeType = TypeNode.withExceptionClazz(NullPointerException.class);
     ThrowExpr.builder().setType(npeType).setMessageExpr("Some message").build();
     // No exception thrown, we're good.
   }
 
   @Test
-  public void createThrowExpr_messageExpr() {
+  void createThrowExpr_messageExpr() {
     TypeNode npeType = TypeNode.withExceptionClazz(NullPointerException.class);
     Expr messageExpr =
         MethodInvocationExpr.builder()
@@ -65,14 +65,14 @@ public class ThrowExprTest {
   }
 
   @Test
-  public void createThrowExpr_badExceptionType() {
+  void createThrowExpr_badExceptionType() {
     TypeNode nonExceptionType = TypeNode.STRING;
     assertThrows(
         IllegalStateException.class, () -> ThrowExpr.builder().setType(nonExceptionType).build());
   }
 
   @Test
-  public void createThrowExpr_badMessageExpr() {
+  void createThrowExpr_badMessageExpr() {
     TypeNode npeType = TypeNode.withExceptionClazz(NullPointerException.class);
     Expr messageExpr =
         MethodInvocationExpr.builder().setMethodName("foobar").setReturnType(TypeNode.INT).build();
@@ -82,7 +82,7 @@ public class ThrowExprTest {
   }
 
   @Test
-  public void createThrowExpr_causeExpr() {
+  void createThrowExpr_causeExpr() {
     TypeNode npeType =
         TypeNode.withReference(ConcreteReference.withClazz(NullPointerException.class));
     ThrowExpr.builder()
@@ -96,7 +96,7 @@ public class ThrowExprTest {
   }
 
   @Test
-  public void createThrowExpr_causeExpr_throwableSubtype() {
+  void createThrowExpr_causeExpr_throwableSubtype() {
     TypeNode npeType =
         TypeNode.withReference(ConcreteReference.withClazz(NullPointerException.class));
     ThrowExpr.builder()
@@ -110,7 +110,7 @@ public class ThrowExprTest {
   }
 
   @Test
-  public void createThrowExpr_causeExpr_onThrowableSubtype() {
+  void createThrowExpr_causeExpr_onThrowableSubtype() {
     TypeNode npeType =
         TypeNode.withReference(ConcreteReference.withClazz(NullPointerException.class));
     assertThrows(
@@ -123,7 +123,7 @@ public class ThrowExprTest {
   }
 
   @Test
-  public void createThrowExpr_messageAndCauseExpr() {
+  void createThrowExpr_messageAndCauseExpr() {
     TypeNode npeType =
         TypeNode.withReference(ConcreteReference.withClazz(NullPointerException.class));
     Expr messageExpr =
@@ -143,7 +143,7 @@ public class ThrowExprTest {
   }
 
   @Test
-  public void createThrowExpr_cannotThrowVariableDeclaration() {
+  void createThrowExpr_cannotThrowVariableDeclaration() {
     VariableExpr throwVarExpr =
         VariableExpr.builder()
             .setVariable(
@@ -161,7 +161,7 @@ public class ThrowExprTest {
   }
 
   @Test
-  public void createThrowExpr_cannotThrowNonExceptionTypedExpr() {
+  void createThrowExpr_cannotThrowNonExceptionTypedExpr() {
     VariableExpr throwVarExpr =
         VariableExpr.builder()
             .setVariable(Variable.builder().setName("str").setType(TypeNode.STRING).build())
@@ -171,7 +171,7 @@ public class ThrowExprTest {
   }
 
   @Test
-  public void createThrowExpr_cannotHaveThrowVariableAndMessageExprPresent() {
+  void createThrowExpr_cannotHaveThrowVariableAndMessageExprPresent() {
     Expr messageExpr =
         MethodInvocationExpr.builder()
             .setMethodName("foobar")
@@ -191,7 +191,7 @@ public class ThrowExprTest {
   }
 
   @Test
-  public void createThrowExpr_cannotHaveThrowVariableAndCauseExprPresent() {
+  void createThrowExpr_cannotHaveThrowVariableAndCauseExprPresent() {
     VariableExpr throwVarExpr =
         VariableExpr.builder()
             .setVariable(

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/TryCatchStatementTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/TryCatchStatementTest.java
@@ -20,12 +20,12 @@ import static org.junit.Assert.assertThrows;
 
 import java.util.Arrays;
 import java.util.Collections;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class TryCatchStatementTest {
+class TryCatchStatementTest {
 
   @Test
-  public void validTryCatchStatement_simple() {
+  void validTryCatchStatement_simple() {
     Reference exceptionReference = ConcreteReference.withClazz(IllegalArgumentException.class);
     TypeNode type = TypeNode.withReference(exceptionReference);
     VariableExpr variableExpr =
@@ -41,7 +41,7 @@ public class TryCatchStatementTest {
   }
 
   @Test
-  public void validTryCatchStatement_simpleMultiBlock() {
+  void validTryCatchStatement_simpleMultiBlock() {
     VariableExpr firstCatchVarExpr =
         VariableExpr.builder()
             .setVariable(
@@ -67,7 +67,7 @@ public class TryCatchStatementTest {
   }
 
   @Test
-  public void validTryCatchStatement_withResources() {
+  void validTryCatchStatement_withResources() {
     Reference exceptionReference = ConcreteReference.withClazz(IllegalArgumentException.class);
     TypeNode type = TypeNode.withReference(exceptionReference);
     VariableExpr variableExpr =
@@ -85,7 +85,7 @@ public class TryCatchStatementTest {
   }
 
   @Test
-  public void validTryCatchStatement_sampleCode() {
+  void validTryCatchStatement_sampleCode() {
     TryCatchStatement tryCatch =
         TryCatchStatement.builder()
             .setTryBody(Arrays.asList(ExprStatement.withExpr(createAssignmentExpr())))
@@ -95,7 +95,7 @@ public class TryCatchStatementTest {
   }
 
   @Test
-  public void invalidTryCatchStatement_missingCatchVariable() {
+  void invalidTryCatchStatement_missingCatchVariable() {
     assertThrows(
         IllegalStateException.class,
         () ->
@@ -105,7 +105,7 @@ public class TryCatchStatementTest {
   }
 
   @Test
-  public void invalidTryCatchStatement_catchVariableNotDecl() {
+  void invalidTryCatchStatement_catchVariableNotDecl() {
     Reference exceptionReference = ConcreteReference.withClazz(IllegalArgumentException.class);
     TypeNode type = TypeNode.withReference(exceptionReference);
     VariableExpr variableExpr =
@@ -121,7 +121,7 @@ public class TryCatchStatementTest {
   }
 
   @Test
-  public void invalidTryCatchStatement_nonExceptionReference() {
+  void invalidTryCatchStatement_nonExceptionReference() {
     Reference exceptionReference = ConcreteReference.withClazz(Integer.class);
     TypeNode type = TypeNode.withReference(exceptionReference);
     VariableExpr variableExpr =

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/TypeNodeTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/TypeNodeTest.java
@@ -22,9 +22,9 @@ import static org.junit.Assert.assertTrue;
 import com.google.api.generator.engine.ast.TypeNode.TypeKind;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class TypeNodeTest {
+class TypeNodeTest {
   private static final TypeNode INT_ARRAY =
       TypeNode.builder().setTypeKind(TypeKind.INT).setIsArray(true).build();
   private static final TypeNode INTEGER_ARRAY =
@@ -37,7 +37,7 @@ public class TypeNodeTest {
       TypeNode.builder().setTypeKind(TypeKind.BOOLEAN).setIsArray(true).build();
 
   @Test
-  public void strictEquals_basic() {
+  void strictEquals_basic() {
     assertFalse(TypeNode.INT.strictEquals(TypeNode.BOOLEAN));
     assertFalse(TypeNode.CHAR.strictEquals(TypeNode.NULL));
     assertFalse(TypeNode.INT.strictEquals(INT_ARRAY));
@@ -45,7 +45,7 @@ public class TypeNodeTest {
   }
 
   @Test
-  public void strictEquals_referenceType() {
+  void strictEquals_referenceType() {
     TypeNode list = TypeNode.withReference(ConcreteReference.withClazz(List.class));
     TypeNode intList =
         TypeNode.withReference(
@@ -64,7 +64,7 @@ public class TypeNodeTest {
   }
 
   @Test
-  public void isBoxedTypeEquals_basic() {
+  void isBoxedTypeEquals_basic() {
     assertTrue(TypeNode.INT.isBoxedTypeEquals(TypeNode.INT_OBJECT));
     assertTrue(TypeNode.DOUBLE_OBJECT.isBoxedTypeEquals(TypeNode.DOUBLE));
     assertFalse(TypeNode.BOOLEAN_OBJECT.isBoxedTypeEquals(TypeNode.SHORT));
@@ -73,14 +73,14 @@ public class TypeNodeTest {
   }
 
   @Test
-  public void isBoxedTypeEquals_arrayType() {
+  void isBoxedTypeEquals_arrayType() {
     assertFalse(TypeNode.INT.isBoxedTypeEquals(INT_ARRAY));
     assertFalse(INTEGER_ARRAY.isBoxedTypeEquals(INT_ARRAY));
     assertFalse(BOOLEAN_ARRAY.isBoxedTypeEquals(INT_ARRAY));
   }
 
   @Test
-  public void equals_basic() {
+  void equals_basic() {
     assertTrue(TypeNode.INT.equals(TypeNode.INT_OBJECT));
     assertTrue(TypeNode.DOUBLE_OBJECT.equals(TypeNode.DOUBLE));
     assertTrue(TypeNode.BOOLEAN.equals(TypeNode.BOOLEAN));
@@ -92,7 +92,7 @@ public class TypeNodeTest {
   }
 
   @Test
-  public void type_wildcardGenerics() {
+  void type_wildcardGenerics() {
     // No exception thrown equates to success.
     TypeNode.withReference(
         ConcreteReference.builder()
@@ -102,7 +102,7 @@ public class TypeNodeTest {
   }
 
   @Test
-  public void type_wildcardUpperBoundGenerics() {
+  void type_wildcardUpperBoundGenerics() {
     // No exception thrown equates to success.
     TypeNode.withReference(
         ConcreteReference.builder()
@@ -114,7 +114,7 @@ public class TypeNodeTest {
   }
 
   @Test
-  public void compareTypes() {
+  void compareTypes() {
     // Primitive and primitive.
     // Can't compare objects to themselves, so this test is omitted.
     assertThat(TypeNode.INT.compareTo(TypeNode.BOOLEAN)).isGreaterThan(0);
@@ -144,13 +144,13 @@ public class TypeNodeTest {
   }
 
   @Test
-  public void invalidType_topLevelWildcard() {
+  void invalidType_topLevelWildcard() {
     assertThrows(
         IllegalStateException.class, () -> TypeNode.withReference(ConcreteReference.wildcard()));
   }
 
   @Test
-  public void isBoxedType_basic() {
+  void isBoxedType_basic() {
     assertTrue(TypeNode.isBoxedType(TypeNode.INT_OBJECT));
     assertTrue(TypeNode.isBoxedType(TypeNode.BOOLEAN_OBJECT));
     assertTrue(TypeNode.isBoxedType(TypeNode.DOUBLE_OBJECT));

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/UnaryOperationExprTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/UnaryOperationExprTest.java
@@ -16,12 +16,12 @@ package com.google.api.generator.engine.ast;
 
 import static org.junit.Assert.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class UnaryOperationExprTest {
+class UnaryOperationExprTest {
   /** =============================== Logic Not Operation Expr =============================== */
   @Test
-  public void validLogicalNotOperationExpr_basic() {
+  void validLogicalNotOperationExpr_basic() {
     VariableExpr variableExpr =
         VariableExpr.withVariable(
             Variable.builder().setName("x").setType(TypeNode.BOOLEAN).build());
@@ -30,7 +30,7 @@ public class UnaryOperationExprTest {
   }
 
   @Test
-  public void validLogicalNot_boxedType() {
+  void validLogicalNot_boxedType() {
     VariableExpr variableExpr =
         VariableExpr.withVariable(
             Variable.builder().setName("x").setType(TypeNode.BOOLEAN_OBJECT).build());
@@ -39,7 +39,7 @@ public class UnaryOperationExprTest {
   }
 
   @Test
-  public void invalidLogicalNot_numericType() {
+  void invalidLogicalNot_numericType() {
     VariableExpr variableExpr =
         VariableExpr.withVariable(Variable.builder().setName("x").setType(TypeNode.INT).build());
     assertThrows(
@@ -47,7 +47,7 @@ public class UnaryOperationExprTest {
   }
 
   @Test
-  public void invalidLogicalNot_referenceType() {
+  void invalidLogicalNot_referenceType() {
     VariableExpr variableExpr =
         VariableExpr.withVariable(Variable.builder().setName("x").setType(TypeNode.STRING).build());
     assertThrows(
@@ -58,7 +58,7 @@ public class UnaryOperationExprTest {
    * =============================== Post Increment Operation Expr ===============================
    */
   @Test
-  public void validPostIncrement_basic() {
+  void validPostIncrement_basic() {
     VariableExpr variableExpr =
         VariableExpr.withVariable(Variable.builder().setName("x").setType(TypeNode.INT).build());
     UnaryOperationExpr.postfixIncrementWithExpr(variableExpr);
@@ -66,7 +66,7 @@ public class UnaryOperationExprTest {
   }
 
   @Test
-  public void validPostIncrement_boxedType() {
+  void validPostIncrement_boxedType() {
     VariableExpr variableExpr =
         VariableExpr.withVariable(
             Variable.builder().setName("x").setType(TypeNode.FLOAT_OBJECT).build());
@@ -75,7 +75,7 @@ public class UnaryOperationExprTest {
   }
 
   @Test
-  public void invalidPostIncrement_boxedBooleanType() {
+  void invalidPostIncrement_boxedBooleanType() {
     VariableExpr variableExpr =
         VariableExpr.withVariable(
             Variable.builder().setName("x").setType(TypeNode.BOOLEAN_OBJECT).build());
@@ -85,7 +85,7 @@ public class UnaryOperationExprTest {
   }
 
   @Test
-  public void invalidPostIncrement_referenceType() {
+  void invalidPostIncrement_referenceType() {
     VariableExpr variableExpr =
         VariableExpr.withVariable(Variable.builder().setName("x").setType(TypeNode.STRING).build());
     assertThrows(
@@ -94,7 +94,7 @@ public class UnaryOperationExprTest {
   }
 
   @Test
-  public void invalidPostIncrement_finalVariable() {
+  void invalidPostIncrement_finalVariable() {
     Variable variable = Variable.builder().setName("i").setType(TypeNode.INT).build();
     VariableExpr variableExpr =
         VariableExpr.builder().setIsFinal(true).setVariable(variable).build();
@@ -104,7 +104,7 @@ public class UnaryOperationExprTest {
   }
 
   @Test
-  public void invalidPostIncrement_declaredVariable() {
+  void invalidPostIncrement_declaredVariable() {
     Variable variable = Variable.builder().setName("i").setType(TypeNode.INT).build();
     VariableExpr variableExpr =
         VariableExpr.builder().setIsDecl(true).setVariable(variable).build();

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/VaporReferenceTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/VaporReferenceTest.java
@@ -18,11 +18,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class VaporReferenceTest {
+class VaporReferenceTest {
   @Test
-  public void basic() {
+  void basic() {
     String pkg = "com.google.example.examples.library.v1";
     String name = "Babbage";
     Reference ref = VaporReference.builder().setName(name).setPakkage(pkg).build();
@@ -34,7 +34,7 @@ public class VaporReferenceTest {
   }
 
   @Test
-  public void basic_isStaticImport() {
+  void basic_isStaticImport() {
     String pkg = "com.google.example.examples.library.v1";
     String name = "Babbage";
     Reference ref =
@@ -49,7 +49,7 @@ public class VaporReferenceTest {
   }
 
   @Test
-  public void basic_nested() {
+  void basic_nested() {
     String pkg = "com.google.example.examples.library.v1";
     String name = "Charles";
     Reference ref =
@@ -69,7 +69,7 @@ public class VaporReferenceTest {
   }
 
   @Test
-  public void basic_nestedAndStaticImport() {
+  void basic_nestedAndStaticImport() {
     String pkg = "com.google.example.examples.library.v1";
     String name = "Charles";
     String enclosingClassName = "Babbage";
@@ -89,7 +89,7 @@ public class VaporReferenceTest {
   }
 
   @Test
-  public void concreteHierarchiesNotHandled() {
+  void concreteHierarchiesNotHandled() {
     String pkg = "java.io";
     String name = "IOException";
     Reference ref = VaporReference.builder().setName(name).setPakkage(pkg).build();
@@ -101,7 +101,7 @@ public class VaporReferenceTest {
   }
 
   @Test
-  public void enclosingClass() {
+  void enclosingClass() {
     String pkg = "java.util";
     String enclosingName = "Map";
     String name = "Entry";

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/VariableExprTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/VariableExprTest.java
@@ -19,11 +19,11 @@ import static org.junit.Assert.assertThrows;
 
 import java.util.Arrays;
 import java.util.HashMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class VariableExprTest {
+class VariableExprTest {
   @Test
-  public void validVariableExpr_basic() {
+  void validVariableExpr_basic() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.INT).build();
     VariableExpr variableExpr = VariableExpr.builder().setVariable(variable).build();
     assertThat(variableExpr.variable()).isEqualTo(variable);
@@ -35,7 +35,7 @@ public class VariableExprTest {
   }
 
   @Test
-  public void validVariableExpr_staticReference() {
+  void validVariableExpr_staticReference() {
     VariableExpr.builder()
         .setVariable(Variable.builder().setType(TypeNode.INT).setName("MAX_VALUE").build())
         .setStaticReferenceType(TypeNode.INT_OBJECT)
@@ -43,7 +43,7 @@ public class VariableExprTest {
   }
 
   @Test
-  public void validVariableExpr_classFieldOnStaticReference() {
+  void validVariableExpr_classFieldOnStaticReference() {
     VariableExpr.builder()
         .setVariable(
             Variable.builder()
@@ -55,7 +55,7 @@ public class VariableExprTest {
   }
 
   @Test
-  public void validVariableExpr_classFieldOnExprReference() {
+  void validVariableExpr_classFieldOnExprReference() {
     VariableExpr.builder()
         .setVariable(
             Variable.builder()
@@ -71,7 +71,7 @@ public class VariableExprTest {
   }
 
   @Test
-  public void validVariableExpr_withFields() {
+  void validVariableExpr_withFields() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.STRING).build();
     VariableExpr variableExpr =
         VariableExpr.builder()
@@ -89,7 +89,7 @@ public class VariableExprTest {
   }
 
   @Test
-  public void validVariableExpr_declaration() {
+  void validVariableExpr_declaration() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.BOOLEAN).build();
     VariableExpr variableExpr =
         VariableExpr.builder().setVariable(variable).setIsDecl(true).build();
@@ -99,7 +99,7 @@ public class VariableExprTest {
   }
 
   @Test
-  public void validVariableExpr_volatileDeclaration() {
+  void validVariableExpr_volatileDeclaration() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.BOOLEAN).build();
     VariableExpr variableExpr =
         VariableExpr.builder()
@@ -118,7 +118,7 @@ public class VariableExprTest {
   }
 
   @Test
-  public void validVariableExpr_reference() {
+  void validVariableExpr_reference() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.STRING_ARRAY).build();
     VariableExpr variableExpr = VariableExpr.builder().setVariable(variable).build();
 
@@ -128,7 +128,7 @@ public class VariableExprTest {
   }
 
   @Test
-  public void validVariableExpr_referenceWithModifiersSet() {
+  void validVariableExpr_referenceWithModifiersSet() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.STRING_ARRAY).build();
     VariableExpr variableExpr = VariableExpr.builder().setVariable(variable).build();
 
@@ -144,7 +144,7 @@ public class VariableExprTest {
   }
 
   @Test
-  public void validVariableExpr_templatedArgInMethod() {
+  void validVariableExpr_templatedArgInMethod() {
     Variable variable =
         Variable.builder()
             .setName("x")
@@ -158,7 +158,7 @@ public class VariableExprTest {
   }
 
   @Test
-  public void validVariableExpr_templatedArgNameAndTypeInMethod() {
+  void validVariableExpr_templatedArgNameAndTypeInMethod() {
     Variable variable =
         Variable.builder()
             .setName("x")
@@ -174,7 +174,7 @@ public class VariableExprTest {
   }
 
   @Test
-  public void validVariableExpr_declarationWithAnnotations() {
+  void validVariableExpr_declarationWithAnnotations() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.BOOLEAN).build();
     VariableExpr variableExpr =
         VariableExpr.builder()
@@ -194,7 +194,7 @@ public class VariableExprTest {
   }
 
   @Test
-  public void invalidVariableExpr_templatedArgInMethodHasNonStringNonTypeNodeObject() {
+  void invalidVariableExpr_templatedArgInMethodHasNonStringNonTypeNodeObject() {
     Variable variable =
         Variable.builder()
             .setName("x")
@@ -210,7 +210,7 @@ public class VariableExprTest {
   }
 
   @Test
-  public void invalidVariableExpr_badTemplateName() {
+  void invalidVariableExpr_badTemplateName() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.STRING_ARRAY).build();
     assertThrows(
         IdentifierNode.InvalidIdentifierException.class,
@@ -222,7 +222,7 @@ public class VariableExprTest {
   }
 
   @Test
-  public void invalidVariableExpr_referencePrimitiveType() {
+  void invalidVariableExpr_referencePrimitiveType() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.INT).build();
     VariableExpr variableExpr = VariableExpr.builder().setVariable(variable).build();
 
@@ -237,7 +237,7 @@ public class VariableExprTest {
   }
 
   @Test
-  public void invalidVariableExpr_referenceAndDecl() {
+  void invalidVariableExpr_referenceAndDecl() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.STRING_ARRAY).build();
     VariableExpr variableExpr = VariableExpr.builder().setVariable(variable).build();
 
@@ -253,7 +253,7 @@ public class VariableExprTest {
   }
 
   @Test
-  public void invalidVariableExpr_exprAndStaticReference() {
+  void invalidVariableExpr_exprAndStaticReference() {
     Variable refVariable = Variable.builder().setName("x").setType(TypeNode.STRING_ARRAY).build();
     assertThrows(
         IllegalStateException.class,
@@ -266,7 +266,7 @@ public class VariableExprTest {
   }
 
   @Test
-  public void invalidVariableExpr_primitiveStaticReference() {
+  void invalidVariableExpr_primitiveStaticReference() {
     assertThrows(
         IllegalStateException.class,
         () ->
@@ -277,7 +277,7 @@ public class VariableExprTest {
   }
 
   @Test
-  public void invalidVariableExpr_standaloneClassField() {
+  void invalidVariableExpr_standaloneClassField() {
     assertThrows(
         IllegalStateException.class,
         () ->
@@ -291,7 +291,7 @@ public class VariableExprTest {
   }
 
   @Test
-  public void invalidVariableExpr_classFieldOnPrimitiveType() {
+  void invalidVariableExpr_classFieldOnPrimitiveType() {
     assertThrows(
         IllegalStateException.class,
         () ->
@@ -310,7 +310,7 @@ public class VariableExprTest {
   }
 
   @Test
-  public void invalidVariableExpr_annotationNoDeclaration() {
+  void invalidVariableExpr_annotationNoDeclaration() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.BOOLEAN).build();
     VariableExpr.Builder variableExprBuilder =
         VariableExpr.builder()

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/VariableTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/VariableTest.java
@@ -19,11 +19,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 import com.google.api.generator.engine.ast.TypeNode.TypeKind;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class VariableTest {
+class VariableTest {
   @Test
-  public void createVariable_basic() {
+  void createVariable_basic() {
     assertValidVariable(TypeKind.INT, "intVar");
     assertValidVariable(TypeKind.BOOLEAN, "boolVar");
     assertValidVariable(TypeKind.DOUBLE, "doubleVar");
@@ -33,7 +33,7 @@ public class VariableTest {
   }
 
   @Test
-  public void createVariable_setIdentifier() {
+  void createVariable_setIdentifier() {
     IdentifierNode identifierNode = IdentifierNode.builder().setName("x").build();
     Variable variable =
         Variable.builder()
@@ -46,7 +46,7 @@ public class VariableTest {
   }
 
   @Test
-  public void createVariable_invalidType() {
+  void createVariable_invalidType() {
     assertInvalidVariable(TypeNode.VOID);
     assertInvalidVariable(TypeNode.NULL);
   }

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/WhileStatementTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/ast/WhileStatementTest.java
@@ -19,11 +19,11 @@ import static org.junit.Assert.assertThrows;
 
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class WhileStatementTest {
+class WhileStatementTest {
   @Test
-  public void validWhileStatement_simple() {
+  void validWhileStatement_simple() {
     WhileStatement whileStatement =
         WhileStatement.builder()
             .setConditionExpr(createConditionExpr("condition"))
@@ -33,7 +33,7 @@ public class WhileStatementTest {
   }
 
   @Test
-  public void validWhileStatement_booleanObjectCondition() {
+  void validWhileStatement_booleanObjectCondition() {
     // The condition expression type can be boolean or its boxed type.
     VariableExpr condExpr =
         VariableExpr.withVariable(
@@ -47,7 +47,7 @@ public class WhileStatementTest {
   }
 
   @Test
-  public void validWhileStatement_nested() {
+  void validWhileStatement_nested() {
     WhileStatement nestedWhileStatement =
         WhileStatement.builder()
             .setConditionExpr(createConditionExpr("nestedCondition"))
@@ -62,7 +62,7 @@ public class WhileStatementTest {
   }
 
   @Test
-  public void invalidWhileStatement_emptyBody() {
+  void invalidWhileStatement_emptyBody() {
     assertThrows(
         IllegalStateException.class,
         () -> {

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/lexicon/InvalidSymbolTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/lexicon/InvalidSymbolTest.java
@@ -16,12 +16,12 @@ package com.google.api.generator.engine.lexicon;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class InvalidSymbolTest {
+class InvalidSymbolTest {
 
   @Test
-  public void invalidSymbolDetected() {
+  void invalidSymbolDetected() {
     assertThat(InvalidSymbol.containsInvalidSymbol("foo")).isFalse();
 
     assertThat(InvalidSymbol.containsInvalidSymbol("foo`foo")).isTrue();

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/lexicon/KeywordTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/lexicon/KeywordTest.java
@@ -16,11 +16,11 @@ package com.google.api.generator.engine.lexicon;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class KeywordTest {
+class KeywordTest {
   @Test
-  public void keywordDetected() {
+  void keywordDetected() {
     // Modifiers.
     assertThat(Keyword.isKeyword("static")).isTrue();
     assertThat(Keyword.isKeyword("private")).isTrue();
@@ -47,32 +47,32 @@ public class KeywordTest {
   }
 
   @Test
-  public void unescapedKeyword_shouldReturnItselfIfEmpty() {
+  void unescapedKeyword_shouldReturnItselfIfEmpty() {
     assertThat(Keyword.unescapeKeyword("")).isEqualTo("");
   }
 
   @Test
-  public void unescapedKeyword_shouldReturnItselfIfDoesNotEndWithEscapeChar() {
+  void unescapedKeyword_shouldReturnItselfIfDoesNotEndWithEscapeChar() {
     assertThat(Keyword.unescapeKeyword("hello")).isEqualTo("hello");
   }
 
   @Test
-  public void unescapedKeyword_shouldReturnItselfIfEndsWithEscapeCharButNotAKeyword() {
+  void unescapedKeyword_shouldReturnItselfIfEndsWithEscapeCharButNotAKeyword() {
     assertThat(Keyword.unescapeKeyword("important_")).isEqualTo("important_");
   }
 
   @Test
-  public void unescapedKeyword_shouldUnescapeIfEndsWithEscapeCharAndAKeyword() {
+  void unescapedKeyword_shouldUnescapeIfEndsWithEscapeCharAndAKeyword() {
     assertThat(Keyword.unescapeKeyword("import_")).isEqualTo("import");
   }
 
   @Test
-  public void escapeKeyword_shouldEscapeIfIsAKeyword() {
+  void escapeKeyword_shouldEscapeIfIsAKeyword() {
     assertThat(Keyword.escapeKeyword("final")).isEqualTo("final_");
   }
 
   @Test
-  public void escapeKeyword_shouldNotEscapeIfIsNotAKeyword() {
+  void escapeKeyword_shouldNotEscapeIfIsNotAKeyword() {
     assertThat(Keyword.escapeKeyword("fantasy")).isEqualTo("fantasy");
   }
 }

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/lexicon/LiteralTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/lexicon/LiteralTest.java
@@ -16,17 +16,17 @@ package com.google.api.generator.engine.lexicon;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class LiteralTest {
+class LiteralTest {
   @Test
-  public void booleanDetected() {
+  void booleanDetected() {
     assertThat(Literal.isBooleanLiteral("True")).isFalse();
     assertThat(Literal.isBooleanLiteral("true")).isTrue();
   }
 
   @Test
-  public void nullLDetected() {
+  void nullLDetected() {
     assertThat(Literal.isNullLiteral("NULL")).isFalse();
     assertThat(Literal.isNullLiteral("null")).isTrue();
     assertThat(Literal.isNullLiteral("null_asdf")).isFalse();
@@ -34,7 +34,7 @@ public class LiteralTest {
   }
 
   @Test
-  public void integerDetected() {
+  void integerDetected() {
     assertThat(Literal.isIntegerLiteral("a123")).isFalse();
     assertThat(Literal.isIntegerLiteral("123")).isTrue();
     assertThat(Literal.isIntegerLiteral("-123")).isTrue();
@@ -44,7 +44,7 @@ public class LiteralTest {
   }
 
   @Test
-  public void longDetected() {
+  void longDetected() {
     assertThat(Literal.isLongLiteral("123")).isTrue();
     assertThat(Literal.isLongLiteral("123L")).isTrue();
     assertThat(Literal.isLongLiteral("123l")).isTrue();
@@ -53,7 +53,7 @@ public class LiteralTest {
   }
 
   @Test
-  public void floatDetected() {
+  void floatDetected() {
     assertThat(Literal.isFloatLiteral("123")).isTrue();
     assertThat(Literal.isFloatLiteral("123f")).isTrue();
     assertThat(Literal.isFloatLiteral("123.")).isFalse();
@@ -68,7 +68,7 @@ public class LiteralTest {
   }
 
   @Test
-  public void doubleDetected() {
+  void doubleDetected() {
     assertThat(Literal.isDoubleLiteral("123")).isTrue();
     assertThat(Literal.isDoubleLiteral("0.01")).isTrue();
     assertThat(Literal.isDoubleLiteral(".01")).isTrue();
@@ -86,7 +86,7 @@ public class LiteralTest {
   }
 
   @Test
-  public void literalDetected() {
+  void literalDetected() {
     assertThat(Literal.isLiteral("False")).isFalse();
     assertThat(Literal.isLiteral("asdf")).isFalse();
     assertThat(Literal.isLiteral("asdf12345")).isFalse();

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/lexicon/OperatorTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/lexicon/OperatorTest.java
@@ -16,12 +16,12 @@ package com.google.api.generator.engine.lexicon;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class OperatorTest {
+class OperatorTest {
 
   @Test
-  public void operatorsDetected() {
+  void operatorsDetected() {
     assertThat(Operator.containsOperator("foo")).isFalse();
 
     assertThat(Operator.containsOperator("foo+foo")).isTrue();

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/lexicon/SeparatorTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/lexicon/SeparatorTest.java
@@ -16,11 +16,11 @@ package com.google.api.generator.engine.lexicon;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class SeparatorTest {
+class SeparatorTest {
   @Test
-  public void separatorTest() {
+  void separatorTest() {
     assertThat(Separator.containsSeparator("foo")).isFalse();
 
     assertThat(Separator.containsSeparator("foo.foo")).isTrue();

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/writer/ImportWriterVisitorTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/writer/ImportWriterVisitorTest.java
@@ -71,22 +71,22 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.LongStream;
 import javax.annotation.Generated;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class ImportWriterVisitorTest {
+class ImportWriterVisitorTest {
   private static final String CURRENT_PACKAGE = "com.google.api.generator.engine.foobar";
   private static final String CURRENT_CLASS = "SomeClass";
   private ImportWriterVisitor writerVisitor;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     writerVisitor = new ImportWriterVisitor();
     writerVisitor.initialize(CURRENT_PACKAGE, CURRENT_CLASS);
   }
 
   @Test
-  public void writeReferenceTypeImports_basic() {
+  void writeReferenceTypeImports_basic() {
     TypeNode.withReference(ConcreteReference.withClazz(List.class)).accept(writerVisitor);
     assertEquals("import java.util.List;\n\n", writerVisitor.write());
 
@@ -98,7 +98,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeReferenceTypeImports_useFullName() {
+  void writeReferenceTypeImports_useFullName() {
     TypeNode.withReference(
             ConcreteReference.builder().setClazz(List.class).setUseFullName(true).build())
         .accept(writerVisitor);
@@ -116,7 +116,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeNewObjectExprImports_basic() {
+  void writeNewObjectExprImports_basic() {
     // [Constructing] `new ArrayList<>()`
     NewObjectExpr newObjectExpr =
         NewObjectExpr.builder()
@@ -128,7 +128,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeNewObjectExprImports_withArgs() {
+  void writeNewObjectExprImports_withArgs() {
     // [Constructing] `new FileOutputStream(File file)` and the argument needs to be imported.
     ConcreteReference fileOutputStreamRef = ConcreteReference.withClazz(FileOutputStream.class);
     ConcreteReference fileRef = ConcreteReference.withClazz(File.class);
@@ -147,7 +147,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeNewObjectExprImports_genericsAndVariableArgs() {
+  void writeNewObjectExprImports_genericsAndVariableArgs() {
     // [Constructing] `new HashMap<List<String>, Integer>>(int initialCapacity, float loadFactor)`
     ConcreteReference listRef =
         ConcreteReference.builder()
@@ -179,7 +179,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeNewObjectExprImports_methodExprArg() {
+  void writeNewObjectExprImports_methodExprArg() {
     // [Constructing] `new IOException(message, cause(mapArg))` and `cause(mapArg)` is a method
     // invocation with a `HashMap` argument.
     TypeNode exceptionType = TypeNode.withReference(ConcreteReference.withClazz(IOException.class));
@@ -208,7 +208,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeTernaryExprImports() {
+  void writeTernaryExprImports() {
     MethodInvocationExpr conditionExpr =
         MethodInvocationExpr.builder()
             .setStaticReferenceType(TypeNode.withReference(ConcreteReference.withClazz(Expr.class)))
@@ -246,7 +246,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeVariableExprImports_staticReference() {
+  void writeVariableExprImports_staticReference() {
     VariableExpr variableExpr =
         VariableExpr.builder()
             .setVariable(
@@ -268,7 +268,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeVariableExprImports_wildcardType() {
+  void writeVariableExprImports_wildcardType() {
     TypeNode wildcardListType =
         TypeNode.withReference(
             ConcreteReference.builder()
@@ -286,7 +286,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeVariableExprImport_wildcardTypeWithUpperBound() {
+  void writeVariableExprImport_wildcardTypeWithUpperBound() {
     TypeNode wildcardListType =
         TypeNode.withReference(
             ConcreteReference.builder()
@@ -310,7 +310,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeVariableExprImports_reference() {
+  void writeVariableExprImports_reference() {
     Variable variable =
         Variable.builder()
             .setName("expr")
@@ -334,7 +334,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeVariableExprImports_nestedReference() {
+  void writeVariableExprImports_nestedReference() {
     Variable variable =
         Variable.builder()
             .setName("expr")
@@ -367,7 +367,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeVariableExprImports_withAnnotations() {
+  void writeVariableExprImports_withAnnotations() {
     Variable variable =
         Variable.builder()
             .setName("expr")
@@ -393,7 +393,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeVariableExprImports_annotationsWithDescription() {
+  void writeVariableExprImports_annotationsWithDescription() {
     Variable variable =
         Variable.builder()
             .setName("expr")
@@ -430,7 +430,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeVaporReferenceImport_outermostForNestedClass() {
+  void writeVaporReferenceImport_outermostForNestedClass() {
     VaporReference nestedVaporReference =
         VaporReference.builder()
             .setName("Inner")
@@ -443,7 +443,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeConcreteReferenceImport_outermostForNestedClass() {
+  void writeConcreteReferenceImport_outermostForNestedClass() {
     ConcreteReference nestedConcreteReference =
         ConcreteReference.withClazz(Outer.Middle.Inner.class);
     TypeNode.withReference(nestedConcreteReference).accept(writerVisitor);
@@ -451,7 +451,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeAnonymousClassExprImports() {
+  void writeAnonymousClassExprImports() {
     // [Constructing] Function<List<IOException>, MethodDefinition>
     ConcreteReference exceptionListRef =
         ConcreteReference.builder()
@@ -526,7 +526,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeThrowExprImports_basic() {
+  void writeThrowExprImports_basic() {
     TypeNode exceptionTypes =
         TypeNode.withReference(ConcreteReference.withClazz(IOException.class));
     String message = "Some message asdf";
@@ -537,7 +537,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeThrowExprImports_throwExpr() {
+  void writeThrowExprImports_throwExpr() {
     Expr exprToThrow =
         MethodInvocationExpr.builder()
             .setStaticReferenceType(
@@ -557,7 +557,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeThrowExprImports_messageExpr() {
+  void writeThrowExprImports_messageExpr() {
     TypeNode npeType = TypeNode.withExceptionClazz(NullPointerException.class);
     Expr messageExpr =
         MethodInvocationExpr.builder()
@@ -584,7 +584,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeThrowExprImports_messageAndCauseExpr() {
+  void writeThrowExprImports_messageAndCauseExpr() {
     TypeNode npeType = TypeNode.withExceptionClazz(NullPointerException.class);
     Expr messageExpr =
         MethodInvocationExpr.builder()
@@ -620,7 +620,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeInstanceofExprImports_basic() {
+  void writeInstanceofExprImports_basic() {
     TypeNode exprType = TypeNode.withReference(ConcreteReference.withClazz(Expr.class));
     TypeNode assignExprType =
         TypeNode.withReference(ConcreteReference.withClazz(AssignmentExpr.class));
@@ -639,7 +639,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeEnumRefExprImports_basic() {
+  void writeEnumRefExprImports_basic() {
     TypeNode enumType =
         TypeNode.withReference(
             ConcreteReference.builder()
@@ -655,7 +655,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeEnumRefExprImports_nested() {
+  void writeEnumRefExprImports_nested() {
     TypeNode enumType =
         TypeNode.withReference(ConcreteReference.withClazz(TypeNode.TypeKind.class));
     EnumRefExpr enumRefExpr = EnumRefExpr.builder().setName("VOID").setType(enumType).build();
@@ -664,7 +664,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeReturnExprImports_basic() {
+  void writeReturnExprImports_basic() {
     ReturnExpr returnExpr =
         ReturnExpr.withExpr(
             MethodInvocationExpr.builder()
@@ -676,7 +676,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeMethodDefinitionImports_templatedMixedNamesAndTypes() {
+  void writeMethodDefinitionImports_templatedMixedNamesAndTypes() {
     Reference mapRef = ConcreteReference.withClazz(Map.class);
     List<VariableExpr> arguments =
         Arrays.asList(
@@ -718,7 +718,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeReferenceConstructorExprImports_basic() {
+  void writeReferenceConstructorExprImports_basic() {
     VaporReference ref =
         VaporReference.builder().setName("Parent").setPakkage("com.google.example.v1").build();
     TypeNode classType = TypeNode.withReference(ref);
@@ -729,7 +729,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeReferenceConstructorExprImports_withArgs() {
+  void writeReferenceConstructorExprImports_withArgs() {
     VaporReference ref =
         VaporReference.builder().setName("Student").setPakkage("com.google.example.v1").build();
     TypeNode classType = TypeNode.withReference(ref);
@@ -749,7 +749,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeArithmeticOperationExprImports() {
+  void writeArithmeticOperationExprImports() {
     MethodInvocationExpr lhsExpr =
         MethodInvocationExpr.builder()
             .setStaticReferenceType(TypeNode.withReference(ConcreteReference.withClazz(Expr.class)))
@@ -764,7 +764,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeSynchronizedStatementImports_basicThis() {
+  void writeSynchronizedStatementImports_basicThis() {
     SynchronizedStatement synchronizedStatement =
         SynchronizedStatement.builder()
             .setLock(
@@ -786,7 +786,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeSuperObjectValueImports() {
+  void writeSuperObjectValueImports() {
     VaporReference ref =
         VaporReference.builder()
             .setName("Student")
@@ -805,7 +805,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeSynchronizedStatementImports_basicVariableExpr() {
+  void writeSynchronizedStatementImports_basicVariableExpr() {
     VariableExpr strVarExpr =
         VariableExpr.withVariable(
             Variable.builder()
@@ -833,7 +833,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeUnaryOperationExprImports_LogicalNot() {
+  void writeUnaryOperationExprImports_LogicalNot() {
     MethodInvocationExpr expr =
         MethodInvocationExpr.builder()
             .setStaticReferenceType(TypeNode.withReference(ConcreteReference.withClazz(Expr.class)))
@@ -846,7 +846,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeUnaryOperationExprImports_PostIncrement() {
+  void writeUnaryOperationExprImports_PostIncrement() {
     MethodInvocationExpr expr =
         MethodInvocationExpr.builder()
             .setStaticReferenceType(TypeNode.withReference(ConcreteReference.withClazz(Expr.class)))
@@ -859,7 +859,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeRelationalOperationExprImports() {
+  void writeRelationalOperationExprImports() {
     MethodInvocationExpr lhsExpr =
         MethodInvocationExpr.builder()
             .setStaticReferenceType(TypeNode.withReference(ConcreteReference.withClazz(Expr.class)))
@@ -889,7 +889,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeLogicalOperationExprImports() {
+  void writeLogicalOperationExprImports() {
     MethodInvocationExpr lhsExpr =
         MethodInvocationExpr.builder()
             .setStaticReferenceType(
@@ -908,14 +908,14 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeEmptyLineStatementImports() {
+  void writeEmptyLineStatementImports() {
     EmptyLineStatement statement = EmptyLineStatement.create();
     statement.accept(writerVisitor);
     assertThat(writerVisitor.write()).isEmpty();
   }
 
   @Test
-  public void writePackageInfoDefinitionImports() {
+  void writePackageInfoDefinitionImports() {
     PackageInfoDefinition packageInfo =
         PackageInfoDefinition.builder()
             .setPakkage("com.google.example.library.v1")
@@ -935,7 +935,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void writeLambdaExprImports() {
+  void writeLambdaExprImports() {
     // Similar to method defnitions.
     Reference mapRef = ConcreteReference.withClazz(Map.class);
     List<VariableExpr> arguments =
@@ -981,7 +981,7 @@ public class ImportWriterVisitorTest {
   }
 
   @Test
-  public void importArrayExprTypes() {
+  void importArrayExprTypes() {
     ArrayExpr arrayExpr =
         ArrayExpr.builder()
             .setType(

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/writer/JavaWriterVisitorTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/writer/JavaWriterVisitorTest.java
@@ -90,26 +90,26 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 import javax.annotation.Generated;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class JavaWriterVisitorTest {
+class JavaWriterVisitorTest {
   private JavaWriterVisitor writerVisitor;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     writerVisitor = new JavaWriterVisitor();
   }
 
   @Test
-  public void writeIdentifier() {
+  void writeIdentifier() {
     String idName = "foobar";
     IdentifierNode.builder().setName(idName).build().accept(writerVisitor);
     assertEquals(idName, writerVisitor.write());
   }
 
   @Test
-  public void writePrimitiveType() {
+  void writePrimitiveType() {
     TypeNode intType = TypeNode.INT;
     assertThat(intType).isNotNull();
     intType.accept(writerVisitor);
@@ -117,7 +117,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writePrimitiveArrayType() {
+  void writePrimitiveArrayType() {
     TypeNode byteArrayType =
         TypeNode.builder().setTypeKind(TypeNode.TypeKind.BYTE).setIsArray(true).build();
     assertThat(byteArrayType).isNotNull();
@@ -126,7 +126,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeReferenceType_basic() {
+  void writeReferenceType_basic() {
     TypeNode.withReference(ConcreteReference.withClazz(List.class)).accept(writerVisitor);
     assertEquals("List", writerVisitor.write());
 
@@ -138,7 +138,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeVaporReferenceType_nestedClasses() {
+  void writeVaporReferenceType_nestedClasses() {
     VaporReference nestedVaporReference =
         VaporReference.builder()
             .setName("Inner")
@@ -150,7 +150,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeConcreteReferenceType_nestedClasses() {
+  void writeConcreteReferenceType_nestedClasses() {
     ConcreteReference nestedConcreteReference =
         ConcreteReference.withClazz(Outer.Middle.Inner.class);
     TypeNode.withReference(nestedConcreteReference).accept(writerVisitor);
@@ -158,7 +158,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeReferenceType_useFullName() {
+  void writeReferenceType_useFullName() {
     TypeNode.withReference(
             ConcreteReference.builder().setClazz(List.class).setUseFullName(true).build())
         .accept(writerVisitor);
@@ -176,21 +176,21 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeAnnotation_simple() {
+  void writeAnnotation_simple() {
     AnnotationNode annotation = AnnotationNode.OVERRIDE;
     annotation.accept(writerVisitor);
     assertEquals("@Override\n", writerVisitor.write());
   }
 
   @Test
-  public void writeAnnotation_withStringDescription() {
+  void writeAnnotation_withStringDescription() {
     AnnotationNode annotation = AnnotationNode.withSuppressWarnings("all");
     annotation.accept(writerVisitor);
     assertEquals("@SuppressWarnings(\"all\")\n", writerVisitor.write());
   }
 
   @Test
-  public void writeAnnotation_withValueDescription() {
+  void writeAnnotation_withValueDescription() {
     TypeNode fakeAnnotationType =
         TypeNode.withReference(
             VaporReference.builder().setName("FakeAnnotation").setPakkage("com.foo.bar").build());
@@ -206,7 +206,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeAnnotation_withVariableExprDescription() {
+  void writeAnnotation_withVariableExprDescription() {
     TypeNode conditionalOnPropertyType =
         TypeNode.withReference(
             VaporReference.builder()
@@ -235,7 +235,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeAnnotation_withMultipleNamedDescriptions() {
+  void writeAnnotation_withMultipleNamedDescriptions() {
     TypeNode conditionalOnPropertyType =
         TypeNode.withReference(
             VaporReference.builder()
@@ -274,7 +274,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeAnnotation_withInvalidDescriptions() {
+  void writeAnnotation_withInvalidDescriptions() {
     TypeNode fakeAnnotationType =
         TypeNode.withReference(
             VaporReference.builder().setName("FakeAnnotation").setPakkage("com.foo.bar").build());
@@ -339,7 +339,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeAnnotation_withArrayExpr() {
+  void writeAnnotation_withArrayExpr() {
     TypeNode fakeAnnotationType =
         TypeNode.withReference(
             VaporReference.builder().setName("FakeAnnotation").setPakkage("com.foo.bar").build());
@@ -358,7 +358,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeAnnotation_withArrayExprAssignment() {
+  void writeAnnotation_withArrayExprAssignment() {
     TypeNode fakeAnnotationType =
         TypeNode.withReference(
             VaporReference.builder().setName("FakeAnnotation").setPakkage("com.foo.bar").build());
@@ -404,7 +404,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeArrayExpr_add1StringExpr() {
+  void writeArrayExpr_add1StringExpr() {
     ArrayExpr expr =
         ArrayExpr.builder()
             .setType(TypeNode.createArrayTypeOf(TypeNode.STRING))
@@ -415,7 +415,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeArrayExpr_addManyStrExpr() {
+  void writeArrayExpr_addManyStrExpr() {
     ArrayExpr expr =
         ArrayExpr.builder()
             .setType(TypeNode.createArrayTypeOf(TypeNode.STRING))
@@ -428,7 +428,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeArrayExpr_addManyClassExpr() {
+  void writeArrayExpr_addManyClassExpr() {
     ArrayExpr expr =
         ArrayExpr.builder()
             .setType(TypeNode.createArrayTypeOf(TypeNode.CLASS_OBJECT))
@@ -441,7 +441,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeArrayExpr_mixedVariablesStaticAndNormalReference() {
+  void writeArrayExpr_mixedVariablesStaticAndNormalReference() {
     VariableExpr clazzVar =
         VariableExpr.builder()
             .setVariable(
@@ -458,7 +458,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeArrayExpr_assignemntWithDeclaration() {
+  void writeArrayExpr_assignemntWithDeclaration() {
     VariableExpr varExpr =
         VariableExpr.builder()
             .setVariable(
@@ -481,7 +481,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeNewObjectExpr_basic() {
+  void writeNewObjectExpr_basic() {
     // isGeneric() is true, but generics() is empty.
     ConcreteReference ref = ConcreteReference.withClazz(List.class);
     TypeNode type = TypeNode.withReference(ref);
@@ -491,7 +491,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeNewObjectExpr_withMethodExprArgs() {
+  void writeNewObjectExpr_withMethodExprArgs() {
     // isGeneric() is false, and generics() is empty.
     // [Constructing] `new IOException(message, cause())` and `cause()` is a method invocation.
     TypeNode type = TypeNode.withReference(ConcreteReference.withClazz(IOException.class));
@@ -512,7 +512,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeNewObjectExpr_withGenericsAndArgs() {
+  void writeNewObjectExpr_withGenericsAndArgs() {
     // isGeneric() is true and generics() is not empty.
     ConcreteReference listRef =
         ConcreteReference.builder()
@@ -553,7 +553,7 @@ public class JavaWriterVisitorTest {
 
   /** =============================== EXPRESSIONS =============================== */
   @Test
-  public void writeValueExpr() {
+  void writeValueExpr() {
     Value value = PrimitiveValue.builder().setType(TypeNode.INT).setValue("3").build();
     ValueExpr valueExpr = ValueExpr.builder().setValue(value).build();
     valueExpr.accept(writerVisitor);
@@ -561,7 +561,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeVariableExpr_basic() {
+  void writeVariableExpr_basic() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.INT).build();
     VariableExpr variableExpr = VariableExpr.builder().setVariable(variable).build();
 
@@ -570,7 +570,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeVariableExpr_wildcardType() {
+  void writeVariableExpr_wildcardType() {
     TypeNode wildcardListType =
         TypeNode.withReference(
             ConcreteReference.builder()
@@ -587,7 +587,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeVariableExpr_wildcardTypeWithUpperBound() {
+  void writeVariableExpr_wildcardTypeWithUpperBound() {
     TypeNode wildcardListType =
         TypeNode.withReference(
             ConcreteReference.builder()
@@ -607,7 +607,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeVariableExpr_staticReference() {
+  void writeVariableExpr_staticReference() {
     VariableExpr variableExpr =
         VariableExpr.builder()
             .setVariable(
@@ -620,7 +620,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeVariableExpr_nonDeclIgnoresModifiers() {
+  void writeVariableExpr_nonDeclIgnoresModifiers() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.BOOLEAN).build();
     VariableExpr expr =
         VariableExpr.builder()
@@ -635,7 +635,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeVariableExpr_basicLocalDecl() {
+  void writeVariableExpr_basicLocalDecl() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.INT).build();
     VariableExpr expr = VariableExpr.builder().setVariable(variable).setIsDecl(true).build();
 
@@ -644,7 +644,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeVariableExpr_localFinalDecl() {
+  void writeVariableExpr_localFinalDecl() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.BOOLEAN).build();
 
     VariableExpr expr =
@@ -655,7 +655,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeVariableExpr_scopedDecl() {
+  void writeVariableExpr_scopedDecl() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.INT).build();
     VariableExpr expr =
         VariableExpr.builder()
@@ -669,7 +669,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeVariableExpr_scopedStaticFinalDecl() {
+  void writeVariableExpr_scopedStaticFinalDecl() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.BOOLEAN).build();
     VariableExpr expr =
         VariableExpr.builder()
@@ -685,7 +685,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeVariableExpr_scopedStaticFinalVolatileDecl() {
+  void writeVariableExpr_scopedStaticFinalVolatileDecl() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.BOOLEAN).build();
     VariableExpr expr =
         VariableExpr.builder()
@@ -702,7 +702,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeVariableExpr_basicReference() {
+  void writeVariableExpr_basicReference() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.STRING_ARRAY).build();
     VariableExpr variableExpr = VariableExpr.builder().setVariable(variable).build();
 
@@ -714,7 +714,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeVariableExpr_basicReferenceWithModifiersSet() {
+  void writeVariableExpr_basicReferenceWithModifiersSet() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.STRING_ARRAY).build();
     VariableExpr variableExpr = VariableExpr.builder().setVariable(variable).build();
 
@@ -732,7 +732,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeVariableExpr_nestedReference() {
+  void writeVariableExpr_nestedReference() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.STRING_ARRAY).build();
     VariableExpr variableExpr = VariableExpr.builder().setVariable(variable).build();
 
@@ -751,7 +751,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeArithmeticOperationExpr_concatStringWithMethod() {
+  void writeArithmeticOperationExpr_concatStringWithMethod() {
     ValueExpr lhsExpr = ValueExpr.withValue(StringObjectValue.withValue("someWord"));
     MethodInvocationExpr methodInvocationExpr =
         MethodInvocationExpr.builder().setMethodName("getMethod").build();
@@ -768,7 +768,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeArithmeticOperationExpr_concatStringWithNumber() {
+  void writeArithmeticOperationExpr_concatStringWithNumber() {
     ValueExpr rhsExpr =
         ValueExpr.withValue(PrimitiveValue.builder().setType(TypeNode.INT).setValue("5").build());
     ValueExpr lhsExpr = ValueExpr.withValue(StringObjectValue.withValue("someWord"));
@@ -780,7 +780,7 @@ public class JavaWriterVisitorTest {
 
   /** =============================== COMMENT =============================== */
   @Test
-  public void writeBlockCommentStatement_basic() {
+  void writeBlockCommentStatement_basic() {
     String content = "this is a test comment";
     BlockComment blockComment = BlockComment.builder().setComment(content).build();
     CommentStatement commentStatement = CommentStatement.withComment(blockComment);
@@ -790,7 +790,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeLineCommentStatement_basic() {
+  void writeLineCommentStatement_basic() {
     String content = "this is a test comment";
     LineComment lineComment = LineComment.builder().setComment(content).build();
     CommentStatement commentStatement = CommentStatement.withComment(lineComment);
@@ -800,7 +800,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeJavaDocCommentStatement_allComponents() {
+  void writeJavaDocCommentStatement_allComponents() {
     String content = "this is a test comment";
     String deprecatedText = "Use the {@link ArchivedBookName} class instead.";
     String paramName = "shelfName";
@@ -861,7 +861,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeBlockComment_shortLines() {
+  void writeBlockComment_shortLines() {
     String content = "Apache License \nThis is a test file header";
     BlockComment blockComment = BlockComment.builder().setComment(content).build();
     String expected =
@@ -871,7 +871,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeBlockComment_newLineInBetween() {
+  void writeBlockComment_newLineInBetween() {
     String content =
         "Apache License \n"
             + "Licensed under the Apache License, Version 2.0 (the \"License\");\n\n"
@@ -890,7 +890,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeLineComment_longLine() {
+  void writeLineComment_longLine() {
     String content =
         "this is a long test comment with so many words, hello world, hello again, hello for 3"
             + " times, blah, blah!";
@@ -905,7 +905,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeLineComment_specialChar() {
+  void writeLineComment_specialChar() {
     String content =
         "usage: gradle run -PmainClass=com.google.example.examples.library.v1.Hopper"
             + " [--args='[--shelf \"Novel\\\"`\b\t\n\r"
@@ -923,7 +923,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeJavaDocComment_specialChar() {
+  void writeJavaDocComment_specialChar() {
     // Only comments and sample codes in JavaDocComment need this escaper.
     // <p> <ol> <li> <ul> are hard-coded in monolith generator, which do not need escaping.
     JavaDocComment javaDocComment =
@@ -962,7 +962,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeFailingComment_specialChar() {
+  void writeFailingComment_specialChar() {
     JavaDocComment javaDocComment =
         JavaDocComment.builder()
             .addUnescapedComment(
@@ -981,7 +981,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeTernaryExpr_basic() {
+  void writeTernaryExpr_basic() {
     Variable conditionVariable =
         Variable.builder().setName("condition").setType(TypeNode.BOOLEAN).build();
     VariableExpr conditionExpr = VariableExpr.builder().setVariable(conditionVariable).build();
@@ -1002,7 +1002,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeAssignmentExpr_basicValue() {
+  void writeAssignmentExpr_basicValue() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.INT).build();
     VariableExpr variableExpr =
         VariableExpr.builder().setVariable(variable).setIsDecl(true).build();
@@ -1018,7 +1018,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeAssignmentExpr_varToVar() {
+  void writeAssignmentExpr_varToVar() {
     Variable variable = Variable.builder().setName("foobar").setType(TypeNode.INT).build();
     VariableExpr variableExpr =
         VariableExpr.builder()
@@ -1040,7 +1040,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeAssignmentExpr_nullObjectValueReferenceType() {
+  void writeAssignmentExpr_nullObjectValueReferenceType() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.STRING).build();
     VariableExpr variableExpr =
         VariableExpr.builder().setVariable(variable).setIsDecl(true).build();
@@ -1056,7 +1056,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeStringObjectValue_basic() {
+  void writeStringObjectValue_basic() {
     Value value = StringObjectValue.withValue("test");
     Expr valueExpr = ValueExpr.builder().setValue(value).build();
     valueExpr.accept(writerVisitor);
@@ -1064,7 +1064,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeAssignmentExpr_stringObjectValue() {
+  void writeAssignmentExpr_stringObjectValue() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.STRING).build();
     VariableExpr variableExpr =
         VariableExpr.builder().setVariable(variable).setIsDecl(true).build();
@@ -1079,7 +1079,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeAssignmentExpr_variableDeclarationWithAnnotation() {
+  void writeAssignmentExpr_variableDeclarationWithAnnotation() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.STRING).build();
     VariableExpr variableExpr =
         VariableExpr.builder()
@@ -1098,7 +1098,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeMethodInvocationExpr_basic() {
+  void writeMethodInvocationExpr_basic() {
     MethodInvocationExpr methodExpr =
         MethodInvocationExpr.builder().setMethodName("foobar").build();
 
@@ -1107,7 +1107,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeMethodInvocationExpr_staticRef() {
+  void writeMethodInvocationExpr_staticRef() {
     TypeNode someType =
         TypeNode.withReference(
             VaporReference.builder()
@@ -1126,7 +1126,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeMethodInvocationExpr_genericWithArgs() {
+  void writeMethodInvocationExpr_genericWithArgs() {
     Reference mapReference =
         ConcreteReference.builder()
             .setClazz(HashMap.class)
@@ -1173,7 +1173,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeMethodInvocationExpr_chained() {
+  void writeMethodInvocationExpr_chained() {
     Variable variable = Variable.builder().setType(TypeNode.INT).setName("libraryClient").build();
     VariableExpr varExpr = VariableExpr.builder().setVariable(variable).build();
 
@@ -1199,7 +1199,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeCastExpr_basic() {
+  void writeCastExpr_basic() {
     Variable variable = Variable.builder().setType(TypeNode.STRING).setName("str").build();
     VariableExpr varExpr = VariableExpr.builder().setVariable(variable).build();
     CastExpr castExpr =
@@ -1212,7 +1212,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeCastExpr_methodInvocation() {
+  void writeCastExpr_methodInvocation() {
     TypeNode someType =
         TypeNode.withReference(
             VaporReference.builder()
@@ -1236,7 +1236,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeCastExpr_nested() {
+  void writeCastExpr_nested() {
     Variable variable = Variable.builder().setType(TypeNode.STRING).setName("str").build();
     VariableExpr varExpr = VariableExpr.builder().setVariable(variable).build();
     CastExpr castExpr =
@@ -1250,7 +1250,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeAnonymousClassExpr_basic() {
+  void writeAnonymousClassExpr_basic() {
     ConcreteReference ref = ConcreteReference.withClazz(Runnable.class);
     TypeNode type = TypeNode.withReference(ref);
     AssignmentExpr assignmentExpr = createAssignmentExpr("foobar", "false", TypeNode.BOOLEAN);
@@ -1277,7 +1277,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeAnonymousClassExpr_withStatementsMethods() {
+  void writeAnonymousClassExpr_withStatementsMethods() {
     ConcreteReference ref = ConcreteReference.withClazz(Runnable.class);
     TypeNode type = TypeNode.withReference(ref);
     // [Constructing] private static final String s = "foo";
@@ -1322,7 +1322,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeAnonymousClassExpr_generics() {
+  void writeAnonymousClassExpr_generics() {
     // [Constructing] Function<List<IOException>, MethodDefinition>
     ConcreteReference exceptionListRef =
         ConcreteReference.builder()
@@ -1378,7 +1378,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeThrowExpr_basic() {
+  void writeThrowExpr_basic() {
     TypeNode npeType =
         TypeNode.withReference(ConcreteReference.withClazz(NullPointerException.class));
     ThrowExpr throwExpr = ThrowExpr.builder().setType(npeType).build();
@@ -1387,7 +1387,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeThrowExpr_basicThrowExpr() {
+  void writeThrowExpr_basicThrowExpr() {
     Expr exprToThrow =
         MethodInvocationExpr.builder()
             .setStaticReferenceType(
@@ -1402,7 +1402,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeThrowExpr_basicWithMessage() {
+  void writeThrowExpr_basicWithMessage() {
     TypeNode npeType =
         TypeNode.withReference(ConcreteReference.withClazz(NullPointerException.class));
     String message = "Some message asdf";
@@ -1412,7 +1412,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeThrowExpr_basicWithCause() {
+  void writeThrowExpr_basicWithCause() {
     TypeNode npeType =
         TypeNode.withReference(ConcreteReference.withClazz(NullPointerException.class));
     ThrowExpr throwExpr =
@@ -1428,7 +1428,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeThrowExpr_messageExpr() {
+  void writeThrowExpr_messageExpr() {
     TypeNode npeType = TypeNode.withExceptionClazz(NullPointerException.class);
     Expr messageExpr =
         MethodInvocationExpr.builder()
@@ -1442,7 +1442,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeThrowExpr_messageAndCauseExpr() {
+  void writeThrowExpr_messageAndCauseExpr() {
     TypeNode npeType = TypeNode.withExceptionClazz(NullPointerException.class);
     Expr messageExpr =
         MethodInvocationExpr.builder()
@@ -1465,7 +1465,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeInstanceofExpr() {
+  void writeInstanceofExpr() {
     Variable variable = Variable.builder().setName("x").setType(TypeNode.STRING).build();
     VariableExpr variableExpr = VariableExpr.builder().setVariable(variable).build();
     InstanceofExpr instanceofExpr =
@@ -1475,7 +1475,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeEnumRefExpr_basic() {
+  void writeEnumRefExpr_basic() {
     TypeNode enumType =
         TypeNode.withReference(
             ConcreteReference.builder()
@@ -1489,7 +1489,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeEnumRefExpr_nested() {
+  void writeEnumRefExpr_nested() {
     TypeNode enumType =
         TypeNode.withReference(ConcreteReference.withClazz(TypeNode.TypeKind.class));
     EnumRefExpr enumRefExpr = EnumRefExpr.builder().setName("VOID").setType(enumType).build();
@@ -1498,7 +1498,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeReturnExpr_basic() {
+  void writeReturnExpr_basic() {
     ReturnExpr returnExpr =
         ReturnExpr.withExpr(ValueExpr.withValue(StringObjectValue.withValue("asdf")));
     returnExpr.accept(writerVisitor);
@@ -1507,7 +1507,7 @@ public class JavaWriterVisitorTest {
 
   /** =============================== STATEMENTS =============================== */
   @Test
-  public void writeExprStatement() {
+  void writeExprStatement() {
     TypeNode someType =
         TypeNode.withReference(
             VaporReference.builder()
@@ -1527,14 +1527,14 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeBlockStatement_empty() {
+  void writeBlockStatement_empty() {
     BlockStatement blockStatement = BlockStatement.builder().build();
     blockStatement.accept(writerVisitor);
     assertEquals("{\n}\n", writerVisitor.write());
   }
 
   @Test
-  public void writeBlockStatement_simple() {
+  void writeBlockStatement_simple() {
     TypeNode someType =
         TypeNode.withReference(
             VaporReference.builder()
@@ -1555,7 +1555,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeBlockStatement_static() {
+  void writeBlockStatement_static() {
     TypeNode someType =
         TypeNode.withReference(
             VaporReference.builder()
@@ -1581,7 +1581,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeIfStatement_simple() {
+  void writeIfStatement_simple() {
     AssignmentExpr assignExpr = createAssignmentExpr("x", "3", TypeNode.INT);
     Statement assignExprStatement = ExprStatement.withExpr(assignExpr);
     List<Statement> ifBody = Arrays.asList(assignExprStatement, assignExprStatement);
@@ -1597,7 +1597,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeIfStatement_withElse() {
+  void writeIfStatement_withElse() {
     AssignmentExpr assignExpr = createAssignmentExpr("x", "3", TypeNode.INT);
     Statement assignExprStatement = ExprStatement.withExpr(assignExpr);
     List<Statement> ifBody = Arrays.asList(assignExprStatement, assignExprStatement);
@@ -1625,7 +1625,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeIfStatement_elseIfs() {
+  void writeIfStatement_elseIfs() {
     List<Statement> ifBody =
         Arrays.asList(
             ExprStatement.withExpr(createAssignmentExpr("x", "3", TypeNode.INT)),
@@ -1666,7 +1666,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeIfStatement_nested() {
+  void writeIfStatement_nested() {
     List<Statement> ifBody =
         Arrays.asList(
             ExprStatement.withExpr(createAssignmentExpr("x", "3", TypeNode.INT)),
@@ -1729,7 +1729,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeWhileStatement_simple() {
+  void writeWhileStatement_simple() {
     AssignmentExpr assignExpr = createAssignmentExpr("x", "3", TypeNode.INT);
     Statement assignExprStatement = ExprStatement.withExpr(assignExpr);
     List<Statement> whileBody = Arrays.asList(assignExprStatement, assignExprStatement);
@@ -1745,7 +1745,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeForStatement() {
+  void writeForStatement() {
     AssignmentExpr assignExpr = createAssignmentExpr("x", "3", TypeNode.INT);
     Statement assignExprStatement = ExprStatement.withExpr(assignExpr);
     List<Statement> body = Arrays.asList(assignExprStatement, assignExprStatement);
@@ -1769,7 +1769,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeGeneralForStatement_basicIsDecl() {
+  void writeGeneralForStatement_basicIsDecl() {
     AssignmentExpr assignExpr = createAssignmentExpr("x", "3", TypeNode.INT);
     Statement assignExprStatement = ExprStatement.withExpr(assignExpr);
     List<Statement> body = Arrays.asList(assignExprStatement, assignExprStatement);
@@ -1792,7 +1792,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeGeneralForStatement_basicIsNotDecl() {
+  void writeGeneralForStatement_basicIsNotDecl() {
     AssignmentExpr assignExpr = createAssignmentExpr("x", "3", TypeNode.INT);
     Statement assignExprStatement = ExprStatement.withExpr(assignExpr);
     List<Statement> body = Arrays.asList(assignExprStatement, assignExprStatement);
@@ -1814,7 +1814,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeTryCatchStatement_simple() {
+  void writeTryCatchStatement_simple() {
     Reference exceptionReference = ConcreteReference.withClazz(IllegalArgumentException.class);
     TypeNode type = TypeNode.withReference(exceptionReference);
     VariableExpr variableExpr =
@@ -1836,7 +1836,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeTryCatchStatement_simpleMultiCatch() {
+  void writeTryCatchStatement_simpleMultiCatch() {
     VariableExpr firstCatchVarExpr =
         VariableExpr.builder()
             .setVariable(
@@ -1869,7 +1869,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeTryCatchStatement_simpleMultiCatchOrderMatters() {
+  void writeTryCatchStatement_simpleMultiCatchOrderMatters() {
     VariableExpr firstCatchVarExpr =
         VariableExpr.builder()
             .setVariable(
@@ -1902,7 +1902,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeTryCatchStatement_withResources() {
+  void writeTryCatchStatement_withResources() {
     Reference exceptionReference = ConcreteReference.withClazz(IllegalArgumentException.class);
     TypeNode type = TypeNode.withReference(exceptionReference);
     VariableExpr variableExpr =
@@ -1932,7 +1932,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeTryCatchStatement_sampleCodeNoCatch() {
+  void writeTryCatchStatement_sampleCodeNoCatch() {
     TryCatchStatement tryCatch =
         TryCatchStatement.builder()
             .setTryBody(
@@ -1945,7 +1945,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeTryCatchStatement_sampleCodeWithCatch() {
+  void writeTryCatchStatement_sampleCodeWithCatch() {
     Reference exceptionReference = ConcreteReference.withClazz(IllegalArgumentException.class);
     TypeNode type = TypeNode.withReference(exceptionReference);
     VariableExpr variableExpr =
@@ -1976,7 +1976,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeSynchronizedStatement_basicThis() {
+  void writeSynchronizedStatement_basicThis() {
     SynchronizedStatement synchronizedStatement =
         SynchronizedStatement.builder()
             .setLock(
@@ -1993,7 +1993,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeSynchronizedStatement_basicVariableExpr() {
+  void writeSynchronizedStatement_basicVariableExpr() {
     VariableExpr strVarExpr =
         VariableExpr.withVariable(
             Variable.builder().setName("str").setType(TypeNode.STRING).build());
@@ -2012,7 +2012,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeMethodDefinition_basic() {
+  void writeMethodDefinition_basic() {
     MethodDefinition methodDefinition =
         MethodDefinition.builder()
             .setName("close")
@@ -2029,7 +2029,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeMethodDefinition_constructor() {
+  void writeMethodDefinition_constructor() {
     TypeNode returnType =
         TypeNode.withReference(
             VaporReference.builder()
@@ -2047,7 +2047,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeMethodDefinition_basicEmptyBody() {
+  void writeMethodDefinition_basicEmptyBody() {
     MethodDefinition methodDefinition =
         MethodDefinition.builder()
             .setName("close")
@@ -2060,7 +2060,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeMethodDefinition_basicAbstract() {
+  void writeMethodDefinition_basicAbstract() {
     MethodDefinition methodDefinition =
         MethodDefinition.builder()
             .setName("close")
@@ -2078,7 +2078,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeMethodDefinition_basicAbstractEmptyBody() {
+  void writeMethodDefinition_basicAbstractEmptyBody() {
     MethodDefinition methodDefinition =
         MethodDefinition.builder()
             .setName("close")
@@ -2092,7 +2092,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeMethodDefinition_withArgumentsAndReturnExpr() {
+  void writeMethodDefinition_withArgumentsAndReturnExpr() {
     ValueExpr returnExpr =
         ValueExpr.builder()
             .setValue(PrimitiveValue.builder().setType(TypeNode.INT).setValue("3").build())
@@ -2131,7 +2131,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeMethodDefinition_withCommentsAnnotationsAndThrows() {
+  void writeMethodDefinition_withCommentsAnnotationsAndThrows() {
     LineComment lineComment = LineComment.withComment("AUTO-GENERATED DOCUMENTATION AND METHOD");
     JavaDocComment javaDocComment =
         JavaDocComment.builder()
@@ -2208,7 +2208,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeMethodDefinition_templatedReturnTypeAndArguments() {
+  void writeMethodDefinition_templatedReturnTypeAndArguments() {
     Reference mapRef = ConcreteReference.withClazz(Map.class);
     List<VariableExpr> arguments =
         Arrays.asList(
@@ -2249,7 +2249,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeClassDefinition_basicWithFileHeader() {
+  void writeClassDefinition_basicWithFileHeader() {
     List<CommentStatement> fileHeader =
         Arrays.asList(CommentStatement.withComment(BlockComment.withComment("Apache License")));
     ClassDefinition classDef =
@@ -2273,7 +2273,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeClassDefinition_withAnnotationsExtendsAndImplements() {
+  void writeClassDefinition_withAnnotationsExtendsAndImplements() {
     ClassDefinition classDef =
         ClassDefinition.builder()
             .setPackageString("com.google.example.library.v1.stub")
@@ -2304,7 +2304,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeClassDefinition_commentsStatementsAndMethods() {
+  void writeClassDefinition_commentsStatementsAndMethods() {
     LineComment lineComment = LineComment.withComment("AUTO-GENERATED DOCUMENTATION AND CLASS");
     JavaDocComment javaDocComment =
         JavaDocComment.builder()
@@ -2443,7 +2443,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeClassDefinition_withImportCollision() {
+  void writeClassDefinition_withImportCollision() {
 
     VaporReference firstType =
         VaporReference.builder()
@@ -2508,7 +2508,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeReferenceConstructorExpr_thisConstructorWithArguments() {
+  void writeReferenceConstructorExpr_thisConstructorWithArguments() {
     VaporReference ref =
         VaporReference.builder().setName("Student").setPakkage("com.google.example.v1").build();
     TypeNode classType = TypeNode.withReference(ref);
@@ -2530,7 +2530,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeReferenceConstructorExpr_superConstructorWithNoArguments() {
+  void writeReferenceConstructorExpr_superConstructorWithNoArguments() {
     VaporReference ref =
         VaporReference.builder().setName("Parent").setPakkage("com.google.example.v1").build();
     TypeNode classType = TypeNode.withReference(ref);
@@ -2541,7 +2541,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeThisObjectValue_methodReturn() {
+  void writeThisObjectValue_methodReturn() {
     VaporReference ref =
         VaporReference.builder().setName("Student").setPakkage("com.google.example.v1").build();
     TypeNode classType = TypeNode.withReference(ref);
@@ -2560,7 +2560,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeThisObjectValue_accessFieldAndInvokeMethod() {
+  void writeThisObjectValue_accessFieldAndInvokeMethod() {
     VaporReference ref =
         VaporReference.builder().setName("Student").setPakkage("com.google.example.v1").build();
     TypeNode classType = TypeNode.withReference(ref);
@@ -2589,7 +2589,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeSuperObjectValue_accessFieldAndInvokeMethod() {
+  void writeSuperObjectValue_accessFieldAndInvokeMethod() {
     VaporReference ref =
         VaporReference.builder().setName("Student").setPakkage("com.google.example.v1").build();
     TypeNode classType = TypeNode.withReference(ref);
@@ -2619,7 +2619,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeUnaryOperationExpr_postfixIncrement() {
+  void writeUnaryOperationExpr_postfixIncrement() {
     VariableExpr variableExpr =
         VariableExpr.withVariable(Variable.builder().setType(TypeNode.INT).setName("i").build());
     UnaryOperationExpr postIncrementOperationExpr =
@@ -2629,7 +2629,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeUnaryOperationExpr_logicalNot() {
+  void writeUnaryOperationExpr_logicalNot() {
     MethodInvocationExpr methodInvocationExpr =
         MethodInvocationExpr.builder()
             .setMethodName("isEmpty")
@@ -2642,7 +2642,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeRelationalOperationExpr_equalTo() {
+  void writeRelationalOperationExpr_equalTo() {
     VariableExpr variableExprLHS =
         VariableExpr.withVariable(
             Variable.builder().setType(TypeNode.BOOLEAN_OBJECT).setName("isGood").build());
@@ -2659,7 +2659,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeRelationOperationExpr_notEqualTo() {
+  void writeRelationOperationExpr_notEqualTo() {
     TypeNode someType =
         TypeNode.withReference(
             VaporReference.builder()
@@ -2681,7 +2681,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeRelationalOperationExpr_lessThan() {
+  void writeRelationalOperationExpr_lessThan() {
     VariableExpr lhsExpr = VariableExpr.withVariable(createVariable("i", TypeNode.INT));
     MethodInvocationExpr rhsExpr =
         MethodInvocationExpr.builder()
@@ -2696,7 +2696,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeLogicalOperationExpr_logicalAnd() {
+  void writeLogicalOperationExpr_logicalAnd() {
     VariableExpr lhsExpr = VariableExpr.withVariable(createVariable("isEmpty", TypeNode.BOOLEAN));
     VaporReference ref =
         VaporReference.builder().setName("Student").setPakkage("com.google.example.v1").build();
@@ -2714,7 +2714,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeLogicalOperationExpr_logicalOr() {
+  void writeLogicalOperationExpr_logicalOr() {
     VariableExpr lhsExpr = VariableExpr.withVariable(createVariable("isGood", TypeNode.BOOLEAN));
     MethodInvocationExpr rhsExpr =
         MethodInvocationExpr.builder()
@@ -2728,7 +2728,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeAssignmentOperationExpr_multiplyAssignment() {
+  void writeAssignmentOperationExpr_multiplyAssignment() {
     VariableExpr lhsExpr = createVariableExpr("h", TypeNode.INT);
     ValueExpr rhsExpr =
         ValueExpr.withValue(
@@ -2740,7 +2740,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeAssignmentOperationExpr_xorAssignment() {
+  void writeAssignmentOperationExpr_xorAssignment() {
     VariableExpr lhsExpr = createVariableExpr("h", TypeNode.INT);
     TypeNode objectType =
         TypeNode.withReference(
@@ -2761,7 +2761,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeLambdaExpr_noParameters() {
+  void writeLambdaExpr_noParameters() {
     LambdaExpr lambdaExpr =
         LambdaExpr.builder()
             .setReturnExpr(ValueExpr.withValue(StringObjectValue.withValue("foo")))
@@ -2771,7 +2771,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeLambdaExpr_assignToVariable() {
+  void writeLambdaExpr_assignToVariable() {
     LambdaExpr lambdaExpr =
         LambdaExpr.builder()
             .setReturnExpr(ValueExpr.withValue(StringObjectValue.withValue("foo")))
@@ -2788,7 +2788,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeLambdaExpr_oneParameter() {
+  void writeLambdaExpr_oneParameter() {
     VariableExpr argVarExpr =
         VariableExpr.builder()
             .setVariable(Variable.builder().setName("arg").setType(TypeNode.INT).build())
@@ -2805,7 +2805,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeLambdaExpr_severalParameters() {
+  void writeLambdaExpr_severalParameters() {
     VariableExpr argOneVarExpr =
         VariableExpr.builder()
             .setVariable(Variable.builder().setName("arg").setType(TypeNode.INT).build())
@@ -2832,7 +2832,7 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeLambdaExpr_body() {
+  void writeLambdaExpr_body() {
     VariableExpr argVarExpr =
         VariableExpr.builder()
             .setVariable(Variable.builder().setName("arg").setType(TypeNode.INT).build())
@@ -2864,21 +2864,21 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
-  public void writeEmptyLineStatement() {
+  void writeEmptyLineStatement() {
     EmptyLineStatement statement = EmptyLineStatement.create();
     statement.accept(writerVisitor);
     assertEquals("\n", writerVisitor.write());
   }
 
   @Test
-  public void writeBreakStatement() {
+  void writeBreakStatement() {
     BreakStatement statement = BreakStatement.create();
     statement.accept(writerVisitor);
     assertEquals("break;", writerVisitor.write());
   }
 
   @Test
-  public void writePackageInfoDefinition() {
+  void writePackageInfoDefinition() {
     PackageInfoDefinition packageInfo =
         PackageInfoDefinition.builder()
             .setPakkage("com.google.example.library.v1")
@@ -2910,7 +2910,7 @@ public class JavaWriterVisitorTest {
 
   /** =============================== GOLDEN TESTS =============================== */
   @Test
-  public void writeSGrpcServiceClientWithNestedClassImport() {
+  void writeSGrpcServiceClientWithNestedClassImport() {
     GapicContext context = TestProtoLoader.instance().parseNestedMessage();
     Service nestedService = context.services().get(0);
     GapicClass clazz = ServiceClientClassComposer.instance().generate(context, nestedService);

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/ClientLibraryPackageInfoComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/ClientLibraryPackageInfoComposerTest.java
@@ -22,13 +22,13 @@ import com.google.api.generator.test.framework.GoldenFileWriter;
 import com.google.api.generator.test.protoloader.TestProtoLoader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ClientLibraryPackageInfoComposerTest {
+class ClientLibraryPackageInfoComposerTest {
   private GapicContext context = TestProtoLoader.instance().parseShowcaseEcho();
 
   @Test
-  public void composePackageInfo_showcase() {
+  void composePackageInfo_showcase() {
     GapicPackageInfo packageInfo = ClientLibraryPackageInfoComposer.generatePackageInfo(context);
     JavaWriterVisitor visitor = new JavaWriterVisitor();
     packageInfo.packageInfo().accept(visitor);

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/ClientLibraryReflectConfigComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/ClientLibraryReflectConfigComposerTest.java
@@ -26,9 +26,9 @@ import com.google.api.generator.test.protoloader.TestProtoLoader;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ClientLibraryReflectConfigComposerTest {
+class ClientLibraryReflectConfigComposerTest {
 
   private final Message.Builder testMessageBuilder =
       Message.builder()
@@ -37,7 +37,7 @@ public class ClientLibraryReflectConfigComposerTest {
           .setType(TypeNode.OBJECT);
 
   @Test
-  public void composeReflectConfigs_showcase() {
+  void composeReflectConfigs_showcase() {
     final GapicContext context = TestProtoLoader.instance().parseShowcaseEcho();
     List<ReflectConfig> configs = Composer.composeNativeReflectConfig(context);
     assertThat(configs).isNotEmpty();
@@ -75,7 +75,7 @@ public class ClientLibraryReflectConfigComposerTest {
   }
 
   @Test
-  public void composeReflectConfigs_SimpleMessage() {
+  void composeReflectConfigs_SimpleMessage() {
     List<String> entries =
         ClientLibraryReflectConfigComposer.calculateReflectConfigList(
             "foo.Bar", testMessageBuilder.build());
@@ -85,7 +85,7 @@ public class ClientLibraryReflectConfigComposerTest {
   }
 
   @Test
-  public void composeReflectConfigs_Enum() {
+  void composeReflectConfigs_Enum() {
     List<String> entries =
         ClientLibraryReflectConfigComposer.calculateReflectConfigList(
             "e.Num",
@@ -96,7 +96,7 @@ public class ClientLibraryReflectConfigComposerTest {
   }
 
   @Test
-  public void composeReflectConfigs_NestedEnums() {
+  void composeReflectConfigs_NestedEnums() {
     List<String> nestedEnums = Arrays.asList("NestedEnum1", "NestedEnum2");
     List<String> entries =
         ClientLibraryReflectConfigComposer.calculateReflectConfigList(
@@ -112,27 +112,27 @@ public class ClientLibraryReflectConfigComposerTest {
   }
 
   @Test
-  public void formatNestedClassFullyQualifiedNames_noNested() {
+  void formatNestedClassFullyQualifiedNames_noNested() {
     assertEquals("a.B", ClientLibraryReflectConfigComposer.convertToBinaryName("a.B"));
     assertEquals("aa.bb.CC", ClientLibraryReflectConfigComposer.convertToBinaryName("aa.bb.CC"));
   }
 
   @Test
-  public void formatNestedClassFullyQualifiedNames_oneNested() {
+  void formatNestedClassFullyQualifiedNames_oneNested() {
     assertEquals("a.B$C", ClientLibraryReflectConfigComposer.convertToBinaryName("a.B.C"));
     assertEquals(
         "aa.bb.Cc$Dd", ClientLibraryReflectConfigComposer.convertToBinaryName("aa.bb.Cc.Dd"));
   }
 
   @Test
-  public void formatNestedClassFullyQualifiedNames_twoNested() {
+  void formatNestedClassFullyQualifiedNames_twoNested() {
     assertEquals("a.B$C$D", ClientLibraryReflectConfigComposer.convertToBinaryName("a.B.C.D"));
     assertEquals(
         "aa.bb.Cc$Dd$Ee", ClientLibraryReflectConfigComposer.convertToBinaryName("aa.bb.Cc.Dd.Ee"));
   }
 
   @Test
-  public void duplicateEntries_found() {
+  void duplicateEntries_found() {
     assertThat(ClientLibraryReflectConfigComposer.calculateDuplicates(Arrays.asList("a", "a", "b")))
         .containsExactly("a");
 

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/ComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/ComposerTest.java
@@ -35,9 +35,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ComposerTest {
+class ComposerTest {
   private final GapicContext context = GrpcTestProtoLoader.instance().parseShowcaseEcho();
   private final Service echoProtoService = context.services().get(0);
   private final List<GapicClass> clazzes =
@@ -54,7 +54,7 @@ public class ComposerTest {
   private List<Sample> ListofSamples = Arrays.asList(new Sample[] {sample});
 
   @Test
-  public void gapicClass_addApacheLicense() {
+  void gapicClass_addApacheLicense() {
     ClassDefinition classDef =
         ClassDefinition.builder()
             .setPackageString("com.google.showcase.v1beta1.stub")
@@ -74,7 +74,7 @@ public class ComposerTest {
   }
 
   @Test
-  public void composeSamples_showcase() {
+  void composeSamples_showcase() {
     GapicClass testClass = clazzes.get(0).withSamples(ListofSamples);
     List<GapicClass> testClassList = Arrays.asList(new GapicClass[] {testClass});
 
@@ -96,7 +96,7 @@ public class ComposerTest {
   }
 
   @Test
-  public void gapicClass_addRegionTagAndHeaderToSample() {
+  void gapicClass_addRegionTagAndHeaderToSample() {
     Sample testSample;
     testSample = Composer.addRegionTagAndHeaderToSample(sample, "showcase", "v1");
     assertEquals("Showcase", testSample.regionTag().apiShortName());
@@ -105,7 +105,7 @@ public class ComposerTest {
   }
 
   @Test
-  public void composeSamples_parseProtoPackage() {
+  void composeSamples_parseProtoPackage() {
 
     String defaultHost = "accessapproval.googleapis.com:443";
     String protoPack = "google.cloud.accessapproval.v1";

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/common/AbstractTransportServiceStubClassComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/common/AbstractTransportServiceStubClassComposerTest.java
@@ -51,19 +51,19 @@ import com.google.api.generator.test.utils.LineFormatter;
 import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class AbstractTransportServiceStubClassComposerTest {
+class AbstractTransportServiceStubClassComposerTest {
   private JavaWriterVisitor writerVisitor;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     writerVisitor = new JavaWriterVisitor();
   }
 
   @Test
-  public void shouldGenerateRequestMutator_fieldConfiguredCorrectly() {
+  void shouldGenerateRequestMutator_fieldConfiguredCorrectly() {
     String ECHO_PACKAGE = "com.google.showcase.v1beta1";
     List<String> autoPopulatedFieldList = new ArrayList<>();
     autoPopulatedFieldList.add("TestField");
@@ -105,7 +105,7 @@ public class AbstractTransportServiceStubClassComposerTest {
   }
 
   @Test
-  public void shouldNotGenerateRequestMutator_fieldConfiguredIncorrectly() {
+  void shouldNotGenerateRequestMutator_fieldConfiguredIncorrectly() {
     String ECHO_PACKAGE = "com.google.showcase.v1beta1";
     List<String> autoPopulatedFieldList = new ArrayList<>();
     autoPopulatedFieldList.add("TestField");
@@ -148,7 +148,7 @@ public class AbstractTransportServiceStubClassComposerTest {
 
   // TODO: add unit tests where the field is not found in the messageTypes map
   @Test
-  public void createAutoPopulatedRequestStatement_sampleField() {
+  void createAutoPopulatedRequestStatement_sampleField() {
     Reference RequestBuilderRef =
         VaporReference.builder()
             .setName("EchoRequest")
@@ -194,7 +194,7 @@ public class AbstractTransportServiceStubClassComposerTest {
   }
 
   @Test
-  public void createRequestMutatorBody_TestField() {
+  void createRequestMutatorBody_TestField() {
     List<Statement> bodyStatements = new ArrayList<>();
     String ECHO_PACKAGE = "com.google.showcase.v1beta1";
     List<String> autoPopulatedFieldList = new ArrayList<>();
@@ -266,7 +266,7 @@ public class AbstractTransportServiceStubClassComposerTest {
   }
 
   @Test
-  public void createRequestMutatorBody_TestFieldNotString_shouldReturnNull() {
+  void createRequestMutatorBody_TestFieldNotString_shouldReturnNull() {
     List<Statement> bodyStatements = new ArrayList<>();
 
     String ECHO_PACKAGE = "com.google.showcase.v1beta1";
@@ -335,7 +335,7 @@ public class AbstractTransportServiceStubClassComposerTest {
   }
 
   @Test
-  public void createRequestMutatorBody_TestFieldFormatNotUUID_shouldReturnNull() {
+  void createRequestMutatorBody_TestFieldFormatNotUUID_shouldReturnNull() {
     List<Statement> bodyStatements = new ArrayList<>();
     String ECHO_PACKAGE = "com.google.showcase.v1beta1";
     List<String> autoPopulatedFieldList = new ArrayList<>();
@@ -403,7 +403,7 @@ public class AbstractTransportServiceStubClassComposerTest {
   }
 
   @Test
-  public void createRequestMutatorBody_TestFieldIncorrectName_shouldReturnNull() {
+  void createRequestMutatorBody_TestFieldIncorrectName_shouldReturnNull() {
     List<Statement> bodyStatements = new ArrayList<>();
     String ECHO_PACKAGE = "com.google.showcase.v1beta1";
     List<String> autoPopulatedFieldList = new ArrayList<>();
@@ -471,7 +471,7 @@ public class AbstractTransportServiceStubClassComposerTest {
   }
 
   @Test
-  public void createRequestMutator_TestField() {
+  void createRequestMutator_TestField() {
     String ECHO_PACKAGE = "com.google.showcase.v1beta1";
     List<String> autoPopulatedFieldList = new ArrayList<>();
     autoPopulatedFieldList.add("TestField");

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/common/BatchingDescriptorComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/common/BatchingDescriptorComposerTest.java
@@ -48,19 +48,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class BatchingDescriptorComposerTest {
+class BatchingDescriptorComposerTest {
   private JavaWriterVisitor writerVisitor;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     writerVisitor = new JavaWriterVisitor();
   }
 
   @Test
-  public void batchingDescriptor_hasSubresponseField() {
+  void batchingDescriptor_hasSubresponseField() {
     FileDescriptor serviceFileDescriptor = PubsubProto.getDescriptor();
     FileDescriptor commonResourcesFileDescriptor = CommonResources.getDescriptor();
     ServiceDescriptor serviceDescriptor = serviceFileDescriptor.getServices().get(0);
@@ -115,7 +115,7 @@ public class BatchingDescriptorComposerTest {
   }
 
   @Test
-  public void batchingDescriptor_noSubresponseField() {
+  void batchingDescriptor_noSubresponseField() {
     FileDescriptor serviceFileDescriptor = LoggingProto.getDescriptor();
     ServiceDescriptor serviceDescriptor = serviceFileDescriptor.getServices().get(0);
     assertEquals(serviceDescriptor.getName(), "LoggingServiceV2");

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/common/RetrySettingsComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/common/RetrySettingsComposerTest.java
@@ -53,10 +53,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class RetrySettingsComposerTest {
+class RetrySettingsComposerTest {
   private static final VariableExpr RETRY_PARAM_DEFINITIONS_VAR_EXPR =
       createRetryParamDefinitionsVarExpr();
   private static final VariableExpr RETRY_CODES_DEFINITIONS_VAR_EXPR =
@@ -64,13 +64,13 @@ public class RetrySettingsComposerTest {
 
   private JavaWriterVisitor writerVisitor;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     writerVisitor = new JavaWriterVisitor();
   }
 
   @Test
-  public void paramDefinitionsBlock_noConfigsFound() {
+  void paramDefinitionsBlock_noConfigsFound() {
     GapicContext context = TestProtoLoader.instance().parseShowcaseEcho();
     Service service = context.services().get(0);
 
@@ -98,7 +98,7 @@ public class RetrySettingsComposerTest {
   }
 
   @Test
-  public void paramDefinitionsBlock_basic() {
+  void paramDefinitionsBlock_basic() {
     GapicContext context = TestProtoLoader.instance().parseShowcaseEcho();
     Service service = context.services().get(0);
 
@@ -140,7 +140,7 @@ public class RetrySettingsComposerTest {
   }
 
   @Test
-  public void codesDefinitionsBlock_noConfigsFound() {
+  void codesDefinitionsBlock_noConfigsFound() {
     FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
@@ -176,7 +176,7 @@ public class RetrySettingsComposerTest {
   }
 
   @Test
-  public void codesDefinitionsBlock_basic() {
+  void codesDefinitionsBlock_basic() {
     FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
@@ -215,7 +215,7 @@ public class RetrySettingsComposerTest {
   }
 
   @Test
-  public void simpleBuilderExpr_basic() {
+  void simpleBuilderExpr_basic() {
     FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
@@ -296,7 +296,7 @@ public class RetrySettingsComposerTest {
   }
 
   @Test
-  public void lroBuilderExpr() {
+  void lroBuilderExpr() {
     FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
@@ -350,7 +350,7 @@ public class RetrySettingsComposerTest {
   }
 
   @Test
-  public void batchingSettings_minimalFlowControlSettings() {
+  void batchingSettings_minimalFlowControlSettings() {
     String filename = "pubsub_gapic.yaml";
     Path path = Paths.get(TestProtoLoader.instance().getTestFilesDirectory(), filename);
     Optional<List<GapicBatchingSettings>> batchingSettingsOpt =
@@ -404,7 +404,7 @@ public class RetrySettingsComposerTest {
   }
 
   @Test
-  public void batchingSettings_fullFlowControlSettings() {
+  void batchingSettings_fullFlowControlSettings() {
     String filename = "logging_gapic.yaml";
     Path path = Paths.get(TestProtoLoader.instance().getTestFilesDirectory(), filename);
     Optional<List<GapicBatchingSettings>> batchingSettingsOpt =

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/defaultvalue/DefaultValueComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/defaultvalue/DefaultValueComposerTest.java
@@ -38,19 +38,19 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class DefaultValueComposerTest {
+class DefaultValueComposerTest {
   private JavaWriterVisitor writerVisitor;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     writerVisitor = new JavaWriterVisitor();
   }
 
   @Test
-  public void defaultValue_mapField() {
+  void defaultValue_mapField() {
     // Incorrect and will never happen in real usage, but proves that map detection is based on
     // isMap rather than type().
     Field field =
@@ -75,7 +75,7 @@ public class DefaultValueComposerTest {
   }
 
   @Test
-  public void defaultValue_listField() {
+  void defaultValue_listField() {
     // Incorrect and will never happen in real usage, but proves that list detection is based on
     // isRepeated rather than type().
     Field field =
@@ -86,7 +86,7 @@ public class DefaultValueComposerTest {
   }
 
   @Test
-  public void defaultValue_enumField() {
+  void defaultValue_enumField() {
     // Incorrect and will never happen in real usage, but proves that enum detection is based on
     // isEnum() rather than type().
     Field field =
@@ -97,7 +97,7 @@ public class DefaultValueComposerTest {
   }
 
   @Test
-  public void defaultValue_messageField() {
+  void defaultValue_messageField() {
     // Incorrect and will never happen in real usage, but proves that message detection is based on
     // isMessage() rather than type().
     Field field =
@@ -108,7 +108,7 @@ public class DefaultValueComposerTest {
   }
 
   @Test
-  public void defaultValue_stringField() {
+  void defaultValue_stringField() {
     Field field = Field.builder().setName("foobar").setType(TypeNode.STRING).build();
     Expr expr = DefaultValueComposer.createValue(field);
     expr.accept(writerVisitor);
@@ -124,7 +124,7 @@ public class DefaultValueComposerTest {
   }
 
   @Test
-  public void defaultValue_numericField() {
+  void defaultValue_numericField() {
     Field field = Field.builder().setName("foobar").setType(TypeNode.INT).build();
     Expr expr = DefaultValueComposer.createValue(field);
     expr.accept(writerVisitor);
@@ -138,7 +138,7 @@ public class DefaultValueComposerTest {
   }
 
   @Test
-  public void defaultValue_booleanField() {
+  void defaultValue_booleanField() {
     Field field = Field.builder().setName("foobar").setType(TypeNode.BOOLEAN).build();
     Expr expr = DefaultValueComposer.createValue(field);
     expr.accept(writerVisitor);
@@ -146,7 +146,7 @@ public class DefaultValueComposerTest {
   }
 
   @Test
-  public void defaultValue_byteStringField() {
+  void defaultValue_byteStringField() {
     Field field =
         Field.builder()
             .setName("foobar")
@@ -158,7 +158,7 @@ public class DefaultValueComposerTest {
   }
 
   @Test
-  public void defaultValue_resourceNameWithOnePattern() {
+  void defaultValue_resourceNameWithOnePattern() {
     FileDescriptor lockerServiceFileDescriptor = LockerProto.getDescriptor();
     Map<String, ResourceName> typeStringsToResourceNames =
         Parser.parseResourceNames(lockerServiceFileDescriptor);
@@ -176,7 +176,7 @@ public class DefaultValueComposerTest {
   }
 
   @Test
-  public void defaultValue_resourceNameWithMultiplePatterns_noBindings() {
+  void defaultValue_resourceNameWithMultiplePatterns_noBindings() {
     FileDescriptor lockerServiceFileDescriptor = LockerProto.getDescriptor();
     Map<String, ResourceName> typeStringsToResourceNames =
         Parser.parseResourceNames(lockerServiceFileDescriptor);
@@ -201,7 +201,7 @@ public class DefaultValueComposerTest {
   }
 
   @Test
-  public void defaultValue_resourceNameWithMultiplePatterns_matchesBindings() {
+  void defaultValue_resourceNameWithMultiplePatterns_matchesBindings() {
     FileDescriptor lockerServiceFileDescriptor = LockerProto.getDescriptor();
     Map<String, ResourceName> typeStringsToResourceNames =
         Parser.parseResourceNames(lockerServiceFileDescriptor);
@@ -230,7 +230,7 @@ public class DefaultValueComposerTest {
   }
 
   @Test
-  public void defaultValue_resourceNameWithWildcardPattern() {
+  void defaultValue_resourceNameWithWildcardPattern() {
     FileDescriptor lockerServiceFileDescriptor = LockerProto.getDescriptor();
     Map<String, ResourceName> typeStringsToResourceNames =
         Parser.parseResourceNames(lockerServiceFileDescriptor);
@@ -248,7 +248,7 @@ public class DefaultValueComposerTest {
   }
 
   @Test
-  public void defaultValue_wildcardResourceNameWithOnlyDeletedTopic() {
+  void defaultValue_wildcardResourceNameWithOnlyDeletedTopic() {
     // Edge case that should never happen in practice.
     // Wildcard, but the resource names map has only other names that contain only the deleted-topic
     // constant.
@@ -272,7 +272,7 @@ public class DefaultValueComposerTest {
   }
 
   @Test
-  public void defaultValue_resourceNameWithOnlyWildcards_valueOnly() {
+  void defaultValue_resourceNameWithOnlyWildcards_valueOnly() {
     // Edge case that occurs in GCS.
     // Wildcard, but the resource names map has only other names that contain only the deleted-topic
     // constant.
@@ -296,7 +296,7 @@ public class DefaultValueComposerTest {
   }
 
   @Test
-  public void defaultValue_resourceNameWithOnlyWildcards_matchingBinding() {
+  void defaultValue_resourceNameWithOnlyWildcards_matchingBinding() {
     FileDescriptor lockerServiceFileDescriptor = LockerProto.getDescriptor();
     Map<String, ResourceName> typeStringsToResourceNames =
         Parser.parseResourceNames(lockerServiceFileDescriptor);
@@ -334,7 +334,7 @@ public class DefaultValueComposerTest {
   }
 
   @Test
-  public void defaultValue_resourceNameWithOnlyWildcards_mismatchingBinding() {
+  void defaultValue_resourceNameWithOnlyWildcards_mismatchingBinding() {
     FileDescriptor lockerServiceFileDescriptor = LockerProto.getDescriptor();
     Map<String, ResourceName> typeStringsToResourceNames =
         Parser.parseResourceNames(lockerServiceFileDescriptor);
@@ -373,7 +373,7 @@ public class DefaultValueComposerTest {
   }
 
   @Test
-  public void defaultValue_resourceNameWithOnlyWildcards_allowAnonResourceNameClass() {
+  void defaultValue_resourceNameWithOnlyWildcards_allowAnonResourceNameClass() {
     // Edge case that occurs in GCS.
     // Wildcard, but the resource names map has only other names that contain only the deleted-topic
     // constant.
@@ -412,7 +412,7 @@ public class DefaultValueComposerTest {
   }
 
   @Test
-  public void createSimpleMessageBuilderValue_resourceNameMultiplePatterns_matchesHttpBinding() {
+  void createSimpleMessageBuilderValue_resourceNameMultiplePatterns_matchesHttpBinding() {
     FileDescriptor messagingFileDescriptor = MessagingOuterClass.getDescriptor();
     Map<String, Message> messageTypes = Parser.parseMessages(messagingFileDescriptor);
     Map<String, ResourceName> typeStringsToResourceNames =
@@ -446,8 +446,7 @@ public class DefaultValueComposerTest {
   }
 
   @Test
-  public void
-      createSimpleMessageBuilderValue_resourceNameMultiplePatterns_matchesAdditionalHttpBinding() {
+  void createSimpleMessageBuilderValue_resourceNameMultiplePatterns_matchesAdditionalHttpBinding() {
     FileDescriptor messagingFileDescriptor = MessagingOuterClass.getDescriptor();
     Map<String, Message> messageTypes = Parser.parseMessages(messagingFileDescriptor);
     Map<String, ResourceName> typeStringsToResourceNames =
@@ -482,8 +481,7 @@ public class DefaultValueComposerTest {
   }
 
   @Test
-  public void
-      createSimpleMessageBuilderValue_resourceNameMultiplePatterns_doesNotMatchHttpBinding() {
+  void createSimpleMessageBuilderValue_resourceNameMultiplePatterns_doesNotMatchHttpBinding() {
     FileDescriptor messagingFileDescriptor = MessagingOuterClass.getDescriptor();
     Map<String, Message> messageTypes = Parser.parseMessages(messagingFileDescriptor);
     Map<String, ResourceName> typeStringsToResourceNames =
@@ -518,7 +516,7 @@ public class DefaultValueComposerTest {
   }
 
   @Test
-  public void defaultValue_resourceNameMultiplePatterns_noHttpBinding() {
+  void defaultValue_resourceNameMultiplePatterns_noHttpBinding() {
     FileDescriptor messagingFileDescriptor = MessagingOuterClass.getDescriptor();
     Map<String, Message> messageTypes = Parser.parseMessages(messagingFileDescriptor);
     Map<String, ResourceName> typeStringsToResourceNames =
@@ -537,7 +535,7 @@ public class DefaultValueComposerTest {
   }
 
   @Test
-  public void createSimpleMessage_basicPrimitivesOnly() {
+  void createSimpleMessage_basicPrimitivesOnly() {
     FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
     Map<String, ResourceName> typeStringsToResourceNames =
@@ -554,7 +552,7 @@ public class DefaultValueComposerTest {
   }
 
   @Test
-  public void createSimpleMessage_containsMessagesEnumsAndResourceName() {
+  void createSimpleMessage_containsMessagesEnumsAndResourceName() {
     FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
     Map<String, ResourceName> typeStringsToResourceNames =
@@ -574,7 +572,7 @@ public class DefaultValueComposerTest {
   }
 
   @Test
-  public void createSimpleMessage_valueField() {
+  void createSimpleMessage_valueField() {
     FileDescriptor echoFileDescriptor =
         com.google.showcase.grpcrest.v1beta1.EchoGrpcrest.getDescriptor();
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -596,7 +594,7 @@ public class DefaultValueComposerTest {
   }
 
   @Test
-  public void createSimpleMessage_containsRepeatedField() {
+  void createSimpleMessage_containsRepeatedField() {
     FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
     Map<String, ResourceName> typeStringsToResourceNames =
@@ -613,7 +611,7 @@ public class DefaultValueComposerTest {
   }
 
   @Test
-  public void createSimpleMessage_onlyOneofs() {
+  void createSimpleMessage_onlyOneofs() {
     FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
     Map<String, ResourceName> typeStringsToResourceNames =
@@ -627,7 +625,7 @@ public class DefaultValueComposerTest {
   }
 
   @Test
-  public void createAnonymousResourceNameClass() {
+  void createAnonymousResourceNameClass() {
     Expr expr = DefaultValueComposer.createAnonymousResourceNameClassValue("resource", null);
     expr.accept(writerVisitor);
     String expected =

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/GrpcServiceCallableFactoryClassComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/GrpcServiceCallableFactoryClassComposerTest.java
@@ -19,11 +19,11 @@ import com.google.api.generator.gapic.model.GapicContext;
 import com.google.api.generator.gapic.model.Service;
 import com.google.api.generator.test.framework.Assert;
 import com.google.api.generator.test.protoloader.GrpcTestProtoLoader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class GrpcServiceCallableFactoryClassComposerTest {
+class GrpcServiceCallableFactoryClassComposerTest {
   @Test
-  public void generateServiceClasses() {
+  void generateServiceClasses() {
     GapicContext context = GrpcTestProtoLoader.instance().parseShowcaseEcho();
     Service echoProtoService = context.services().get(0);
     GapicClass clazz =
@@ -34,7 +34,7 @@ public class GrpcServiceCallableFactoryClassComposerTest {
   }
 
   @Test
-  public void generateServiceClasses_deprecated() {
+  void generateServiceClasses_deprecated() {
     GapicContext context = GrpcTestProtoLoader.instance().parseDeprecatedService();
     Service protoService = context.services().get(0);
     GapicClass clazz =

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/GrpcServiceStubClassComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/GrpcServiceStubClassComposerTest.java
@@ -19,11 +19,11 @@ import com.google.api.generator.gapic.model.GapicContext;
 import com.google.api.generator.gapic.model.Service;
 import com.google.api.generator.test.framework.Assert;
 import com.google.api.generator.test.protoloader.GrpcTestProtoLoader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class GrpcServiceStubClassComposerTest {
+class GrpcServiceStubClassComposerTest {
   @Test
-  public void generateGrpcServiceStubClass_simple() {
+  void generateGrpcServiceStubClass_simple() {
     GapicContext context = GrpcTestProtoLoader.instance().parseShowcaseEcho();
     Service echoProtoService = context.services().get(0);
     GapicClass clazz = GrpcServiceStubClassComposer.instance().generate(context, echoProtoService);
@@ -33,7 +33,7 @@ public class GrpcServiceStubClassComposerTest {
   }
 
   @Test
-  public void generateGrpcServiceStubClass_deprecated() {
+  void generateGrpcServiceStubClass_deprecated() {
     GapicContext context = GrpcTestProtoLoader.instance().parseDeprecatedService();
     Service protoService = context.services().get(0);
     GapicClass clazz = GrpcServiceStubClassComposer.instance().generate(context, protoService);
@@ -43,7 +43,7 @@ public class GrpcServiceStubClassComposerTest {
   }
 
   @Test
-  public void generateGrpcServiceStubClass_httpBindings() {
+  void generateGrpcServiceStubClass_httpBindings() {
     GapicContext context = GrpcTestProtoLoader.instance().parseShowcaseTesting();
     Service service = context.services().get(0);
     GapicClass clazz = GrpcServiceStubClassComposer.instance().generate(context, service);
@@ -53,7 +53,7 @@ public class GrpcServiceStubClassComposerTest {
   }
 
   @Test
-  public void generateGrpcServiceStubClass_routingHeaders() {
+  void generateGrpcServiceStubClass_routingHeaders() {
     GapicContext context =
         GrpcTestProtoLoader.instance().parseExplicitDynamicRoutingHeaderTesting();
     Service service = context.services().get(0);
@@ -64,7 +64,7 @@ public class GrpcServiceStubClassComposerTest {
   }
 
   @Test
-  public void generateGrpcServiceStubClass_httpBindingsWithSubMessageFields() {
+  void generateGrpcServiceStubClass_httpBindingsWithSubMessageFields() {
     GapicContext context = GrpcTestProtoLoader.instance().parsePubSubPublisher();
     Service service = context.services().get(0);
     GapicClass clazz = GrpcServiceStubClassComposer.instance().generate(context, service);
@@ -74,7 +74,7 @@ public class GrpcServiceStubClassComposerTest {
   }
 
   @Test
-  public void generateGrpcServiceStubClass_createBatchingCallable() {
+  void generateGrpcServiceStubClass_createBatchingCallable() {
     GapicContext context = GrpcTestProtoLoader.instance().parseLogging();
     Service service = context.services().get(0);
     GapicClass clazz = GrpcServiceStubClassComposer.instance().generate(context, service);
@@ -84,7 +84,7 @@ public class GrpcServiceStubClassComposerTest {
   }
 
   @Test
-  public void generateGrpcServiceStubClass_autopopulateField() {
+  void generateGrpcServiceStubClass_autopopulateField() {
     GapicContext context = GrpcTestProtoLoader.instance().parseAutoPopulateFieldTesting();
     Service service = context.services().get(0);
     GapicClass clazz = GrpcServiceStubClassComposer.instance().generate(context, service);

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/MockServiceClassComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/MockServiceClassComposerTest.java
@@ -19,30 +19,23 @@ import com.google.api.generator.gapic.model.GapicContext;
 import com.google.api.generator.gapic.model.Service;
 import com.google.api.generator.test.framework.Assert;
 import com.google.api.generator.test.protoloader.GrpcTestProtoLoader;
-import java.util.Arrays;
-import java.util.Collection;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
-public class MockServiceClassComposerTest {
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() {
-    return Arrays.asList(
-        new Object[][] {
-          {"MockEcho", GrpcTestProtoLoader.instance().parseShowcaseEcho()},
-          {"MockDeprecatedService", GrpcTestProtoLoader.instance().parseDeprecatedService()}
-        });
+class MockServiceClassComposerTest {
+
+  static Stream<Arguments> data() {
+    return Stream.of(
+        Arguments.of("MockEcho", GrpcTestProtoLoader.instance().parseShowcaseEcho()),
+        Arguments.of(
+            "MockDeprecatedService", GrpcTestProtoLoader.instance().parseDeprecatedService()));
   }
 
-  @Parameterized.Parameter public String name;
-
-  @Parameterized.Parameter(1)
-  public GapicContext context;
-
-  @Test
-  public void generateMockServiceClasses() {
+  @ParameterizedTest
+  @MethodSource("data")
+  void generateMockServiceClasses(String name, GapicContext context) {
     Service service = context.services().get(0);
     GapicClass clazz = MockServiceClassComposer.instance().generate(context, service);
 

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/MockServiceImplClassComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/MockServiceImplClassComposerTest.java
@@ -19,30 +19,22 @@ import com.google.api.generator.gapic.model.GapicContext;
 import com.google.api.generator.gapic.model.Service;
 import com.google.api.generator.test.framework.Assert;
 import com.google.api.generator.test.protoloader.GrpcTestProtoLoader;
-import java.util.Arrays;
-import java.util.Collection;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
-public class MockServiceImplClassComposerTest {
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() {
-    return Arrays.asList(
-        new Object[][] {
-          {"MockEchoImpl", GrpcTestProtoLoader.instance().parseShowcaseEcho()},
-          {"MockDeprecatedServiceImpl", GrpcTestProtoLoader.instance().parseDeprecatedService()}
-        });
+class MockServiceImplClassComposerTest {
+  static Stream<Arguments> data() {
+    return Stream.of(
+        Arguments.of("MockEchoImpl", GrpcTestProtoLoader.instance().parseShowcaseEcho()),
+        Arguments.of(
+            "MockDeprecatedServiceImpl", GrpcTestProtoLoader.instance().parseDeprecatedService()));
   }
 
-  @Parameterized.Parameter public String name;
-
-  @Parameterized.Parameter(1)
-  public GapicContext context;
-
-  @Test
-  public void generateMockServiceImplClasses() {
+  @ParameterizedTest
+  @MethodSource("data")
+  void generateMockServiceImplClasses(String name, GapicContext context) {
     Service service = context.services().get(0);
     GapicClass clazz = MockServiceImplClassComposer.instance().generate(context, service);
 

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/ServiceClientClassComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/ServiceClientClassComposerTest.java
@@ -20,62 +20,49 @@ import com.google.api.generator.gapic.model.Service;
 import com.google.api.generator.test.framework.Assert;
 import com.google.api.generator.test.protoloader.GrpcTestProtoLoader;
 import java.util.*;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
-public class ServiceClientClassComposerTest {
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() {
-    return Arrays.asList(
-        new Object[][] {
-          {
+class ServiceClientClassComposerTest {
+
+  private static Stream<Arguments> data() {
+    return Stream.of(
+        Arguments.of(
             "EchoClient",
             GrpcTestProtoLoader.instance().parseShowcaseEcho(),
             "localhost:7469",
-            "v1beta1"
-          },
-          {
+            "v1beta1"),
+        Arguments.of(
             "DeprecatedServiceClient",
             GrpcTestProtoLoader.instance().parseDeprecatedService(),
             "localhost:7469",
-            "v1"
-          },
-          {
+            "v1"),
+        Arguments.of(
             "IdentityClient",
             GrpcTestProtoLoader.instance().parseShowcaseIdentity(),
             "localhost:7469",
-            "v1beta1"
-          },
-          {
+            "v1beta1"),
+        Arguments.of(
             "BookshopClient",
             GrpcTestProtoLoader.instance().parseBookshopService(),
             "localhost:2665",
-            "v1beta1"
-          },
-          {
+            "v1beta1"),
+        Arguments.of(
             "MessagingClient",
             GrpcTestProtoLoader.instance().parseShowcaseMessaging(),
             "localhost:7469",
-            "v1beta1"
-          },
-        });
+            "v1beta1"));
   }
 
-  @Parameterized.Parameter public String name;
-
-  @Parameterized.Parameter(1)
-  public GapicContext context;
-
-  @Parameterized.Parameter(2)
-  public String apiShortNameExpected;
-
-  @Parameterized.Parameter(3)
-  public String packageVersionExpected;
-
-  @Test
-  public void generateServiceClientClasses() {
+  @ParameterizedTest
+  @MethodSource("data")
+  void generateServiceClientClasses(
+      String name,
+      GapicContext context,
+      String apiShortNameExpected,
+      String packageVersionExpected) {
     Service service = context.services().get(0);
     GapicClass clazz = ServiceClientClassComposer.instance().generate(context, service);
 

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/ServiceClientTestClassComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/ServiceClientTestClassComposerTest.java
@@ -19,40 +19,29 @@ import com.google.api.generator.gapic.model.GapicContext;
 import com.google.api.generator.gapic.model.Service;
 import com.google.api.generator.test.framework.Assert;
 import com.google.api.generator.test.protoloader.GrpcTestProtoLoader;
-import java.util.Arrays;
-import java.util.Collection;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
-public class ServiceClientTestClassComposerTest {
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() {
-    return Arrays.asList(
-        new Object[][] {
-          {"EchoClientTest", GrpcTestProtoLoader.instance().parseShowcaseEcho(), 0},
-          {
+class ServiceClientTestClassComposerTest {
+
+  static Stream<Arguments> data() {
+    return Stream.of(
+        Arguments.of("EchoClientTest", GrpcTestProtoLoader.instance().parseShowcaseEcho(), 0),
+        Arguments.of(
             "DeprecatedServiceClientTest",
             GrpcTestProtoLoader.instance().parseDeprecatedService(),
-            0
-          },
-          {"TestingClientTest", GrpcTestProtoLoader.instance().parseShowcaseTesting(), 0},
-          {"SubscriberClientTest", GrpcTestProtoLoader.instance().parsePubSubPublisher(), 1},
-          {"LoggingClientTest", GrpcTestProtoLoader.instance().parseLogging(), 0},
-        });
+            0),
+        Arguments.of("TestingClientTest", GrpcTestProtoLoader.instance().parseShowcaseTesting(), 0),
+        Arguments.of(
+            "SubscriberClientTest", GrpcTestProtoLoader.instance().parsePubSubPublisher(), 1),
+        Arguments.of("LoggingClientTest", GrpcTestProtoLoader.instance().parseLogging(), 0));
   }
 
-  @Parameterized.Parameter public String name;
-
-  @Parameterized.Parameter(1)
-  public GapicContext context;
-
-  @Parameterized.Parameter(2)
-  public int serviceIndex;
-
-  @Test
-  public void generateServiceClientTestClasses() {
+  @ParameterizedTest
+  @MethodSource("data")
+  void generateServiceClientTestClasses(String name, GapicContext context, int serviceIndex) {
     Service echoProtoService = context.services().get(serviceIndex);
     GapicClass clazz =
         ServiceClientTestClassComposer.instance().generate(context, echoProtoService);

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/ServiceSettingsClassComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/ServiceSettingsClassComposerTest.java
@@ -19,46 +19,34 @@ import com.google.api.generator.gapic.model.GapicContext;
 import com.google.api.generator.gapic.model.Service;
 import com.google.api.generator.test.framework.Assert;
 import com.google.api.generator.test.protoloader.TestProtoLoader;
-import java.util.Arrays;
-import java.util.Collection;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
-public class ServiceSettingsClassComposerTest {
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() {
-    return Arrays.asList(
-        new Object[][] {
-          {
+class ServiceSettingsClassComposerTest {
+
+  static Stream<Arguments> data() {
+    return Stream.of(
+        Arguments.of(
             "EchoSettings",
             TestProtoLoader.instance().parseShowcaseEcho(),
             "localhost:7469",
-            "v1beta1"
-          },
-          {
+            "v1beta1"),
+        Arguments.of(
             "DeprecatedServiceSettings",
             TestProtoLoader.instance().parseDeprecatedService(),
             "localhost:7469",
-            "v1"
-          }
-        });
+            "v1"));
   }
 
-  @Parameterized.Parameter public String name;
-
-  @Parameterized.Parameter(1)
-  public GapicContext context;
-
-  @Parameterized.Parameter(2)
-  public String apiShortNameExpected;
-
-  @Parameterized.Parameter(3)
-  public String packageVersionExpected;
-
-  @Test
-  public void generateServiceSettingsClasses() {
+  @ParameterizedTest
+  @MethodSource("data")
+  void generateServiceSettingsClasses(
+      String name,
+      GapicContext context,
+      String apiShortNameExpected,
+      String packageVersionExpected) {
     Service service = context.services().get(0);
     GapicClass clazz = ServiceSettingsClassComposer.instance().generate(context, service);
 

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/ServiceStubClassComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/ServiceStubClassComposerTest.java
@@ -19,36 +19,26 @@ import com.google.api.generator.gapic.model.GapicContext;
 import com.google.api.generator.gapic.model.Service;
 import com.google.api.generator.test.framework.Assert;
 import com.google.api.generator.test.protoloader.TestProtoLoader;
-import java.util.Arrays;
-import java.util.Collection;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
-public class ServiceStubClassComposerTest {
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() {
-    return Arrays.asList(
-        new Object[][] {
-          {"EchoStub", TestProtoLoader.instance().parseShowcaseEcho(), "", ""},
-          {"DeprecatedServiceStub", TestProtoLoader.instance().parseDeprecatedService(), "", ""}
-        });
+class ServiceStubClassComposerTest {
+  static Stream<Arguments> data() {
+    return Stream.of(
+        Arguments.of("EchoStub", TestProtoLoader.instance().parseShowcaseEcho(), "", ""),
+        Arguments.of(
+            "DeprecatedServiceStub", TestProtoLoader.instance().parseDeprecatedService(), "", ""));
   }
 
-  @Parameterized.Parameter public String name;
-
-  @Parameterized.Parameter(1)
-  public GapicContext context;
-
-  @Parameterized.Parameter(2)
-  public String apiShortNameExpected;
-
-  @Parameterized.Parameter(3)
-  public String packageVersionExpected;
-
-  @Test
-  public void generateServiceStubClasses() {
+  @ParameterizedTest
+  @MethodSource("data")
+  void generateServiceStubClasses(
+      String name,
+      GapicContext context,
+      String apiShortNameExpected,
+      String packageVersionExpected) {
     Service service = context.services().get(0);
     GapicClass clazz = ServiceStubClassComposer.instance().generate(context, service);
 

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/ServiceStubSettingsClassComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/ServiceStubSettingsClassComposerTest.java
@@ -19,64 +19,48 @@ import com.google.api.generator.gapic.model.GapicContext;
 import com.google.api.generator.gapic.model.Service;
 import com.google.api.generator.test.framework.Assert;
 import com.google.api.generator.test.protoloader.GrpcTestProtoLoader;
-import java.util.Arrays;
-import java.util.Collection;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
-public class ServiceStubSettingsClassComposerTest {
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() {
-    return Arrays.asList(
-        new Object[][] {
-          {
+class ServiceStubSettingsClassComposerTest {
+  static Stream<Arguments> data() {
+    return Stream.of(
+        Arguments.of(
             "LoggingServiceV2StubSettings",
             GrpcTestProtoLoader.instance().parseLogging(),
             "logging",
-            "v2"
-          },
-          {
+            "v2"),
+        Arguments.of(
             "PublisherStubSettings",
             GrpcTestProtoLoader.instance().parsePubSubPublisher(),
             "pubsub",
-            "v1"
-          },
-          {
+            "v1"),
+        Arguments.of(
             "EchoStubSettings",
             GrpcTestProtoLoader.instance().parseShowcaseEcho(),
             "localhost:7469",
-            "v1beta1"
-          },
-          {
+            "v1beta1"),
+        Arguments.of(
             "DeprecatedServiceStubSettings",
             GrpcTestProtoLoader.instance().parseDeprecatedService(),
             "localhost:7469",
-            "v1"
-          },
-          {
+            "v1"),
+        Arguments.of(
             "ApiVersionTestingStubSettings",
             GrpcTestProtoLoader.instance().parseApiVersionTesting(),
             "localhost:7469",
-            "v1"
-          }
-        });
+            "v1"));
   }
 
-  @Parameterized.Parameter public String name;
-
-  @Parameterized.Parameter(1)
-  public GapicContext context;
-
-  @Parameterized.Parameter(2)
-  public String apiShortNameExpected;
-
-  @Parameterized.Parameter(3)
-  public String packageVersionExpected;
-
-  @Test
-  public void generateServiceStubSettingsClasses() {
+  @ParameterizedTest
+  @MethodSource("data")
+  void generateServiceStubSettingsClasses(
+      String name,
+      GapicContext context,
+      String apiShortNameExpected,
+      String packageVersionExpected) {
     Service service = context.services().get(0);
     GapicClass clazz = ServiceStubSettingsClassComposer.instance().generate(context, service);
 

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/GrpcServiceCallableFactoryClassComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/GrpcServiceCallableFactoryClassComposerTest.java
@@ -24,11 +24,11 @@ import com.google.api.generator.test.framework.GoldenFileWriter;
 import com.google.api.generator.test.protoloader.GrpcRestTestProtoLoader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class GrpcServiceCallableFactoryClassComposerTest {
+class GrpcServiceCallableFactoryClassComposerTest {
   @Test
-  public void generateServiceClasses() {
+  void generateServiceClasses() {
     GapicContext context = GrpcRestTestProtoLoader.instance().parseShowcaseEcho();
     Service echoProtoService = context.services().get(0);
     GapicClass clazz =
@@ -44,7 +44,7 @@ public class GrpcServiceCallableFactoryClassComposerTest {
   }
 
   @Test
-  public void generateServiceClassesWicked() {
+  void generateServiceClassesWicked() {
     GapicContext context = GrpcRestTestProtoLoader.instance().parseShowcaseWicked();
     Service wickedProtoService = context.services().get(0);
     GapicClass clazz =

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/GrpcServiceStubClassComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/GrpcServiceStubClassComposerTest.java
@@ -24,11 +24,11 @@ import com.google.api.generator.test.framework.GoldenFileWriter;
 import com.google.api.generator.test.protoloader.GrpcRestTestProtoLoader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class GrpcServiceStubClassComposerTest {
+class GrpcServiceStubClassComposerTest {
   @Test
-  public void generateServiceClasses() {
+  void generateServiceClasses() {
     GapicContext context = GrpcRestTestProtoLoader.instance().parseShowcaseEcho();
     Service echoProtoService = context.services().get(0);
     GapicClass clazz = GrpcServiceStubClassComposer.instance().generate(context, echoProtoService);
@@ -42,7 +42,7 @@ public class GrpcServiceStubClassComposerTest {
   }
 
   @Test
-  public void generateServiceClassesWicked() {
+  void generateServiceClassesWicked() {
     GapicContext context = GrpcRestTestProtoLoader.instance().parseShowcaseWicked();
     Service wickedProtoService = context.services().get(0);
     GapicClass clazz =

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/HttpJsonServiceCallableFactoryClassComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/HttpJsonServiceCallableFactoryClassComposerTest.java
@@ -26,11 +26,11 @@ import com.google.api.generator.test.framework.GoldenFileWriter;
 import com.google.api.generator.test.protoloader.GrpcRestTestProtoLoader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class HttpJsonServiceCallableFactoryClassComposerTest {
+class HttpJsonServiceCallableFactoryClassComposerTest {
   @Test
-  public void generateServiceClasses() {
+  void generateServiceClasses() {
     GapicContext context = GrpcRestTestProtoLoader.instance().parseShowcaseEcho();
     Service echoProtoService = context.services().get(0);
     GapicClass clazz =
@@ -47,7 +47,7 @@ public class HttpJsonServiceCallableFactoryClassComposerTest {
   }
 
   @Test
-  public void generateServiceClassesWicked() {
+  void generateServiceClassesWicked() {
     GapicContext context = GrpcRestTestProtoLoader.instance().parseShowcaseWicked();
     Service wickedProtoService = context.services().get(0);
     GapicClass clazz =

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/HttpJsonServiceClientTestClassComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/HttpJsonServiceClientTestClassComposerTest.java
@@ -25,11 +25,12 @@ import com.google.api.generator.test.framework.GoldenFileWriter;
 import com.google.api.generator.test.protoloader.GrpcRestTestProtoLoader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class HttpJsonServiceClientTestClassComposerTest {
+class HttpJsonServiceClientTestClassComposerTest {
+
   @Test
-  public void generateServiceClasses() {
+  void generateServiceClasses() {
     GapicContext context = GrpcRestTestProtoLoader.instance().parseShowcaseEcho();
     Service echoProtoService = context.services().get(0);
     GapicClass clazz =
@@ -45,7 +46,7 @@ public class HttpJsonServiceClientTestClassComposerTest {
   }
 
   @Test
-  public void generateServiceClassesWicked() {
+  void generateServiceClassesWicked() {
     GapicContext context = GrpcRestTestProtoLoader.instance().parseShowcaseWicked();
     Service wickedProtoService = context.services().get(0);
     GapicClass clazz =

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/HttpJsonServiceStubClassComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/HttpJsonServiceStubClassComposerTest.java
@@ -25,11 +25,11 @@ import com.google.api.generator.test.framework.GoldenFileWriter;
 import com.google.api.generator.test.protoloader.GrpcRestTestProtoLoader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class HttpJsonServiceStubClassComposerTest {
+class HttpJsonServiceStubClassComposerTest {
   @Test
-  public void generateServiceClasses() {
+  void generateServiceClasses() {
     GapicContext context = GrpcRestTestProtoLoader.instance().parseShowcaseEcho();
     Service echoProtoService = context.services().get(0);
     GapicClass clazz =
@@ -44,7 +44,7 @@ public class HttpJsonServiceStubClassComposerTest {
   }
 
   @Test
-  public void generateServiceClassesWicked() {
+  void generateServiceClassesWicked() {
     GapicContext context = GrpcRestTestProtoLoader.instance().parseShowcaseWicked();
     Service wickedProtoService = context.services().get(0);
     GapicClass clazz =

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/ServiceClientClassComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/ServiceClientClassComposerTest.java
@@ -23,11 +23,11 @@ import com.google.api.generator.test.framework.GoldenFileWriter;
 import com.google.api.generator.test.protoloader.GrpcRestTestProtoLoader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ServiceClientClassComposerTest {
+class ServiceClientClassComposerTest {
   @Test
-  public void generateServiceClasses() {
+  void generateServiceClasses() {
     GapicContext context = GrpcRestTestProtoLoader.instance().parseShowcaseEcho();
     Service echoProtoService = context.services().get(0);
     GapicClass clazz = ServiceClientClassComposer.instance().generate(context, echoProtoService);
@@ -41,7 +41,7 @@ public class ServiceClientClassComposerTest {
   }
 
   @Test
-  public void generateServiceClassesEmpty() {
+  void generateServiceClassesEmpty() {
     GapicContext context = GrpcRestTestProtoLoader.instance().parseShowcaseEcho();
     Service echoProtoService = context.services().get(1);
     GapicClass clazz = ServiceClientClassComposer.instance().generate(context, echoProtoService);
@@ -55,7 +55,7 @@ public class ServiceClientClassComposerTest {
   }
 
   @Test
-  public void generateServiceClassesWicked() {
+  void generateServiceClassesWicked() {
     GapicContext context = GrpcRestTestProtoLoader.instance().parseShowcaseWicked();
     Service wickedProtoService = context.services().get(0);
     GapicClass clazz = ServiceClientClassComposer.instance().generate(context, wickedProtoService);

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/ServiceClientTestClassComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/ServiceClientTestClassComposerTest.java
@@ -26,11 +26,11 @@ import com.google.api.generator.test.framework.GoldenFileWriter;
 import com.google.api.generator.test.protoloader.GrpcRestTestProtoLoader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ServiceClientTestClassComposerTest {
+class ServiceClientTestClassComposerTest {
   @Test
-  public void generateServiceClasses() {
+  void generateServiceClasses() {
     GapicContext context = GrpcRestTestProtoLoader.instance().parseShowcaseEcho();
     Service echoProtoService = context.services().get(0);
     GapicClass clazz =
@@ -45,7 +45,7 @@ public class ServiceClientTestClassComposerTest {
   }
 
   @Test
-  public void generateServiceClassesWicked() {
+  void generateServiceClassesWicked() {
     GapicContext context = GrpcRestTestProtoLoader.instance().parseShowcaseWicked();
     Service wickedProtoService = context.services().get(0);
     GapicClass clazz =

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/ServiceSettingsClassComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/ServiceSettingsClassComposerTest.java
@@ -23,11 +23,11 @@ import com.google.api.generator.test.framework.GoldenFileWriter;
 import com.google.api.generator.test.protoloader.GrpcRestTestProtoLoader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ServiceSettingsClassComposerTest {
+class ServiceSettingsClassComposerTest {
   @Test
-  public void generateServiceClasses() {
+  void generateServiceClasses() {
     GapicContext context = GrpcRestTestProtoLoader.instance().parseShowcaseEcho();
     Service echoProtoService = context.services().get(0);
     GapicClass clazz = ServiceSettingsClassComposer.instance().generate(context, echoProtoService);
@@ -41,7 +41,7 @@ public class ServiceSettingsClassComposerTest {
   }
 
   @Test
-  public void generateServiceClassesWicked() {
+  void generateServiceClassesWicked() {
     GapicContext context = GrpcRestTestProtoLoader.instance().parseShowcaseWicked();
     Service wickedProtoService = context.services().get(0);
     GapicClass clazz =

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/ServiceStubSettingsClassComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/ServiceStubSettingsClassComposerTest.java
@@ -23,30 +23,23 @@ import com.google.api.generator.test.framework.GoldenFileWriter;
 import com.google.api.generator.test.protoloader.GrpcRestTestProtoLoader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.Collection;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
-public class ServiceStubSettingsClassComposerTest {
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() {
-    return Arrays.asList(
-        new Object[][] {
-          {"EchoStubSettings.golden", GrpcRestTestProtoLoader.instance().parseShowcaseEcho()},
-          {"WickedStubSettings.golden", GrpcRestTestProtoLoader.instance().parseShowcaseWicked()}
-        });
+class ServiceStubSettingsClassComposerTest {
+  static Stream<Arguments> data() {
+    return Stream.of(
+        Arguments.of(
+            "EchoStubSettings.golden", GrpcRestTestProtoLoader.instance().parseShowcaseEcho()),
+        Arguments.of(
+            "WickedStubSettings.golden", GrpcRestTestProtoLoader.instance().parseShowcaseWicked()));
   }
 
-  @Parameterized.Parameter public String goldenFileName;
-
-  @Parameterized.Parameter(1)
-  public GapicContext context;
-
-  @Test
-  public void generateServiceClasses() {
+  @ParameterizedTest
+  @MethodSource("data")
+  void generateServiceClasses(String goldenFileName, GapicContext context) {
     Service echoProtoService = context.services().get(0);
     GapicClass clazz =
         ServiceStubSettingsClassComposer.instance().generate(context, echoProtoService);

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/resourcename/ResourceNameHelperClassComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/resourcename/ResourceNameHelperClassComposerTest.java
@@ -48,25 +48,25 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class ResourceNameHelperClassComposerTest {
+class ResourceNameHelperClassComposerTest {
 
   private final String COLLIDING_RESOURCE_NAME_KEY = "config.googleapis.com/Resource";
 
   private ServiceDescriptor echoService;
   private FileDescriptor echoFileDescriptor;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     echoFileDescriptor = EchoOuterClass.getDescriptor();
     echoService = echoFileDescriptor.getServices().get(0);
     assertEquals(echoService.getName(), "Echo");
   }
 
   @Test
-  public void getTokenSet_basic() {
+  void getTokenSet_basic() {
     List<String> patterns =
         Arrays.asList(
             "projects/{project}/agent/sessions/{session}",
@@ -80,7 +80,7 @@ public class ResourceNameHelperClassComposerTest {
   }
 
   @Test
-  public void concatToUpperSnakeCaseName_basic() {
+  void concatToUpperSnakeCaseName_basic() {
     assertEquals(
         "PROJECT_LOCATION_AUTOSCALING_POLICY",
         ResourceNameHelperClassComposer.concatToUpperSnakeCaseName(
@@ -88,7 +88,7 @@ public class ResourceNameHelperClassComposerTest {
   }
 
   @Test
-  public void concatToUpperCamelCaseName_basic() {
+  void concatToUpperCamelCaseName_basic() {
     assertEquals(
         "ProjectLocationAutoscalingPolicy",
         ResourceNameHelperClassComposer.concatToUpperCamelCaseName(
@@ -96,7 +96,7 @@ public class ResourceNameHelperClassComposerTest {
   }
 
   @Test
-  public void generateResourceNameClass_echoFoobarMultiplePatterns() {
+  void generateResourceNameClass_echoFoobarMultiplePatterns() {
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Set<ResourceName> outputResourceNames = new HashSet<>();
@@ -119,7 +119,7 @@ public class ResourceNameHelperClassComposerTest {
   }
 
   @Test
-  public void generateResourceNameClass_loggingOnePatternMultipleVariables() {
+  void generateResourceNameClass_loggingOnePatternMultipleVariables() {
     FileDescriptor serviceFileDescriptor = LoggingConfigProto.getDescriptor();
     ServiceDescriptor serviceDescriptor = serviceFileDescriptor.getServices().get(0);
     assertEquals(serviceDescriptor.getName(), "ConfigServiceV2");
@@ -166,7 +166,7 @@ public class ResourceNameHelperClassComposerTest {
   }
 
   @Test
-  public void generateResourceNameClass_testingSessionOnePattern() {
+  void generateResourceNameClass_testingSessionOnePattern() {
     FileDescriptor testingFileDescriptor = TestingOuterClass.getDescriptor();
     ServiceDescriptor testingService = testingFileDescriptor.getServices().get(0);
     assertEquals(testingService.getName(), "Testing");
@@ -193,7 +193,7 @@ public class ResourceNameHelperClassComposerTest {
   }
 
   @Test
-  public void generateResourceNameClass_testingBlueprintPatternWithNonSlashSeparator() {
+  void generateResourceNameClass_testingBlueprintPatternWithNonSlashSeparator() {
     FileDescriptor testingFileDescriptor = TestingOuterClass.getDescriptor();
     ServiceDescriptor testingService = testingFileDescriptor.getServices().get(0);
     assertEquals(testingService.getName(), "Testing");
@@ -220,7 +220,7 @@ public class ResourceNameHelperClassComposerTest {
   }
 
   @Test
-  public void generateResourceNameClass_childSingleton() {
+  void generateResourceNameClass_childSingleton() {
     ResourceName agentResname =
         ResourceName.builder()
             .setVariableName("agent")
@@ -245,7 +245,7 @@ public class ResourceNameHelperClassComposerTest {
   }
 
   @Test
-  public void generateResourceNameClass_resourceNameCollisionIsAvoided() {
+  void generateResourceNameClass_resourceNameCollisionIsAvoided() {
     ResourceName collidingResourceName =
         Parser.parseResourceNames(CollisionsOuterClass.getDescriptor())
             .get(COLLIDING_RESOURCE_NAME_KEY);

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/resourcename/ResourceNameTokenizerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/resourcename/ResourceNameTokenizerTest.java
@@ -22,22 +22,22 @@ import com.google.protobuf.Descriptors.ServiceDescriptor;
 import com.google.showcase.v1beta1.EchoOuterClass;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class ResourceNameTokenizerTest {
+class ResourceNameTokenizerTest {
   private ServiceDescriptor echoService;
   private FileDescriptor echoFileDescriptor;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     echoFileDescriptor = EchoOuterClass.getDescriptor();
     echoService = echoFileDescriptor.getServices().get(0);
     assertEquals(echoService.getName(), "Echo");
   }
 
   @Test
-  public void parseTokenHierarchy_basic() {
+  void parseTokenHierarchy_basic() {
     List<String> patterns =
         Arrays.asList(
             "projects/{project}/locations/{location}/autoscalingPolicies/{autoscaling_policy}",
@@ -52,7 +52,7 @@ public class ResourceNameTokenizerTest {
   }
 
   @Test
-  public void parseTokenHierarchy_substringsInPattern() {
+  void parseTokenHierarchy_substringsInPattern() {
     List<String> patterns =
         Arrays.asList(
             "customers/{customer}/customerExtensionSettings/{customer_extension_setting}");
@@ -62,7 +62,7 @@ public class ResourceNameTokenizerTest {
   }
 
   @Test
-  public void parseTokenHierarchy_wildcards() {
+  void parseTokenHierarchy_wildcards() {
     List<String> patterns =
         Arrays.asList(
             "projects/{project}/metricDescriptors/{metric_descriptor=**}",
@@ -76,7 +76,7 @@ public class ResourceNameTokenizerTest {
   }
 
   @Test
-  public void parseTokenHierarchy_singletonCollection() {
+  void parseTokenHierarchy_singletonCollection() {
     List<String> patterns =
         Arrays.asList(
             "projects/{project}/agent/sessions/{session}",
@@ -89,7 +89,7 @@ public class ResourceNameTokenizerTest {
   }
 
   @Test
-  public void parseTokenHierarchy_singletonCollectionAndNonSlashSeparators() {
+  void parseTokenHierarchy_singletonCollectionAndNonSlashSeparators() {
     List<String> patterns =
         Arrays.asList(
             "users/{user}/profile/blurbs/legacy/{legacy_user}~{blurb}",
@@ -110,7 +110,7 @@ public class ResourceNameTokenizerTest {
   }
 
   @Test
-  public void parseTokenHierarchy_invalidPatterns() {
+  void parseTokenHierarchy_invalidPatterns() {
     List<String> patterns =
         Arrays.asList(
             "projects/{project}/agent/sessions/{session}/anotherSingleton",

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceCallableFactoryClassComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceCallableFactoryClassComposerTest.java
@@ -23,11 +23,11 @@ import com.google.api.generator.test.framework.GoldenFileWriter;
 import com.google.api.generator.test.protoloader.RestTestProtoLoader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class HttpJsonServiceCallableFactoryClassComposerTest {
+class HttpJsonServiceCallableFactoryClassComposerTest {
   @Test
-  public void generateServiceClasses() {
+  void generateServiceClasses() {
     GapicContext context = RestTestProtoLoader.instance().parseCompliance();
     Service echoProtoService = context.services().get(0);
     GapicClass clazz =

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposerTest.java
@@ -35,20 +35,20 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class HttpJsonServiceStubClassComposerTest {
+class HttpJsonServiceStubClassComposerTest {
 
   private HttpJsonServiceStubClassComposer composer;
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeEach
+  void setUp() throws Exception {
     composer = HttpJsonServiceStubClassComposer.instance();
   }
 
   @Test
-  public void generateComplianceServiceClasses() {
+  void generateComplianceServiceClasses() {
     GapicContext context = RestTestProtoLoader.instance().parseCompliance();
     Service complianceProtoServices = context.services().get(0);
     GapicClass clazz = composer.generate(context, complianceProtoServices);
@@ -63,7 +63,7 @@ public class HttpJsonServiceStubClassComposerTest {
   }
 
   @Test
-  public void generateEchoServiceClasses() {
+  void generateEchoServiceClasses() {
     GapicContext context = RestTestProtoLoader.instance().parseEcho();
     Service echoProtoService = context.services().get(0);
     GapicClass clazz = composer.generate(context, echoProtoService);
@@ -77,8 +77,7 @@ public class HttpJsonServiceStubClassComposerTest {
   }
 
   @Test
-  public void
-      getBindingFieldMethodName_shouldReturnGetFieldListIfTheFieldIsInLastPositionAndIsRepeated() {
+  void getBindingFieldMethodName_shouldReturnGetFieldListIfTheFieldIsInLastPositionAndIsRepeated() {
     Field field =
         Field.builder()
             .setIsRepeated(true)
@@ -92,8 +91,7 @@ public class HttpJsonServiceStubClassComposerTest {
   }
 
   @Test
-  public void
-      getBindingFieldMethodName_shouldReturnGetFieldValueIfTheFieldIsInLastPositionAndIsEnum() {
+  void getBindingFieldMethodName_shouldReturnGetFieldValueIfTheFieldIsInLastPositionAndIsEnum() {
     Field field =
         Field.builder().setIsEnum(true).setName("doesNotMatter").setType(TypeNode.OBJECT).build();
     HttpBinding httpBinding =
@@ -103,7 +101,7 @@ public class HttpJsonServiceStubClassComposerTest {
   }
 
   @Test
-  public void
+  void
       getBindingFieldMethodName_shouldReturnGetFieldIfTheFieldIsInLastPositionAndNotRepeatedOrEnum() {
     Field field = Field.builder().setName("doesNotMatter").setType(TypeNode.OBJECT).build();
     HttpBinding httpBinding =
@@ -113,7 +111,7 @@ public class HttpJsonServiceStubClassComposerTest {
   }
 
   @Test
-  public void getBindingFieldMethodName_shouldReturnGetFieldIfTheFieldIsNotInLastPosition() {
+  void getBindingFieldMethodName_shouldReturnGetFieldIfTheFieldIsNotInLastPosition() {
     Field field = Field.builder().setName("doesNotMatter").setType(TypeNode.OBJECT).build();
     HttpBinding httpBinding =
         HttpBinding.builder().setField(field).setName("doesNotMatter").build();
@@ -122,7 +120,7 @@ public class HttpJsonServiceStubClassComposerTest {
   }
 
   @Test
-  public void parseOperationsCustomHttpRules_shouldReturnMapIfContextContainsValidServiceYaml() {
+  void parseOperationsCustomHttpRules_shouldReturnMapIfContextContainsValidServiceYaml() {
     List<HttpRule> httpRuleList =
         ImmutableList.of(
             HttpRule.newBuilder()
@@ -152,7 +150,7 @@ public class HttpJsonServiceStubClassComposerTest {
   }
 
   @Test
-  public void parseOperationsCustomHttpRules_shouldReturnEmptyMapIfContextHasInvalidServiceYaml() {
+  void parseOperationsCustomHttpRules_shouldReturnEmptyMapIfContextHasInvalidServiceYaml() {
     GapicContext contextNullServiceYaml = RestTestProtoLoader.instance().parseCompliance();
     contextNullServiceYaml = contextNullServiceYaml.toBuilder().setServiceYamlProto(null).build();
     Map<String, HttpRule> httpRuleMapNull =
@@ -171,7 +169,7 @@ public class HttpJsonServiceStubClassComposerTest {
   }
 
   @Test
-  public void testGetOperationsURIValueFromHttpRule() {
+  void testGetOperationsURIValueFromHttpRule() {
     HttpRule getHttpRule = HttpRule.newBuilder().setGet("Get").build();
     Truth.assertThat(composer.getOperationsURIValueFromHttpRule(getHttpRule)).isEqualTo("Get");
     HttpRule postHttpRule = HttpRule.newBuilder().setPost("Post").build();
@@ -198,7 +196,7 @@ public class HttpJsonServiceStubClassComposerTest {
   }
 
   @Test
-  public void generateGrpcServiceStubClass_routingHeaders() {
+  void generateGrpcServiceStubClass_routingHeaders() {
     GapicContext context =
         RestTestProtoLoader.instance().parseExplicitDynamicRoutingHeaderTesting();
     Service service = context.services().get(0);
@@ -209,7 +207,7 @@ public class HttpJsonServiceStubClassComposerTest {
   }
 
   @Test
-  public void generateHttpJsonServiceStubClass_autopopulateField() {
+  void generateHttpJsonServiceStubClass_autopopulateField() {
     GapicContext context = RestTestProtoLoader.instance().parseAutoPopulateFieldTesting();
     Service service = context.services().get(0);
     GapicClass clazz = HttpJsonServiceStubClassComposer.instance().generate(context, service);

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/ServiceClientTestClassComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/ServiceClientTestClassComposerTest.java
@@ -24,11 +24,11 @@ import com.google.api.generator.test.framework.GoldenFileWriter;
 import com.google.api.generator.test.protoloader.RestTestProtoLoader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ServiceClientTestClassComposerTest {
+class ServiceClientTestClassComposerTest {
   @Test
-  public void generateServiceClasses() {
+  void generateServiceClasses() {
     GapicContext context = RestTestProtoLoader.instance().parseCompliance();
     Service echoProtoService = context.services().get(0);
     GapicClass clazz =

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/ServiceSettingsClassComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/ServiceSettingsClassComposerTest.java
@@ -23,11 +23,11 @@ import com.google.api.generator.test.framework.GoldenFileWriter;
 import com.google.api.generator.test.protoloader.RestTestProtoLoader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ServiceSettingsClassComposerTest {
+class ServiceSettingsClassComposerTest {
   @Test
-  public void generateServiceClasses() {
+  void generateServiceClasses() {
     GapicContext context = RestTestProtoLoader.instance().parseCompliance();
     Service echoProtoService = context.services().get(0);
     GapicClass clazz = ServiceSettingsClassComposer.instance().generate(context, echoProtoService);

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/ServiceStubSettingsClassComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/ServiceStubSettingsClassComposerTest.java
@@ -23,34 +23,25 @@ import com.google.api.generator.test.framework.GoldenFileWriter;
 import com.google.api.generator.test.protoloader.RestTestProtoLoader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.Collection;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
-public class ServiceStubSettingsClassComposerTest {
+class ServiceStubSettingsClassComposerTest {
 
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() {
-    return Arrays.asList(
-        new Object[][] {
-          {"ComplianceStubSettings.golden", RestTestProtoLoader.instance().parseCompliance()},
-          {
+  static Stream<Arguments> data() {
+    return Stream.of(
+        Arguments.of(
+            "ComplianceStubSettings.golden", RestTestProtoLoader.instance().parseCompliance()),
+        Arguments.of(
             "HttpJsonApiVersionTestingStubSettings.golden",
-            RestTestProtoLoader.instance().parseApiVersionTesting()
-          }
-        });
+            RestTestProtoLoader.instance().parseApiVersionTesting()));
   }
 
-  @Parameterized.Parameter public String goldenFileName;
-
-  @Parameterized.Parameter(1)
-  public GapicContext context;
-
-  @Test
-  public void generateServiceClasses() {
+  @ParameterizedTest
+  @MethodSource("data")
+  void generateServiceClasses(String goldenFileName, GapicContext context) {
     Service protoService = context.services().get(0);
     GapicClass clazz = ServiceStubSettingsClassComposer.instance().generate(context, protoService);
 

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/samplecode/SampleBodyJavaFormatterTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/samplecode/SampleBodyJavaFormatterTest.java
@@ -18,12 +18,12 @@ import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 import com.google.api.generator.test.utils.LineFormatter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class SampleBodyJavaFormatterTest {
+class SampleBodyJavaFormatterTest {
 
   @Test
-  public void validFormatSampleCode_tryCatchStatement() {
+  void validFormatSampleCode_tryCatchStatement() {
     String samplecode = LineFormatter.lines("try(boolean condition = false){", "int x = 3;", "}");
     String result = SampleBodyJavaFormatter.format(samplecode);
     String expected =
@@ -32,7 +32,7 @@ public class SampleBodyJavaFormatterTest {
   }
 
   @Test
-  public void validFormatSampleCode_longLineStatement() {
+  void validFormatSampleCode_longLineStatement() {
     String sampleCode =
         "SubscriptionAdminSettings subscriptionAdminSettings = "
             + "SubscriptionAdminSettings.newBuilder().setEndpoint(myEndpoint).build();";
@@ -45,7 +45,7 @@ public class SampleBodyJavaFormatterTest {
   }
 
   @Test
-  public void validFormatSampleCode_longChainMethod() {
+  void validFormatSampleCode_longChainMethod() {
     String sampleCode =
         "echoSettingsBuilder.echoSettings().setRetrySettings("
             + "echoSettingsBuilder.echoSettings().getRetrySettings().toBuilder()"
@@ -66,7 +66,7 @@ public class SampleBodyJavaFormatterTest {
   }
 
   @Test
-  public void invalidFormatSampleCode_nonStatement() {
+  void invalidFormatSampleCode_nonStatement() {
     assertThrows(
         SampleBodyJavaFormatter.FormatException.class,
         () -> {

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/samplecode/SampleCodeWriterTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/samplecode/SampleCodeWriterTest.java
@@ -34,17 +34,17 @@ import com.google.api.generator.test.utils.LineFormatter;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-public class SampleCodeWriterTest {
+class SampleCodeWriterTest {
   private static String packageName = "com.google.samples";
   private static List<Statement> testingSampleStatements;
   private static Sample testingSample;
   private static RegionTag regionTag;
 
-  @BeforeClass
-  public static void setUp() {
+  @BeforeAll
+  static void setUp() {
     TypeNode settingType =
         TypeNode.withReference(ConcreteReference.withClazz(ClientSettings.class));
     Variable aVar = Variable.builder().setName("clientSettings").setType(settingType).build();
@@ -92,7 +92,7 @@ public class SampleCodeWriterTest {
   }
 
   @Test
-  public void writeSampleCodeStatements() {
+  void writeSampleCodeStatements() {
     String result = SampleCodeWriter.write(testingSampleStatements);
     String expected =
         "ClientSettings clientSettings = ClientSettings.newBuilder().build();\n"
@@ -103,7 +103,7 @@ public class SampleCodeWriterTest {
   }
 
   @Test
-  public void writeInlineSample() {
+  void writeInlineSample() {
     String result = SampleCodeWriter.writeInlineSample(testingSampleStatements);
     String expected =
         LineFormatter.lines(
@@ -120,7 +120,7 @@ public class SampleCodeWriterTest {
   }
 
   @Test
-  public void writeExecutableSample() {
+  void writeExecutableSample() {
     Sample sample =
         testingSample.withRegionTag(regionTag.withOverloadDisambiguation("ExecutableSample"));
     String result = SampleCodeWriter.writeExecutableSample(sample, packageName);

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/samplecode/SampleComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/samplecode/SampleComposerTest.java
@@ -36,15 +36,15 @@ import com.google.api.generator.test.utils.LineFormatter;
 import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class SampleComposerTest {
+class SampleComposerTest {
   private final String packageName = "com.google.example";
   private final RegionTag.Builder regionTag =
       RegionTag.builder().setApiShortName("apiName").setServiceName("echo");
 
   @Test
-  public void createInlineSample() {
+  void createInlineSample() {
     List<Statement> sampleBody = Arrays.asList(ExprStatement.withExpr(systemOutPrint("testing")));
     String sampleResult = writeSample(SampleComposer.composeInlineSample(sampleBody));
     String expected =
@@ -60,7 +60,7 @@ public class SampleComposerTest {
   }
 
   @Test
-  public void createExecutableSampleEmptyStatementSample() {
+  void createExecutableSampleEmptyStatementSample() {
     Sample sample =
         Sample.builder()
             .setRegionTag(
@@ -96,7 +96,7 @@ public class SampleComposerTest {
   }
 
   @Test
-  public void createExecutableSampleMethodArgsNoVar() {
+  void createExecutableSampleMethodArgsNoVar() {
     Statement sampleBody =
         ExprStatement.withExpr(systemOutPrint("Testing CreateExecutableSampleMethodArgsNoVar"));
     Sample sample =
@@ -136,7 +136,7 @@ public class SampleComposerTest {
   }
 
   @Test
-  public void createExecutableSampleMethod() {
+  void createExecutableSampleMethod() {
     VariableExpr variableExpr =
         VariableExpr.builder()
             .setVariable(Variable.builder().setType(TypeNode.STRING).setName("content").build())
@@ -185,7 +185,7 @@ public class SampleComposerTest {
   }
 
   @Test
-  public void createExecutableSampleMethodMultipleStatements() {
+  void createExecutableSampleMethodMultipleStatements() {
     VariableExpr strVariableExpr =
         VariableExpr.builder()
             .setVariable(Variable.builder().setType(TypeNode.STRING).setName("content").build())

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/samplecode/SampleComposerUtilTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/samplecode/SampleComposerUtilTest.java
@@ -28,9 +28,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class SampleComposerUtilTest {
+class SampleComposerUtilTest {
   private static final String SHOWCASE_PACKAGE_NAME = "com.google.showcase.v1beta1";
   TypeNode clientType =
       TypeNode.withReference(
@@ -55,7 +55,7 @@ public class SampleComposerUtilTest {
           .build();
 
   @Test
-  public void assignClientVariableWithCreateMethodExpr() {
+  void assignClientVariableWithCreateMethodExpr() {
     String result =
         SampleCodeWriter.write(
             SampleComposerUtil.assignClientVariableWithCreateMethodExpr(echoClientVariableExpr));
@@ -65,14 +65,14 @@ public class SampleComposerUtilTest {
   }
 
   @Test
-  public void createOverloadDisambiguation_noargs() {
+  void createOverloadDisambiguation_noargs() {
     String result = SampleComposerUtil.createOverloadDisambiguation(new ArrayList<>());
     String expected = "Noargs";
     assertEquals(expected, result);
   }
 
   @Test
-  public void createOverloadDisambiguation_sameargs() {
+  void createOverloadDisambiguation_sameargs() {
     List<VariableExpr> methodArgVarExprs = Collections.nCopies(5, stringVariableExpr);
 
     String result = SampleComposerUtil.createOverloadDisambiguation(methodArgVarExprs);
@@ -81,7 +81,7 @@ public class SampleComposerUtilTest {
   }
 
   @Test
-  public void createOverloadDisambiguation_containsInt() {
+  void createOverloadDisambiguation_containsInt() {
     List<VariableExpr> methodArgVarExprs =
         Arrays.asList(echoClientVariableExpr, stringVariableExpr, intVariableExpr);
 
@@ -91,7 +91,7 @@ public class SampleComposerUtilTest {
   }
 
   @Test
-  public void handleDuplicateSamples_actualDuplicates() {
+  void handleDuplicateSamples_actualDuplicates() {
     List<Sample> samples = Collections.nCopies(5, echoClientSample);
     assertEquals(samples.size(), 5);
 
@@ -101,7 +101,7 @@ public class SampleComposerUtilTest {
   }
 
   @Test
-  public void handleDuplicateSamples_distinctDuplicates() {
+  void handleDuplicateSamples_distinctDuplicates() {
     VariableExpr echoClientVariableExprDiffVarName =
         VariableExpr.withVariable(
             Variable.builder().setName("echoClient2").setType(clientType).build());
@@ -128,7 +128,7 @@ public class SampleComposerUtilTest {
   }
 
   @Test
-  public void handleDuplicateSamples_notDuplicateName() {
+  void handleDuplicateSamples_notDuplicateName() {
     Sample echoClientSampleDiffRpcName =
         echoClientSample.withRegionTag(
             echoClientSample.regionTag().toBuilder().setRpcName("createB").build());

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientCallableMethodSampleComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientCallableMethodSampleComposerTest.java
@@ -31,9 +31,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ServiceClientCallableMethodSampleComposerTest {
+class ServiceClientCallableMethodSampleComposerTest {
   private static final String SHOWCASE_PACKAGE_NAME = "com.google.showcase.v1beta1";
   private static final String LRO_PACKAGE_NAME = "com.google.longrunning";
   private static final String PROTO_PACKAGE_NAME = "com.google.protobuf";
@@ -51,7 +51,7 @@ public class ServiceClientCallableMethodSampleComposerTest {
 
   /*Testing composeLroCallableMethod*/
   @Test
-  public void valid_composeLroCallableMethod_withReturnResponse() {
+  void valid_composeLroCallableMethod_withReturnResponse() {
     Descriptors.FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -122,7 +122,7 @@ public class ServiceClientCallableMethodSampleComposerTest {
   }
 
   @Test
-  public void valid_composeLroCallableMethod_withReturnVoid() {
+  void valid_composeLroCallableMethod_withReturnVoid() {
     Descriptors.FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -191,7 +191,7 @@ public class ServiceClientCallableMethodSampleComposerTest {
 
   /*Testing composePagedCallableMethod*/
   @Test
-  public void valid_composePagedCallableMethod() {
+  void valid_composePagedCallableMethod() {
     Descriptors.FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -255,7 +255,7 @@ public class ServiceClientCallableMethodSampleComposerTest {
   }
 
   @Test
-  public void invalid_composePagedCallableMethod_inputTypeNotExistInMessage() {
+  void invalid_composePagedCallableMethod_inputTypeNotExistInMessage() {
     Descriptors.FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -303,7 +303,7 @@ public class ServiceClientCallableMethodSampleComposerTest {
   }
 
   @Test
-  public void invalid_composePagedCallableMethod_noExistMethodResponse() {
+  void invalid_composePagedCallableMethod_noExistMethodResponse() {
     Descriptors.FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -351,7 +351,7 @@ public class ServiceClientCallableMethodSampleComposerTest {
   }
 
   @Test
-  public void invalid_composePagedCallableMethod_noRepeatedResponse() {
+  void invalid_composePagedCallableMethod_noRepeatedResponse() {
     Descriptors.FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -414,7 +414,7 @@ public class ServiceClientCallableMethodSampleComposerTest {
 
   /*Testing composeStreamCallableMethod*/
   @Test
-  public void valid_composeStreamCallableMethod_serverStream() {
+  void valid_composeStreamCallableMethod_serverStream() {
     Descriptors.FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -472,7 +472,7 @@ public class ServiceClientCallableMethodSampleComposerTest {
   }
 
   @Test
-  public void invalid_composeStreamCallableMethod_serverStreamNotExistRequest() {
+  void invalid_composeStreamCallableMethod_serverStreamNotExistRequest() {
     Descriptors.FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -520,7 +520,7 @@ public class ServiceClientCallableMethodSampleComposerTest {
   }
 
   @Test
-  public void valid_composeStreamCallableMethod_bidiStream() {
+  void valid_composeStreamCallableMethod_bidiStream() {
     Descriptors.FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -587,7 +587,7 @@ public class ServiceClientCallableMethodSampleComposerTest {
   }
 
   @Test
-  public void invalid_composeStreamCallableMethod_bidiStreamNotExistRequest() {
+  void invalid_composeStreamCallableMethod_bidiStreamNotExistRequest() {
     Descriptors.FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -635,7 +635,7 @@ public class ServiceClientCallableMethodSampleComposerTest {
   }
 
   @Test
-  public void valid_composeStreamCallableMethod_clientStream() {
+  void valid_composeStreamCallableMethod_clientStream() {
     Descriptors.FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -716,7 +716,7 @@ public class ServiceClientCallableMethodSampleComposerTest {
   }
 
   @Test
-  public void invalid_composeStreamCallableMethod_clientStreamNotExistRequest() {
+  void invalid_composeStreamCallableMethod_clientStreamNotExistRequest() {
     Descriptors.FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -765,7 +765,7 @@ public class ServiceClientCallableMethodSampleComposerTest {
 
   /*Testing composeRegularCallableMethod*/
   @Test
-  public void valid_composeRegularCallableMethod_unaryRpc() {
+  void valid_composeRegularCallableMethod_unaryRpc() {
     Descriptors.FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -824,7 +824,7 @@ public class ServiceClientCallableMethodSampleComposerTest {
   }
 
   @Test
-  public void valid_composeRegularCallableMethod_lroRpc() {
+  void valid_composeRegularCallableMethod_lroRpc() {
     Descriptors.FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -894,7 +894,7 @@ public class ServiceClientCallableMethodSampleComposerTest {
   }
 
   @Test
-  public void valid_composeRegularCallableMethod_lroRpcWithReturnVoid() {
+  void valid_composeRegularCallableMethod_lroRpcWithReturnVoid() {
     Descriptors.FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -961,7 +961,7 @@ public class ServiceClientCallableMethodSampleComposerTest {
   }
 
   @Test
-  public void valid_composeRegularCallableMethod_pageRpc() {
+  void valid_composeRegularCallableMethod_pageRpc() {
     Descriptors.FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -1032,7 +1032,7 @@ public class ServiceClientCallableMethodSampleComposerTest {
   }
 
   @Test
-  public void invalid_composeRegularCallableMethod_noExistMethodRequest() {
+  void invalid_composeRegularCallableMethod_noExistMethodRequest() {
     Descriptors.FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -1075,7 +1075,7 @@ public class ServiceClientCallableMethodSampleComposerTest {
   }
 
   @Test
-  public void invalid_composeRegularCallableMethod_noExistMethodResponsePagedRpc() {
+  void invalid_composeRegularCallableMethod_noExistMethodResponsePagedRpc() {
     Descriptors.FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -1123,7 +1123,7 @@ public class ServiceClientCallableMethodSampleComposerTest {
   }
 
   @Test
-  public void invalid_composeRegularCallableMethod_noRepeatedResponsePagedRpc() {
+  void invalid_composeRegularCallableMethod_noRepeatedResponsePagedRpc() {
     Descriptors.FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientHeaderSampleComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientHeaderSampleComposerTest.java
@@ -38,9 +38,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ServiceClientHeaderSampleComposerTest {
+class ServiceClientHeaderSampleComposerTest {
   private static final String SHOWCASE_PACKAGE_NAME = "com.google.showcase.v1beta1";
   private static final String LRO_PACKAGE_NAME = "com.google.longrunning";
   private static final String PROTO_PACKAGE_NAME = "com.google.protobuf";
@@ -58,7 +58,7 @@ public class ServiceClientHeaderSampleComposerTest {
 
   /*Testing composeClassHeaderSample*/
   @Test
-  public void composeClassHeaderSample_unaryRpc() {
+  void composeClassHeaderSample_unaryRpc() {
     Descriptors.FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -86,7 +86,7 @@ public class ServiceClientHeaderSampleComposerTest {
   }
 
   @Test
-  public void composeClassHeaderSample_firstMethodIsNotUnaryRpc() {
+  void composeClassHeaderSample_firstMethodIsNotUnaryRpc() {
     Descriptors.FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -170,7 +170,7 @@ public class ServiceClientHeaderSampleComposerTest {
   }
 
   @Test
-  public void composeClassHeaderSample_firstMethodHasNoSignatures() {
+  void composeClassHeaderSample_firstMethodHasNoSignatures() {
     Descriptors.FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -232,7 +232,7 @@ public class ServiceClientHeaderSampleComposerTest {
   }
 
   @Test
-  public void composeClassHeaderSample_firstMethodIsStream() {
+  void composeClassHeaderSample_firstMethodIsStream() {
     Descriptors.FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -291,7 +291,7 @@ public class ServiceClientHeaderSampleComposerTest {
 
   /*Testing composeSetCredentialsSample*/
   @Test
-  public void composeSetCredentialsSample() {
+  void composeSetCredentialsSample() {
     TypeNode clientType =
         TypeNode.withReference(
             VaporReference.builder()
@@ -320,7 +320,7 @@ public class ServiceClientHeaderSampleComposerTest {
 
   /*Testing composeSetEndpointSample*/
   @Test
-  public void composeSetEndpointSample() {
+  void composeSetEndpointSample() {
     TypeNode clientType =
         TypeNode.withReference(
             VaporReference.builder()
@@ -347,7 +347,7 @@ public class ServiceClientHeaderSampleComposerTest {
 
   /*Testing composeShowcaseMethodSample*/
   @Test
-  public void valid_composeShowcaseMethodSample_pagedRpcWithMultipleMethodArguments() {
+  void valid_composeShowcaseMethodSample_pagedRpcWithMultipleMethodArguments() {
     Descriptors.FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -455,7 +455,7 @@ public class ServiceClientHeaderSampleComposerTest {
   }
 
   @Test
-  public void valid_composeShowcaseMethodSample_pagedRpcWithNoMethodArguments() {
+  void valid_composeShowcaseMethodSample_pagedRpcWithNoMethodArguments() {
     Descriptors.FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -537,7 +537,7 @@ public class ServiceClientHeaderSampleComposerTest {
   }
 
   @Test
-  public void invalid_composeShowcaseMethodSample_noMatchedRepeatedResponseTypeInPagedMethod() {
+  void invalid_composeShowcaseMethodSample_noMatchedRepeatedResponseTypeInPagedMethod() {
     Descriptors.FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -587,7 +587,7 @@ public class ServiceClientHeaderSampleComposerTest {
   }
 
   @Test
-  public void invalid_composeShowcaseMethodSample_noRepeatedResponseTypeInPagedMethod() {
+  void invalid_composeShowcaseMethodSample_noRepeatedResponseTypeInPagedMethod() {
     Descriptors.FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -659,7 +659,7 @@ public class ServiceClientHeaderSampleComposerTest {
   }
 
   @Test
-  public void valid_composeShowcaseMethodSample_lroUnaryRpcWithNoMethodArgument() {
+  void valid_composeShowcaseMethodSample_lroUnaryRpcWithNoMethodArgument() {
     Descriptors.FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -727,7 +727,7 @@ public class ServiceClientHeaderSampleComposerTest {
   }
 
   @Test
-  public void valid_composeShowcaseMethodSample_lroRpcWithReturnResponseType() {
+  void valid_composeShowcaseMethodSample_lroRpcWithReturnResponseType() {
     Descriptors.FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -813,7 +813,7 @@ public class ServiceClientHeaderSampleComposerTest {
   }
 
   @Test
-  public void valid_composeShowcaseMethodSample_lroRpcWithReturnVoid() {
+  void valid_composeShowcaseMethodSample_lroRpcWithReturnVoid() {
     Descriptors.FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientMethodSampleComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientMethodSampleComposerTest.java
@@ -30,16 +30,16 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ServiceClientMethodSampleComposerTest {
+class ServiceClientMethodSampleComposerTest {
   private static final String SHOWCASE_PACKAGE_NAME = "com.google.showcase.v1beta1";
   private static final String LRO_PACKAGE_NAME = "com.google.longrunning";
   private static final String PROTO_PACKAGE_NAME = "com.google.protobuf";
   private static final String PAGINATED_FIELD_NAME = "page_size";
 
   @Test
-  public void valid_composeDefaultSample_isPagedMethod() {
+  void valid_composeDefaultSample_isPagedMethod() {
     FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -101,7 +101,7 @@ public class ServiceClientMethodSampleComposerTest {
   }
 
   @Test
-  public void invalid_composeDefaultSample_isPagedMethod() {
+  void invalid_composeDefaultSample_isPagedMethod() {
     FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -150,7 +150,7 @@ public class ServiceClientMethodSampleComposerTest {
   }
 
   @Test
-  public void valid_composeDefaultSample_hasLroMethodWithReturnResponse() {
+  void valid_composeDefaultSample_hasLroMethodWithReturnResponse() {
     FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -216,7 +216,7 @@ public class ServiceClientMethodSampleComposerTest {
   }
 
   @Test
-  public void valid_composeDefaultSample_hasLroMethodWithReturnVoid() {
+  void valid_composeDefaultSample_hasLroMethodWithReturnVoid() {
     FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -285,7 +285,7 @@ public class ServiceClientMethodSampleComposerTest {
   }
 
   @Test
-  public void valid_composeDefaultSample_pureUnaryReturnVoid() {
+  void valid_composeDefaultSample_pureUnaryReturnVoid() {
     FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -344,7 +344,7 @@ public class ServiceClientMethodSampleComposerTest {
   }
 
   @Test
-  public void valid_composeDefaultSample_pureUnaryReturnResponse() {
+  void valid_composeDefaultSample_pureUnaryReturnResponse() {
     FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/samplecode/SettingsSampleComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/samplecode/SettingsSampleComposerTest.java
@@ -21,11 +21,11 @@ import com.google.api.generator.engine.ast.VaporReference;
 import com.google.api.generator.gapic.model.Sample;
 import com.google.api.generator.test.utils.LineFormatter;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class SettingsSampleComposerTest {
+class SettingsSampleComposerTest {
   @Test
-  public void composeSettingsSample_noMethods() {
+  void composeSettingsSample_noMethods() {
     TypeNode classType =
         TypeNode.withReference(
             VaporReference.builder()
@@ -40,7 +40,7 @@ public class SettingsSampleComposerTest {
   }
 
   @Test
-  public void composeSettingsSample_serviceSettingsClass() {
+  void composeSettingsSample_serviceSettingsClass() {
     TypeNode classType =
         TypeNode.withReference(
             VaporReference.builder()
@@ -68,7 +68,7 @@ public class SettingsSampleComposerTest {
   }
 
   @Test
-  public void composeSettingsSample_serviceStubClass() {
+  void composeSettingsSample_serviceStubClass() {
     TypeNode classType =
         TypeNode.withReference(
             VaporReference.builder()

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/utils/CommentFormatterTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/utils/CommentFormatterTest.java
@@ -17,13 +17,13 @@ package com.google.api.generator.gapic.composer.utils;
 import static org.junit.Assert.assertEquals;
 
 import com.google.api.generator.test.utils.LineFormatter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class CommentFormatterTest {
+class CommentFormatterTest {
   private static final String SERVICE_DESCRIPTION_HEADER_PATTERN = "Service Description: %s";
 
   @Test
-  public void parseCommentWithItemizedList_paragraphContainsList() {
+  void parseCommentWithItemizedList_paragraphContainsList() {
     String protobufComment =
         LineFormatter.lines(
             "Service Name\n\n",
@@ -43,7 +43,7 @@ public class CommentFormatterTest {
   }
 
   @Test
-  public void parseCommentWithItemizedList_paragraphStartsWithList() {
+  void parseCommentWithItemizedList_paragraphStartsWithList() {
     String protobufComment =
         LineFormatter.lines(
             "Paragraphs starting with list items should still be parsed as list:\n\n",
@@ -61,7 +61,7 @@ public class CommentFormatterTest {
   }
 
   @Test
-  public void parseCommentWithPrefixPattern_addIfStartsWithParagraph() {
+  void parseCommentWithPrefixPattern_addIfStartsWithParagraph() {
     String protobufComment =
         LineFormatter.lines(
             "Service Name\n\n",
@@ -83,7 +83,7 @@ public class CommentFormatterTest {
   }
 
   @Test
-  public void parseCommentWithPrefixPattern_ignoreIfStartsWithList() {
+  void parseCommentWithPrefixPattern_ignoreIfStartsWithList() {
     String protobufComment = LineFormatter.lines(" * This is item one\n", " * This is item two");
     String result =
         CommentFormatter.formatAsJavaDocComment(

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/utils/PackageCheckerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/utils/PackageCheckerTest.java
@@ -17,11 +17,11 @@ package com.google.api.generator.gapic.composer.utils;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class PackageCheckerTest {
+class PackageCheckerTest {
   @Test
-  public void isGaApi_gaVersionPresent() {
+  void isGaApi_gaVersionPresent() {
     assertTrue(PackageChecker.isGaApi("com.google.cloud.dataproc.v1.services"));
     assertTrue(PackageChecker.isGaApi("com.google.cloud.v1.foobar.services"));
     assertTrue(PackageChecker.isGaApi("com.google.cloud.dataproc.v1"));
@@ -34,7 +34,7 @@ public class PackageCheckerTest {
   }
 
   @Test
-  public void isGaApi_alphaBetaVersionPresent() {
+  void isGaApi_alphaBetaVersionPresent() {
     assertFalse(PackageChecker.isGaApi("com.google.cloud.dataproc.v1beta1"));
     assertFalse(PackageChecker.isGaApi("com.google.cloud.dataproc.v1alpha1"));
     assertFalse(PackageChecker.isGaApi("com.google.cloud.dataproc.v1beta"));

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/model/FieldTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/model/FieldTest.java
@@ -18,12 +18,12 @@ import static org.junit.Assert.assertEquals;
 
 import com.google.api.FieldInfo.Format;
 import com.google.api.generator.engine.ast.TypeNode;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class FieldTest {
+class FieldTest {
 
   @Test
-  public void shouldAutoPopulate() {
+  void shouldAutoPopulate() {
     Field FIELD =
         Field.builder()
             .setName("SampleField")
@@ -36,7 +36,7 @@ public class FieldTest {
   }
 
   @Test
-  public void isRequired_shouldNotAutoPopulate() {
+  void isRequired_shouldNotAutoPopulate() {
     Field FIELD =
         Field.builder()
             .setName("SampleField")
@@ -49,7 +49,7 @@ public class FieldTest {
   }
 
   @Test
-  public void fieldInfoFormatNotUUID4_shouldNotAutoPopulate() {
+  void fieldInfoFormatNotUUID4_shouldNotAutoPopulate() {
     Field FIELD =
         Field.builder()
             .setName("SampleField")
@@ -62,7 +62,7 @@ public class FieldTest {
   }
 
   @Test
-  public void typeNotString_shouldNotAutoPopulate() {
+  void typeNotString_shouldNotAutoPopulate() {
     Field FIELD =
         Field.builder()
             .setName("SampleField")

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/model/GapicServiceConfigTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/model/GapicServiceConfigTest.java
@@ -34,15 +34,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class GapicServiceConfigTest {
+class GapicServiceConfigTest {
 
   private static final double EPSILON = 1e-4;
   private static final String TESTDATA_DIRECTORY = "src/test/resources/";
 
   @Test
-  public void serviceConfig_noConfigsFound() {
+  void serviceConfig_noConfigsFound() {
     FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Service service = parseService(echoFileDescriptor);
 
@@ -70,7 +70,7 @@ public class GapicServiceConfigTest {
   }
 
   @Test
-  public void serviceConfig_basic() {
+  void serviceConfig_basic() {
     FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Service service = parseService(echoFileDescriptor);
 
@@ -124,7 +124,7 @@ public class GapicServiceConfigTest {
   }
 
   @Test
-  public void serviceConfig_withBatchingSettings() {
+  void serviceConfig_withBatchingSettings() {
     FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Service service = parseService(echoFileDescriptor);
 
@@ -197,7 +197,7 @@ public class GapicServiceConfigTest {
   }
 
   @Test
-  public void serviceConfig_withLroRetrySettings() {
+  void serviceConfig_withLroRetrySettings() {
     FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Service service = parseService(echoFileDescriptor);
 

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/model/HttpBindingsTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/model/HttpBindingsTest.java
@@ -17,28 +17,28 @@ package com.google.api.generator.gapic.model;
 import com.google.api.generator.engine.ast.TypeNode;
 import com.google.api.generator.gapic.model.HttpBindings.HttpBinding;
 import com.google.common.truth.Truth;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class HttpBindingsTest {
+class HttpBindingsTest {
 
-  public Field.Builder fieldBuilder;
-  public HttpBinding.Builder httpBindingBuilder;
+  private Field.Builder fieldBuilder;
+  private HttpBinding.Builder httpBindingBuilder;
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeEach
+  void setUp() throws Exception {
     fieldBuilder = Field.builder().setName("doesNotMatter").setType(TypeNode.OBJECT);
     httpBindingBuilder = HttpBinding.builder().setName("doesNotMatter");
   }
 
   @Test
-  public void isOptional_shouldReturnFalseIfFieldIsNull() {
+  void isOptional_shouldReturnFalseIfFieldIsNull() {
     HttpBinding httpBinding = httpBindingBuilder.build();
     Truth.assertThat(httpBinding.isOptional()).isFalse();
   }
 
   @Test
-  public void isOptional_shouldReturnFalseIfFieldExistsAndIsOptionalIsFalse() {
+  void isOptional_shouldReturnFalseIfFieldExistsAndIsOptionalIsFalse() {
     HttpBinding httpBinding =
         httpBindingBuilder.setField(fieldBuilder.setIsProto3Optional(false).build()).build();
 
@@ -46,7 +46,7 @@ public class HttpBindingsTest {
   }
 
   @Test
-  public void isOptional_shouldReturnTrueIfFieldExistsAndIsOptionalIsTue() {
+  void isOptional_shouldReturnTrueIfFieldExistsAndIsOptionalIsTue() {
     HttpBinding httpBinding =
         httpBindingBuilder.setField(fieldBuilder.setIsProto3Optional(true).build()).build();
 
@@ -54,13 +54,13 @@ public class HttpBindingsTest {
   }
 
   @Test
-  public void isRepeated_shouldReturnFalseIfFieldIsNull() {
+  void isRepeated_shouldReturnFalseIfFieldIsNull() {
     HttpBinding httpBinding = httpBindingBuilder.build();
     Truth.assertThat(httpBinding.isRepeated()).isFalse();
   }
 
   @Test
-  public void isRepeated_shouldReturnFalseIfFieldExistsAndIsRepeatedIsFalse() {
+  void isRepeated_shouldReturnFalseIfFieldExistsAndIsRepeatedIsFalse() {
     HttpBinding httpBinding =
         httpBindingBuilder.setField(fieldBuilder.setIsRepeated(false).build()).build();
 
@@ -68,7 +68,7 @@ public class HttpBindingsTest {
   }
 
   @Test
-  public void isRepeated_shouldReturnTrueIfFieldExistsAndIsRepeatedIsTue() {
+  void isRepeated_shouldReturnTrueIfFieldExistsAndIsRepeatedIsTue() {
     HttpBinding httpBinding =
         httpBindingBuilder.setField(fieldBuilder.setIsRepeated(true).build()).build();
 
@@ -76,13 +76,13 @@ public class HttpBindingsTest {
   }
 
   @Test
-  public void isEnum_shouldReturnFalseIfFieldIsNull() {
+  void isEnum_shouldReturnFalseIfFieldIsNull() {
     HttpBinding httpBinding = httpBindingBuilder.build();
     Truth.assertThat(httpBinding.isEnum()).isFalse();
   }
 
   @Test
-  public void isEnum_shouldReturnFalseIfFieldExistsAndIsEnumIsFalse() {
+  void isEnum_shouldReturnFalseIfFieldExistsAndIsEnumIsFalse() {
     HttpBinding httpBinding =
         httpBindingBuilder.setField(fieldBuilder.setIsEnum(false).build()).build();
 
@@ -90,7 +90,7 @@ public class HttpBindingsTest {
   }
 
   @Test
-  public void isEnum_shouldReturnTrueIfFieldExistsAndIsEnumIsTue() {
+  void isEnum_shouldReturnTrueIfFieldExistsAndIsEnumIsTue() {
     HttpBinding httpBinding =
         httpBindingBuilder.setField(fieldBuilder.setIsEnum(true).build()).build();
 

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/model/MessageTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/model/MessageTest.java
@@ -21,14 +21,14 @@ import com.google.api.generator.engine.ast.TypeNode;
 import com.google.api.generator.engine.ast.VaporReference;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class MessageTest {
+class MessageTest {
 
   private static final String SUB_FIELD_NAME = "table";
   private static final String LEAF_FIELD_NAME = "size";
   private static final String SUB_FIELD_TYPE = "TableFieldType";
-  public static final VaporReference FIELD_TYPE =
+  private static final VaporReference FIELD_TYPE =
       VaporReference.builder().setPakkage("com.google").setName(SUB_FIELD_TYPE).build();
   private static final String MESSAGE_NAME = "TestMessage";
   private static final Message.Builder testMessageBuilder =
@@ -38,7 +38,7 @@ public class MessageTest {
           .setType(TypeNode.OBJECT);
 
   @Test
-  public void validateField_shouldThrowExceptionIfFieldNameIsEmpty() {
+  void validateField_shouldThrowExceptionIfFieldNameIsEmpty() {
     Message message = testMessageBuilder.build();
     IllegalStateException illegalStateException =
         assertThrows(
@@ -50,7 +50,7 @@ public class MessageTest {
   }
 
   @Test
-  public void validateField_shouldThrowExceptionIfFieldDoesNotExist() {
+  void validateField_shouldThrowExceptionIfFieldDoesNotExist() {
     Message message = testMessageBuilder.build();
     String fieldName = "doesNotExist";
     NullPointerException nullPointerException =
@@ -65,7 +65,7 @@ public class MessageTest {
   }
 
   @Test
-  public void validateField_shouldThrowExceptionIfMessageDoesNotExist() {
+  void validateField_shouldThrowExceptionIfMessageDoesNotExist() {
     Field subField =
         Field.builder()
             .setName(SUB_FIELD_NAME)
@@ -92,7 +92,7 @@ public class MessageTest {
   }
 
   @Test
-  public void validateField_shouldThrowExceptionIfFieldIsRepeated() {
+  void validateField_shouldThrowExceptionIfFieldIsRepeated() {
     Field leafField =
         Field.builder()
             .setType(TypeNode.STRING)
@@ -103,7 +103,7 @@ public class MessageTest {
   }
 
   @Test
-  public void validateField_shouldThrowExceptionIfFieldIsOfWrongType() {
+  void validateField_shouldThrowExceptionIfFieldIsOfWrongType() {
     Field leafField = Field.builder().setType(TypeNode.BOOLEAN).setName(LEAF_FIELD_NAME).build();
     testLeafField(leafField);
   }
@@ -126,7 +126,7 @@ public class MessageTest {
   }
 
   @Test
-  public void validateField_shouldNotThrowExceptionIfFieldExist() {
+  void validateField_shouldNotThrowExceptionIfFieldExist() {
     Field leafField = Field.builder().setType(TypeNode.STRING).setName(LEAF_FIELD_NAME).build();
     Message subMessage = createSubMessage(leafField);
     Map<String, Message> messageTypes = ImmutableMap.of(FIELD_TYPE.fullName(), subMessage);

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/model/MethodArgumentTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/model/MethodArgumentTest.java
@@ -19,11 +19,11 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.api.generator.engine.ast.TypeNode;
 import java.util.function.BiFunction;
 import java.util.function.Function;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class MethodArgumentTest {
+class MethodArgumentTest {
   @Test
-  public void compareMethodArguments() {
+  void compareMethodArguments() {
     BiFunction<String, TypeNode, MethodArgument> methodArgFn =
         (name, type) ->
             MethodArgument.builder()

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/model/MethodTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/model/MethodTest.java
@@ -27,9 +27,9 @@ import com.google.common.collect.ImmutableSet;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class MethodTest {
+class MethodTest {
 
   private static final Method METHOD =
       Method.builder()
@@ -47,7 +47,7 @@ public class MethodTest {
           .build();
 
   @Test
-  public void toStream() {
+  void toStream() {
     // Argument order: isClientStreaming, isServerStreaming.
     assertThat(Method.toStream(false, false)).isEqualTo(Method.Stream.NONE);
     assertThat(Method.toStream(true, false)).isEqualTo(Method.Stream.CLIENT);
@@ -56,19 +56,19 @@ public class MethodTest {
   }
 
   @Test
-  public void hasRoutingHeaders_shouldReturnFalseIfRoutingHeadersIsNull() {
+  void hasRoutingHeaders_shouldReturnFalseIfRoutingHeadersIsNull() {
     assertThat(METHOD.hasRoutingHeaderParams()).isFalse();
   }
 
   @Test
-  public void hasRoutingHeaders_shouldReturnFalseIfRoutingHeadersIsEmpty() {
+  void hasRoutingHeaders_shouldReturnFalseIfRoutingHeadersIsEmpty() {
     Method method =
         METHOD.toBuilder().setRoutingHeaderRule(RoutingHeaderRule.builder().build()).build();
     assertThat(method.hasRoutingHeaderParams()).isFalse();
   }
 
   @Test
-  public void hasRoutingHeaders_shouldReturnTrueIfRoutingHeadersIsNotEmpty() {
+  void hasRoutingHeaders_shouldReturnTrueIfRoutingHeadersIsNotEmpty() {
     Method method =
         METHOD
             .toBuilder()
@@ -81,7 +81,7 @@ public class MethodTest {
   }
 
   @Test
-  public void shouldSetParamsExtractor_shouldReturnTrueIfHasRoutingHeaders() {
+  void shouldSetParamsExtractor_shouldReturnTrueIfHasRoutingHeaders() {
     Method method =
         METHOD
             .toBuilder()
@@ -94,15 +94,14 @@ public class MethodTest {
   }
 
   @Test
-  public void shouldSetParamsExtractor_shouldReturnTrueIfHasHttpBindingsAndRoutingHeadersIsNull() {
+  void shouldSetParamsExtractor_shouldReturnTrueIfHasHttpBindingsAndRoutingHeadersIsNull() {
     Method method =
         METHOD.toBuilder().setHttpBindings(HTTP_BINDINGS).setRoutingHeaderRule(null).build();
     assertThat(method.shouldSetParamsExtractor()).isTrue();
   }
 
   @Test
-  public void
-      shouldSetParamsExtractor_shouldReturnFalseIfHasHttpBindingsAndRoutingHeadersIsEmpty() {
+  void shouldSetParamsExtractor_shouldReturnFalseIfHasHttpBindingsAndRoutingHeadersIsEmpty() {
     Method method =
         METHOD
             .toBuilder()
@@ -113,13 +112,13 @@ public class MethodTest {
   }
 
   @Test
-  public void shouldSetParamsExtractor_shouldReturnFalseIfHasNoHttpBindingsAndNoRoutingHeaders() {
+  void shouldSetParamsExtractor_shouldReturnFalseIfHasNoHttpBindingsAndNoRoutingHeaders() {
     Method method = METHOD.toBuilder().setHttpBindings(null).setRoutingHeaderRule(null).build();
     assertThat(method.shouldSetParamsExtractor()).isFalse();
   }
 
   @Test
-  public void hasAutoPopulatedFields_shouldReturnTrueIfMethodIsUnary() {
+  void hasAutoPopulatedFields_shouldReturnTrueIfMethodIsUnary() {
     List<String> autoPopulatedFields = Arrays.asList("field1", "field2");
     Method method = METHOD.toBuilder().setAutoPopulatedFields(autoPopulatedFields).build();
     method.toStream(false, false);
@@ -127,7 +126,7 @@ public class MethodTest {
   }
 
   @Test
-  public void hasAutoPopulatedFields_shouldReturnFalseIfMethodIsStreaming() {
+  void hasAutoPopulatedFields_shouldReturnFalseIfMethodIsStreaming() {
     List<String> autoPopulatedFields = Arrays.asList("field1", "field2");
     Method method =
         METHOD
@@ -155,7 +154,7 @@ public class MethodTest {
   }
 
   @Test
-  public void hasAutoPopulatedFields_shouldReturnFalseIfAutoPopulatedFieldsIsEmpty() {
+  void hasAutoPopulatedFields_shouldReturnFalseIfAutoPopulatedFieldsIsEmpty() {
     List<String> autoPopulatedFields = new ArrayList<>();
     Method method =
         METHOD
@@ -168,8 +167,7 @@ public class MethodTest {
   }
 
   @Test
-  public void
-      isSupportedByTransport_shouldReturnTrueIfHasHttpBindingsAndIsRESTEligibleForRESTTransport() {
+  void isSupportedByTransport_shouldReturnTrueIfHasHttpBindingsAndIsRESTEligibleForRESTTransport() {
     Method methodNoStreaming =
         METHOD.toBuilder().setHttpBindings(HTTP_BINDINGS).setStream(Method.Stream.NONE).build();
     assertThat(methodNoStreaming.isSupportedByTransport(Transport.REST)).isTrue();
@@ -179,7 +177,7 @@ public class MethodTest {
   }
 
   @Test
-  public void isSupportedByTransport_shouldReturnFalseIfNoHttpBindingsForRESTTransport() {
+  void isSupportedByTransport_shouldReturnFalseIfNoHttpBindingsForRESTTransport() {
     Method methodNoStreaming =
         METHOD.toBuilder().setHttpBindings(null).setStream(Method.Stream.NONE).build();
     assertThat(methodNoStreaming.isSupportedByTransport(Transport.REST)).isFalse();
@@ -189,7 +187,7 @@ public class MethodTest {
   }
 
   @Test
-  public void
+  void
       isSupportedByTransport_shouldReturnFalseIfHasHttpBindingsAndIsNotRESTEligibleForRESTTransport() {
     Method methodClientSideStreaming =
         METHOD.toBuilder().setHttpBindings(HTTP_BINDINGS).setStream(Method.Stream.CLIENT).build();
@@ -200,7 +198,7 @@ public class MethodTest {
   }
 
   @Test
-  public void isSupportedByTransport_shouldReturnTrueForGRPCTransport() {
+  void isSupportedByTransport_shouldReturnTrueForGRPCTransport() {
     Method methodNoStreaming =
         METHOD.toBuilder().setHttpBindings(HTTP_BINDINGS).setStream(Method.Stream.NONE).build();
     assertThat(methodNoStreaming.isSupportedByTransport(Transport.GRPC)).isTrue();
@@ -216,7 +214,7 @@ public class MethodTest {
   }
 
   @Test
-  public void isSupportedByTransport_shouldThrowExceptionIfPassedGRPCRESTTransport() {
+  void isSupportedByTransport_shouldThrowExceptionIfPassedGRPCRESTTransport() {
     Method methodClientStreaming =
         METHOD.toBuilder().setHttpBindings(HTTP_BINDINGS).setStream(Method.Stream.CLIENT).build();
     assertThrows(

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/model/RegionTagTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/model/RegionTagTest.java
@@ -18,9 +18,9 @@ import com.google.api.generator.gapic.composer.samplecode.SampleCodeWriter;
 import com.google.api.generator.test.utils.LineFormatter;
 import java.util.Arrays;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class RegionTagTest {
+class RegionTagTest {
   private final String serviceName = "serviceName";
   private final String apiVersion = "v1";
   private final String apiShortName = "shortName";
@@ -28,7 +28,7 @@ public class RegionTagTest {
   private final String disambiguation = "disambiguation";
 
   @Test
-  public void regionTagNoRpcName() {
+  void regionTagNoRpcName() {
     Assert.assertThrows(
         IllegalStateException.class,
         () ->
@@ -42,7 +42,7 @@ public class RegionTagTest {
   }
 
   @Test
-  public void regionTagNoServiceName() {
+  void regionTagNoServiceName() {
     Assert.assertThrows(
         IllegalStateException.class,
         () ->
@@ -56,7 +56,7 @@ public class RegionTagTest {
   }
 
   @Test
-  public void regionTagValidMissingFields() {
+  void regionTagValidMissingFields() {
     RegionTag regionTag =
         RegionTag.builder().setServiceName(serviceName).setRpcName(rpcName).build();
 
@@ -67,7 +67,7 @@ public class RegionTagTest {
   }
 
   @Test
-  public void regionTagSanitizeAttributes() {
+  void regionTagSanitizeAttributes() {
     String apiVersion = "1.4.0-<version!>";
     String serviceName = "service_Na@m*.e!<String>{}";
     String rpcName = "rpc _Nam^#,e   [String]10";
@@ -84,7 +84,7 @@ public class RegionTagTest {
   }
 
   @Test
-  public void generateRegionTagsMissingRequiredFields() {
+  void generateRegionTagsMissingRequiredFields() {
     RegionTag rtMissingShortName =
         RegionTag.builder()
             .setApiVersion(apiVersion)
@@ -95,7 +95,7 @@ public class RegionTagTest {
   }
 
   @Test
-  public void generateRegionTagsValidMissingFields() {
+  void generateRegionTagsValidMissingFields() {
     RegionTag regionTag =
         RegionTag.builder()
             .setApiShortName(apiShortName)
@@ -109,7 +109,7 @@ public class RegionTagTest {
   }
 
   @Test
-  public void generateRegionTagsAllFields() {
+  void generateRegionTagsAllFields() {
     RegionTag regionTag =
         RegionTag.builder()
             .setApiShortName(apiShortName)
@@ -126,7 +126,7 @@ public class RegionTagTest {
   }
 
   @Test
-  public void generateRegionTagTag() {
+  void generateRegionTagTag() {
     RegionTag regionTag =
         RegionTag.builder()
             .setApiShortName(apiShortName)

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/model/ResourceNameTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/model/ResourceNameTest.java
@@ -18,9 +18,9 @@ import com.google.api.generator.gapic.model.HttpBindings.HttpVerb;
 import com.google.common.truth.Truth;
 import java.util.Arrays;
 import java.util.Collections;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ResourceNameTest {
+class ResourceNameTest {
   private final ResourceName resName =
       ResourceName.builder()
           .setVariableName("topic")
@@ -31,7 +31,7 @@ public class ResourceNameTest {
           .build();
 
   @Test
-  public void getMatchingPattern() {
+  void getMatchingPattern() {
     HttpBindings bindings =
         HttpBindings.builder()
             .setHttpVerb(HttpVerb.PUT)
@@ -45,7 +45,7 @@ public class ResourceNameTest {
   }
 
   @Test
-  public void getMatchingPatternFromAdditionalPattern() {
+  void getMatchingPatternFromAdditionalPattern() {
     HttpBindings bindings =
         HttpBindings.builder()
             .setHttpVerb(HttpVerb.PUT)
@@ -59,7 +59,7 @@ public class ResourceNameTest {
   }
 
   @Test
-  public void getMatchingPatternNoMatch() {
+  void getMatchingPatternNoMatch() {
     HttpBindings bindings =
         HttpBindings.builder()
             .setHttpVerb(HttpVerb.PUT)

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/model/RoutingHeaderParamTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/model/RoutingHeaderParamTest.java
@@ -18,12 +18,12 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.api.generator.gapic.model.RoutingHeaderRule.RoutingHeaderParam;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class RoutingHeaderParamTest {
+class RoutingHeaderParamTest {
 
   @Test
-  public void getDescendantFieldNames_shouldSplitFieldNameByDot() {
+  void getDescendantFieldNames_shouldSplitFieldNameByDot() {
     RoutingHeaderParam routingHeaderParam =
         RoutingHeaderParam.create("table.name", "name", "/abc/dec");
     List<String> descendantFieldNames = routingHeaderParam.getDescendantFieldNames();

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/model/SampleTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/model/SampleTest.java
@@ -22,9 +22,9 @@ import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class SampleTest {
+class SampleTest {
   private final RegionTag regionTag =
       RegionTag.builder().setServiceName("serviceName").setRpcName("rpcName").build();
   private final List<Statement> sampleBody =
@@ -33,14 +33,14 @@ public class SampleTest {
       Arrays.asList(CommentStatement.withComment(BlockComment.withComment("apache license")));
 
   @Test
-  public void sampleNoRegionTag() {
+  void sampleNoRegionTag() {
     Assert.assertThrows(
         IllegalStateException.class,
         () -> Sample.builder().setBody(sampleBody).setFileHeader(header).build());
   }
 
   @Test
-  public void sampleValidMissingFields() {
+  void sampleValidMissingFields() {
     Sample sample = Sample.builder().setRegionTag(regionTag).build();
 
     Assert.assertEquals(ImmutableList.of(), sample.fileHeader());
@@ -50,7 +50,7 @@ public class SampleTest {
   }
 
   @Test
-  public void sampleWithHeader() {
+  void sampleWithHeader() {
     Sample sample = Sample.builder().setRegionTag(regionTag).setBody(sampleBody).build();
     Assert.assertEquals(ImmutableList.of(), sample.fileHeader());
 
@@ -59,7 +59,7 @@ public class SampleTest {
   }
 
   @Test
-  public void sampleNameWithRegionTag() {
+  void sampleNameWithRegionTag() {
     Sample sample = Sample.builder().setRegionTag(regionTag).build();
     Assert.assertEquals("SyncRpcName", sample.name());
 
@@ -73,7 +73,7 @@ public class SampleTest {
   }
 
   @Test
-  public void sampleNameWithRegionTagCanonical() {
+  void sampleNameWithRegionTagCanonical() {
     String disambig = "Disambiguation";
     Sample sample =
         Sample.builder().setRegionTag(regionTag.withOverloadDisambiguation(disambig)).build();
@@ -86,7 +86,7 @@ public class SampleTest {
   }
 
   @Test
-  public void sampleCanonicalOverload() {
+  void sampleCanonicalOverload() {
     String disambig = "Disambiguation";
     Sample sample =
         Sample.builder().setRegionTag(regionTag.withOverloadDisambiguation(disambig)).build();

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/model/ServiceTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/model/ServiceTest.java
@@ -18,16 +18,17 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import com.google.api.generator.engine.ast.TypeNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.util.Arrays;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class ServiceTest {
+class ServiceTest {
   private static final String SHOWCASE_PACKAGE_NAME = "com.google.showcase.v1beta1";
   private Service.Builder testServiceBuilder;
 
@@ -46,8 +47,8 @@ public class ServiceTest {
           .setIsAsteriskBody(false)
           .setHttpVerb(HttpBindings.HttpVerb.GET);
 
-  @Before
-  public void init() {
+  @BeforeEach
+  void init() {
     testServiceBuilder =
         Service.builder()
             .setName("Echo")
@@ -60,49 +61,49 @@ public class ServiceTest {
   }
 
   @Test
-  public void apiShortName_shouldReturnApiShortNameIfHostContainsRegionalEndpoint() {
+  void apiShortName_shouldReturnApiShortNameIfHostContainsRegionalEndpoint() {
     String defaultHost = "us-east1-pubsub.googleapis.com";
     Service testService = testServiceBuilder.setDefaultHost(defaultHost).build();
     assertEquals("pubsub", testService.apiShortName());
   }
 
   @Test
-  public void apiShortName_shouldReturnApiShortName() {
+  void apiShortName_shouldReturnApiShortName() {
     String defaultHost = "logging.googleapis.com";
     Service testService = testServiceBuilder.setDefaultHost(defaultHost).build();
     assertEquals("logging", testService.apiShortName());
   }
 
   @Test
-  public void apiShortName_shouldReturnApiShortNameForIam() {
+  void apiShortName_shouldReturnApiShortNameForIam() {
     String defaultHost = "iam-meta-api.googleapis.com";
     Service testService = testServiceBuilder.setDefaultHost(defaultHost).build();
     assertEquals("iam", testService.apiShortName());
   }
 
   @Test
-  public void apiShortName_shouldReturnHostIfNoPeriods() {
+  void apiShortName_shouldReturnHostIfNoPeriods() {
     String defaultHost = "logging:7469";
     Service testService = testServiceBuilder.setDefaultHost(defaultHost).build();
     assertEquals("logging:7469", testService.apiShortName());
   }
 
   @Test
-  public void packageVersion_shouldReturnVersionIfMatch() {
+  void packageVersion_shouldReturnVersionIfMatch() {
     String protoPackage = "com.google.showcase.v1";
     Service testService = testServiceBuilder.setProtoPakkage(protoPackage).build();
     assertEquals("v1", testService.packageVersion());
   }
 
   @Test
-  public void packageVersion_shouldReturnEmptyIfNoMatch() {
+  void packageVersion_shouldReturnEmptyIfNoMatch() {
     String protoPackage = "com.google.showcase";
     Service testService = testServiceBuilder.setProtoPakkage(protoPackage).build();
     assertEquals("", testService.packageVersion());
   }
 
   @Test
-  public void apiVersion_shouldReturnApiVersion() {
+  void apiVersion_shouldReturnApiVersion() {
     String apiVersion = "v1_20230601";
     Service testService = testServiceBuilder.setApiVersion(apiVersion).build();
     assertTrue(testService.hasApiVersion());
@@ -110,14 +111,14 @@ public class ServiceTest {
   }
 
   @Test
-  public void apiVersion_shouldReturnNoApiVersionWhenNull() {
+  void apiVersion_shouldReturnNoApiVersionWhenNull() {
     Service testService = testServiceBuilder.build();
     assertNull(testService.apiVersion());
     assertFalse(testService.hasApiVersion());
   }
 
   @Test
-  public void apiVersion_shouldReturnNoApiVersionWhenEmpty() {
+  void apiVersion_shouldReturnNoApiVersionWhenEmpty() {
     String apiVersion = "";
     Service testService = testServiceBuilder.setApiVersion(apiVersion).build();
     assertEquals("", testService.apiVersion());
@@ -125,16 +126,14 @@ public class ServiceTest {
   }
 
   @Test
-  public void
-      hasAnyEnabledMethodsForTransport_shouldReturnFalseForEmptyMethodListForBothTransports() {
+  void hasAnyEnabledMethodsForTransport_shouldReturnFalseForEmptyMethodListForBothTransports() {
     Service testService = testServiceBuilder.setMethods(ImmutableList.of()).build();
     assertThat(testService.hasAnyEnabledMethodsForTransport(Transport.GRPC)).isFalse();
     assertThat(testService.hasAnyEnabledMethodsForTransport(Transport.REST)).isFalse();
   }
 
   @Test
-  public void
-      hasAnyEnabledMethodsForTransport_shouldReturnTrueForAnyNonEmptyMethodListGRPCTransport() {
+  void hasAnyEnabledMethodsForTransport_shouldReturnTrueForAnyNonEmptyMethodListGRPCTransport() {
     Method testMethod1 =
         testMethodBuilder
             .setStream(Method.Stream.NONE)
@@ -157,7 +156,7 @@ public class ServiceTest {
   }
 
   @Test
-  public void
+  void
       hasAnyEnabledMethodsForTransport_shouldReturnTrueForAnyNonEmptyAndValidMethodListRESTTransport() {
     Method testMethod1 =
         testMethodBuilder
@@ -181,7 +180,7 @@ public class ServiceTest {
   }
 
   @Test
-  public void
+  void
       hasAnyEnabledMethodsForTransport_shouldReturnFalseForAnyNonEmptyButInvalidMethodListRESTTransport() {
     Method testMethod1 =
         testMethodBuilder
@@ -204,20 +203,22 @@ public class ServiceTest {
     assertThat(testService3.hasAnyEnabledMethodsForTransport(Transport.REST)).isFalse();
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void hasAnyEnabledMethodsForTransport_shouldThrowExceptionForGRPCRESTTransport() {
+  @Test
+  void hasAnyEnabledMethodsForTransport_shouldThrowExceptionForGRPCRESTTransport() {
     Service testService = testServiceBuilder.build();
-    testService.hasAnyEnabledMethodsForTransport(Transport.GRPC_REST);
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> testService.hasAnyEnabledMethodsForTransport(Transport.GRPC_REST));
   }
 
   @Test
-  public void hostServiceName_googleApisDefaultHost() {
+  void hostServiceName_googleApisDefaultHost() {
     Service service = testServiceBuilder.setDefaultHost("test.googleapis.com").build();
     assertThat(service.hostServiceName()).isEqualTo("test");
   }
 
   @Test
-  public void hostServiceName_nonGoogleApisDefaultHost() {
+  void hostServiceName_nonGoogleApisDefaultHost() {
     // Default Host is localhost:7469
     Service service = testServiceBuilder.build();
     assertThat(service.hostServiceName()).isEqualTo("");

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/model/TransportTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/model/TransportTest.java
@@ -3,46 +3,35 @@ package com.google.api.generator.gapic.model;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
-import java.util.Arrays;
-import java.util.Collection;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
-public class TransportTest {
+class TransportTest {
 
-  private final String input;
-  private final Transport expected;
-
-  @Parameterized.Parameters
-  public static Collection<Object[]> primeNumbers() {
-    return Arrays.asList(
-        new Object[][] {
-          {"grpc", Transport.GRPC},
-          {"Grpc", Transport.GRPC},
-          {"gRPC", Transport.GRPC},
-          {"rest", Transport.REST},
-          {"REST", Transport.REST},
-          {"rESt", Transport.REST},
-          {"grpc+rest", Transport.GRPC_REST},
-          {"gRPC+REST", Transport.GRPC_REST},
-          {"grPc+rEst", Transport.GRPC_REST}
-        });
+  static Stream<Arguments> data() {
+    return Stream.of(
+        Arguments.of("grpc", Transport.GRPC),
+        Arguments.of("Grpc", Transport.GRPC),
+        Arguments.of("gRPC", Transport.GRPC),
+        Arguments.of("rest", Transport.REST),
+        Arguments.of("REST", Transport.REST),
+        Arguments.of("rESt", Transport.REST),
+        Arguments.of("grpc+rest", Transport.GRPC_REST),
+        Arguments.of("gRPC+REST", Transport.GRPC_REST),
+        Arguments.of("grPc+rEst", Transport.GRPC_REST));
   }
 
-  public TransportTest(String input, Transport expected) {
-    this.input = input;
-    this.expected = expected;
-  }
-
-  @Test
-  public void testParse_returnsValidTransport() {
+  @ParameterizedTest
+  @MethodSource("data")
+  void testParse_returnsValidTransport(String input, Transport expected) {
     assertThat(expected).isEqualTo(Transport.parse(input));
   }
 
   @Test
-  public void testParse_throwsException() {
+  void testParse_throwsException() {
     assertThrows(IllegalArgumentException.class, () -> Transport.parse("invalid transport"));
     assertThrows(IllegalArgumentException.class, () -> Transport.parse("grHttpc"));
   }

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/BatchingSettingsConfigParserTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/BatchingSettingsConfigParserTest.java
@@ -24,14 +24,14 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class BatchingSettingsConfigParserTest {
+class BatchingSettingsConfigParserTest {
 
   private static final String YAML_DIRECTORY = "src/test/resources/";
 
   @Test
-  public void parseGapicSettings_plain() {
+  void parseGapicSettings_plain() {
     String filename = "datastore_gapic.yaml";
     Path path = Paths.get(YAML_DIRECTORY, filename);
     Optional<List<GapicBatchingSettings>> settingsOpt =
@@ -40,7 +40,7 @@ public class BatchingSettingsConfigParserTest {
   }
 
   @Test
-  public void parseGapicSettings_noMethodSettings() {
+  void parseGapicSettings_noMethodSettings() {
     String filename = "showcase_gapic.yaml";
     Path path = Paths.get(YAML_DIRECTORY, filename);
     Optional<List<GapicBatchingSettings>> settingsOpt =
@@ -49,7 +49,7 @@ public class BatchingSettingsConfigParserTest {
   }
 
   @Test
-  public void parseBatchingSettings_logging() {
+  void parseBatchingSettings_logging() {
     String filename = "logging_gapic.yaml";
     Path path = Paths.get(YAML_DIRECTORY, filename);
     Optional<List<GapicBatchingSettings>> settingsOpt =
@@ -82,7 +82,7 @@ public class BatchingSettingsConfigParserTest {
   }
 
   @Test
-  public void parseBatchingSettings_pubsub() {
+  void parseBatchingSettings_pubsub() {
     String filename = "pubsub_gapic.yaml";
     Path path = Paths.get(YAML_DIRECTORY, filename);
     Optional<List<GapicBatchingSettings>> settingsOpt =

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/GapicLanguageSettingsParserTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/GapicLanguageSettingsParserTest.java
@@ -21,14 +21,14 @@ import com.google.api.generator.gapic.model.GapicLanguageSettings;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class GapicLanguageSettingsParserTest {
+class GapicLanguageSettingsParserTest {
 
   private static final String YAML_DIRECTORY = "src/test/resources/";
 
   @Test
-  public void parseLanguageSettings_onlyInterfacePresent() {
+  void parseLanguageSettings_onlyInterfacePresent() {
     String filename = "datastore_gapic.yaml";
     Path path = Paths.get(YAML_DIRECTORY, filename);
     Optional<GapicLanguageSettings> settingsOpt =
@@ -40,7 +40,7 @@ public class GapicLanguageSettingsParserTest {
   }
 
   @Test
-  public void parseLanguageSettings_methodNameOverridesPresent() {
+  void parseLanguageSettings_methodNameOverridesPresent() {
     String filename = "logging_gapic.yaml";
     Path path = Paths.get(YAML_DIRECTORY, filename);
     Optional<GapicLanguageSettings> settingsOpt =

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/GapicLroRetrySettingsParserTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/GapicLroRetrySettingsParserTest.java
@@ -22,15 +22,15 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class GapicLroRetrySettingsParserTest {
+class GapicLroRetrySettingsParserTest {
 
   private static final double DELTA = 0.0001;
   private static final String YAML_DIRECTORY = "src/test/resources/";
 
   @Test
-  public void parseLroRetrySettings_methodsPresentNoLroRetrySettings() {
+  void parseLroRetrySettings_methodsPresentNoLroRetrySettings() {
     String filename = "datastore_gapic.yaml";
     Path path = Paths.get(YAML_DIRECTORY, filename);
     Optional<List<GapicLroRetrySettings>> settingsOpt =
@@ -39,7 +39,7 @@ public class GapicLroRetrySettingsParserTest {
   }
 
   @Test
-  public void parseGapicSettings_noMethodSettings() {
+  void parseGapicSettings_noMethodSettings() {
     String filename = "showcase_gapic.yaml";
     Path path = Paths.get(YAML_DIRECTORY, filename);
     Optional<List<GapicLroRetrySettings>> settingsOpt =
@@ -48,7 +48,7 @@ public class GapicLroRetrySettingsParserTest {
   }
 
   @Test
-  public void parseLroRetrySettings_lroRetrySettingsPresent() {
+  void parseLroRetrySettings_lroRetrySettingsPresent() {
     String filename = "dataproc_gapic.yaml";
     Path path = Paths.get(YAML_DIRECTORY, filename);
     Optional<List<GapicLroRetrySettings>> settingsOpt =

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/HttpRuleParserTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/HttpRuleParserTest.java
@@ -31,12 +31,12 @@ import com.google.showcase.v1beta1.TestingOuterClass;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-public class HttpRuleParserTest {
+class HttpRuleParserTest {
   @Test
-  public void parseHttpAnnotation_basic() {
+  void parseHttpAnnotation_basic() {
     FileDescriptor testingFileDescriptor = TestingOuterClass.getDescriptor();
     ServiceDescriptor testingService = testingFileDescriptor.getServices().get(0);
     assertEquals("Testing", testingService.getName());
@@ -61,7 +61,7 @@ public class HttpRuleParserTest {
   }
 
   @Test
-  public void parseHttpAnnotation_multipleBindings() {
+  void parseHttpAnnotation_multipleBindings() {
     FileDescriptor testingFileDescriptor = TestingOuterClass.getDescriptor();
     ServiceDescriptor testingService = testingFileDescriptor.getServices().get(0);
     assertEquals("Testing", testingService.getName());
@@ -81,7 +81,7 @@ public class HttpRuleParserTest {
   }
 
   @Test
-  public void parseHttpAnnotation_missingFieldFromMessage() {
+  void parseHttpAnnotation_missingFieldFromMessage() {
     FileDescriptor testingFileDescriptor = TestingOuterClass.getDescriptor();
     ServiceDescriptor testingService = testingFileDescriptor.getServices().get(0);
     assertEquals("Testing", testingService.getName());
@@ -97,8 +97,7 @@ public class HttpRuleParserTest {
   }
 
   @Test
-  public void
-      parseHttpAnnotation_shouldPutAllFieldsIntoQueryParamsIfPathParamAndBodyAreNotConfigured() {
+  void parseHttpAnnotation_shouldPutAllFieldsIntoQueryParamsIfPathParamAndBodyAreNotConfigured() {
     FileDescriptor fileDescriptor = HttpRuleParserTestingOuterClass.getDescriptor();
     ServiceDescriptor serviceDescriptor = fileDescriptor.getServices().get(0);
     assertEquals("HttpRuleParserTesting", serviceDescriptor.getName());
@@ -124,7 +123,7 @@ public class HttpRuleParserTest {
     Truth.assertThat(new HashSet<>(actual.queryParameters())).containsExactly(expected1, expected2);
   }
 
-  @Ignore
+  @Disabled
   @Test
   //               request
   //             /         \
@@ -138,7 +137,7 @@ public class HttpRuleParserTest {
   // We need to either traverse all the leaf level fields and exclude field in the generator or pass
   // the excluded fields to gax-java. Re-enable this test once
   // https://github.com/googleapis/sdk-platform-java/issues/1041 is fixed
-  public void parseHttpAnnotation_shouldExcludeFieldsFromQueryParamsIfPathParamsAreConfigured() {
+  void parseHttpAnnotation_shouldExcludeFieldsFromQueryParamsIfPathParamsAreConfigured() {
     FileDescriptor fileDescriptor = HttpRuleParserTestingOuterClass.getDescriptor();
     ServiceDescriptor serviceDescriptor = fileDescriptor.getServices().get(0);
     assertEquals("HttpRuleParserTesting", serviceDescriptor.getName());

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/MethodSignatureParserTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/MethodSignatureParserTest.java
@@ -28,12 +28,12 @@ import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class MethodSignatureParserTest {
+class MethodSignatureParserTest {
 
   @Test
-  public void flattenMethodSignatures_basic() {
+  void flattenMethodSignatures_basic() {
     String fooName = "fooName";
     TypeNode fooTypeOne =
         TypeNode.withReference(
@@ -70,7 +70,7 @@ public class MethodSignatureParserTest {
   }
 
   @Test
-  public void flattenMethodSignatures_oneToMany() {
+  void flattenMethodSignatures_oneToMany() {
     String fooName = "fooName";
     String anInt = "anInt";
 
@@ -110,7 +110,7 @@ public class MethodSignatureParserTest {
   }
 
   @Test
-  public void flattenMethodSignatures_manyToOne() {
+  void flattenMethodSignatures_manyToOne() {
     String fooName = "fooName";
     String anInt = "anInt";
 
@@ -150,7 +150,7 @@ public class MethodSignatureParserTest {
   }
 
   @Test
-  public void flattenMethodSignatures_manyToMany() {
+  void flattenMethodSignatures_manyToMany() {
     String fooName = "fooName";
     String barName = "barName";
     String anInt = "anInt";

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/ParserTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/ParserTest.java
@@ -56,10 +56,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class ParserTest {
+class ParserTest {
   private static final String ECHO_PACKAGE = "com.google.showcase.v1beta1";
   // TODO(miraleung): Backfill with more tests (e.g. field, message, methods) for Parser.java.
   private ServiceDescriptor echoService;
@@ -69,8 +69,8 @@ public class ParserTest {
 
   private Optional<com.google.api.Service> serviceYamlProtoOpt;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     echoFileDescriptor = EchoOuterClass.getDescriptor();
     echoService = echoFileDescriptor.getServices().get(0);
     String yamlFilename = "echo_v1beta1.yaml";
@@ -80,7 +80,7 @@ public class ParserTest {
   }
 
   @Test
-  public void parseMessages_basic() {
+  void parseMessages_basic() {
     // TODO(miraleung): Add more tests for oneofs and other message-parsing edge cases.
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
 
@@ -116,7 +116,7 @@ public class ParserTest {
   }
 
   @Test
-  public void parseMessages_fieldNameConflicts() {
+  void parseMessages_fieldNameConflicts() {
     FileDescriptor bookshopFileDescriptor = BookshopProto.getDescriptor();
     Map<String, Message> messageTypes = Parser.parseMessages(bookshopFileDescriptor);
     Message requestMessage = messageTypes.get("com.google.bookshop.v1beta1.GetBookRequest");
@@ -127,7 +127,7 @@ public class ParserTest {
   }
 
   @Test
-  public void parseMethods_basic() {
+  void parseMethods_basic() {
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Set<ResourceName> outputResourceNames = new HashSet<>();
@@ -190,7 +190,7 @@ public class ParserTest {
   }
 
   @Test
-  public void parseMethods_basicLro() {
+  void parseMethods_basicLro() {
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Set<ResourceName> outputResourceNames = new HashSet<>();
@@ -218,7 +218,7 @@ public class ParserTest {
   }
 
   @Test
-  public void parseLro_missingResponseType() {
+  void parseLro_missingResponseType() {
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
     MethodDescriptor waitMethodDescriptor = echoService.getMethods().get(7);
     assertEquals("Wait", waitMethodDescriptor.getName());
@@ -228,7 +228,7 @@ public class ParserTest {
   }
 
   @Test
-  public void parseLro_missingMetadataType() {
+  void parseLro_missingMetadataType() {
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
     MethodDescriptor waitMethodDescriptor = echoService.getMethods().get(7);
     assertEquals("Wait", waitMethodDescriptor.getName());
@@ -238,7 +238,7 @@ public class ParserTest {
   }
 
   @Test
-  public void parseMethodSignatures_empty() {
+  void parseMethodSignatures_empty() {
     // TODO(miraleung): Move this to MethodSignatureParserTest.
     MethodDescriptor methodDescriptor = echoService.getMethods().get(5);
     assertEquals("PagedExpand", methodDescriptor.getName());
@@ -259,7 +259,7 @@ public class ParserTest {
   }
 
   @Test
-  public void parseMethodSignatures_validArgstAndEmptyString() {
+  void parseMethodSignatures_validArgstAndEmptyString() {
     // TODO(miraleung): Move this to MethodSignatureParserTest.
     MethodDescriptor methodDescriptor = echoService.getMethods().get(0);
     assertEquals("Echo", methodDescriptor.getName());
@@ -282,7 +282,7 @@ public class ParserTest {
   }
 
   @Test
-  public void parseMethodSignatures_basic() {
+  void parseMethodSignatures_basic() {
     MethodDescriptor echoMethodDescriptor = echoService.getMethods().get(0);
     TypeNode inputType = TypeParser.parseType(echoMethodDescriptor.getInputType());
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -361,7 +361,7 @@ public class ParserTest {
   }
 
   @Test
-  public void parseMessagesAndResourceNames_update() {
+  void parseMessagesAndResourceNames_update() {
     FileDescriptor lockerServiceFileDescriptor = LockerProto.getDescriptor();
     Map<String, Message> messageTypes = Parser.parseMessages(lockerServiceFileDescriptor);
 
@@ -381,7 +381,7 @@ public class ParserTest {
   }
 
   @Test
-  public void parseMessages_fieldsHaveResourceReferences() {
+  void parseMessages_fieldsHaveResourceReferences() {
     FileDescriptor lockerServiceFileDescriptor = LockerProto.getDescriptor();
     Map<String, Message> messageTypes = Parser.parseMessages(lockerServiceFileDescriptor);
 
@@ -423,7 +423,7 @@ public class ParserTest {
   }
 
   @Test
-  public void parseFields_mapType() {
+  void parseFields_mapType() {
     FileDescriptor testingFileDescriptor = TestingOuterClass.getDescriptor();
     ServiceDescriptor testingService = testingFileDescriptor.getServices().get(0);
     assertEquals(testingService.getName(), "Testing");
@@ -442,7 +442,7 @@ public class ParserTest {
   }
 
   @Test
-  public void parseFields_autoPopulated() {
+  void parseFields_autoPopulated() {
     Map<String, Message> messageTypes =
         Parser.parseMessages(AutoPopulateFieldTestingOuterClass.getDescriptor());
     Message message =
@@ -474,7 +474,7 @@ public class ParserTest {
   }
 
   @Test
-  public void parseAutoPopulatedMethodsAndFields_exists() {
+  void parseAutoPopulatedMethodsAndFields_exists() {
     String yamlFilename = "auto_populate_field_testing.yaml";
     Path yamlPath = Paths.get(YAML_DIRECTORY, yamlFilename);
     Map<String, List<String>> autoPopulatedMethodsWithFields =
@@ -496,7 +496,7 @@ public class ParserTest {
   }
 
   @Test
-  public void parseAutoPopulatedMethodsAndFields_doesNotExist() {
+  void parseAutoPopulatedMethodsAndFields_doesNotExist() {
     String yamlFilename = "logging.yaml";
     Path yamlPath = Paths.get(YAML_DIRECTORY, yamlFilename);
     Optional<Service> serviceYamlProtoOpt_Null = ServiceYamlParser.parse(yamlPath.toString());
@@ -507,12 +507,12 @@ public class ParserTest {
   }
 
   @Test
-  public void parseAutoPopulatedMethodsAndFields_returnsEmptyMapIfServiceYamlIsNull() {
+  void parseAutoPopulatedMethodsAndFields_returnsEmptyMapIfServiceYamlIsNull() {
     assertEquals(true, Parser.parseAutoPopulatedMethodsAndFields(Optional.empty()).isEmpty());
   }
 
   @Test
-  public void parseAutoPopulatedMethodsAndFields_returnsMapOfMethodsAndAutoPopulatedFields() {
+  void parseAutoPopulatedMethodsAndFields_returnsMapOfMethodsAndAutoPopulatedFields() {
     MethodSettings testMethodSettings =
         MethodSettings.newBuilder()
             .setSelector("test_method")
@@ -546,17 +546,17 @@ public class ParserTest {
   }
 
   @Test
-  public void hasMethodSettings_shouldReturnFalseIfServiceYamlDoesNotExist() {
+  void hasMethodSettings_shouldReturnFalseIfServiceYamlDoesNotExist() {
     assertEquals(false, Parser.hasMethodSettings(Optional.empty()));
   }
 
   @Test
-  public void hasMethodSettings_shouldReturnFalseIfServiceYamlDoesNotHavePublishing() {
+  void hasMethodSettings_shouldReturnFalseIfServiceYamlDoesNotHavePublishing() {
     assertEquals(false, Parser.hasMethodSettings(Optional.of(Service.newBuilder().build())));
   }
 
   @Test
-  public void hasMethodSettings_shouldReturnTrueIfServiceYamlHasNonEmptyMethodSettings() {
+  void hasMethodSettings_shouldReturnTrueIfServiceYamlHasNonEmptyMethodSettings() {
     MethodSettings testMethodSettings =
         MethodSettings.newBuilder().setSelector("test_method").build();
     Publishing testPublishing =
@@ -568,7 +568,7 @@ public class ParserTest {
   }
 
   @Test
-  public void parseResourceNames_inputTypeHasReferenceNotInMethodSignature() {
+  void parseResourceNames_inputTypeHasReferenceNotInMethodSignature() {
     FileDescriptor testingFileDescriptor = TestingOuterClass.getDescriptor();
     ServiceDescriptor testingService = testingFileDescriptor.getServices().get(0);
     assertEquals(testingService.getName(), "Testing");
@@ -589,7 +589,7 @@ public class ParserTest {
   }
 
   @Test
-  public void sanitizeDefaultHost_basic() {
+  void sanitizeDefaultHost_basic() {
     String defaultHost = "localhost:1234";
     assertEquals(defaultHost, Parser.sanitizeDefaultHost(defaultHost));
 
@@ -598,7 +598,7 @@ public class ParserTest {
   }
 
   @Test
-  public void parseNestedProtoTypeName() {
+  void parseNestedProtoTypeName() {
     assertEquals("MutateJobMetadata", Parser.parseNestedProtoTypeName("MutateJobMetadata"));
     assertEquals(
         "MutateJob.MutateJobMetadata",
@@ -610,7 +610,7 @@ public class ParserTest {
   }
 
   @Test
-  public void parseServiceApiVersionTest() {
+  void parseServiceApiVersionTest() {
     FileDescriptor apiVersionFileDescriptor = ApiVersionTestingOuterClass.getDescriptor();
     Map<String, Message> messageTypes = Parser.parseMessages(apiVersionFileDescriptor);
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(apiVersionFileDescriptor);
@@ -629,7 +629,7 @@ public class ParserTest {
   }
 
   @Test
-  public void parseServiceWithoutApiVersionTest() {
+  void parseServiceWithoutApiVersionTest() {
     FileDescriptor apiVersionFileDescriptor = ApiVersionTestingOuterClass.getDescriptor();
     Map<String, Message> messageTypes = Parser.parseMessages(apiVersionFileDescriptor);
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(apiVersionFileDescriptor);
@@ -648,7 +648,7 @@ public class ParserTest {
   }
 
   @Test
-  public void parseServiceWithEmptyApiVersionTest() {
+  void parseServiceWithEmptyApiVersionTest() {
     FileDescriptor apiVersionFileDescriptor = ApiVersionTestingOuterClass.getDescriptor();
     Map<String, Message> messageTypes = Parser.parseMessages(apiVersionFileDescriptor);
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(apiVersionFileDescriptor);
@@ -668,7 +668,7 @@ public class ParserTest {
   }
 
   @Test
-  public void testServiceWithoutApiVersionParsed() {
+  void testServiceWithoutApiVersionParsed() {
     FileDescriptor bookshopFileDescriptor = BookshopProto.getDescriptor();
     Map<String, Message> messageTypes = Parser.parseMessages(bookshopFileDescriptor);
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(bookshopFileDescriptor);

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/PatternParserTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/PatternParserTest.java
@@ -17,22 +17,22 @@ package com.google.api.generator.gapic.protoparser;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class PatternParserTest {
+class PatternParserTest {
   @Test
-  public void getPattenBindings_shouldReturnEmptySetIfPatternIsEmpty() {
+  void getPattenBindings_shouldReturnEmptySetIfPatternIsEmpty() {
     assertThat(PatternParser.getPatternBindings("")).isEmpty();
   }
 
   @Test
-  public void getPattenBindings_shouldFilterOutUnboundVariables() {
+  void getPattenBindings_shouldFilterOutUnboundVariables() {
     Set<String> actual = PatternParser.getPatternBindings("{routing_id=projects/*}/**");
     assertThat(actual).hasSize(1);
   }
 
   @Test
-  public void getPattenBindings_shouldReturnBindingsInNatualOrder() {
+  void getPattenBindings_shouldReturnBindingsInNatualOrder() {
     Set<String> actual =
         PatternParser.getPatternBindings("{routing_id=projects/*}/{name=instance/*}");
     assertThat(actual).containsExactly("name", "routing_id").inOrder();

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/PluginArgumentParserTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/PluginArgumentParserTest.java
@@ -22,11 +22,11 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest;
 import java.util.Arrays;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class PluginArgumentParserTest {
+class PluginArgumentParserTest {
   @Test
-  public void parseJsonPath_onlyOnePresent() {
+  void parseJsonPath_onlyOnePresent() {
     String jsonPath = "/tmp/grpc_service_config.json";
     assertEquals(
         jsonPath,
@@ -34,7 +34,7 @@ public class PluginArgumentParserTest {
   }
 
   @Test
-  public void parseJsonPath_returnsFirstOneFound() {
+  void parseJsonPath_returnsFirstOneFound() {
     String jsonPathOne = "/tmp/foobar_grpc_service_config.json";
     String jsonPathTwo = "/tmp/some_other_grpc_service_config.json";
     assertEquals(
@@ -49,7 +49,7 @@ public class PluginArgumentParserTest {
   }
 
   @Test
-  public void parseJsonPath_similarFileAppearsFirst() {
+  void parseJsonPath_similarFileAppearsFirst() {
     String jsonPath = "/tmp/foo_grpc_service_config.json";
     String gapicPath = "/tmp/something_gapic.yaml";
     String rawArgument =
@@ -65,7 +65,7 @@ public class PluginArgumentParserTest {
   }
 
   @Test
-  public void parseJsonPath_argumentHasSpaces() {
+  void parseJsonPath_argumentHasSpaces() {
     String jsonPath = "/tmp/foo_grpc_service_config.json";
     String gapicPath = "/tmp/something_gapic.yaml";
     String rawArgument =
@@ -81,7 +81,7 @@ public class PluginArgumentParserTest {
   }
 
   @Test
-  public void parseJsonPath_restAreEmpty() {
+  void parseJsonPath_restAreEmpty() {
     String jsonPath = "/tmp/foobar_grpc_service_config.json";
     String gapicPath = "";
     String rawArgument =
@@ -90,14 +90,14 @@ public class PluginArgumentParserTest {
   }
 
   @Test
-  public void parseJsonPath_noneFound() {
+  void parseJsonPath_noneFound() {
     String gapicPath = "/tmp/something_gapic.yaml";
     String rawArgument = String.join(",", Arrays.asList(gapicPath));
     assertFalse(PluginArgumentParser.parseJsonConfigPath(rawArgument).isPresent());
   }
 
   @Test
-  public void parseGapicYamlPath_onlyOnePresent() {
+  void parseGapicYamlPath_onlyOnePresent() {
     String gapicPath = "/tmp/something_gapic.yaml";
     assertEquals(
         gapicPath,
@@ -105,7 +105,7 @@ public class PluginArgumentParserTest {
   }
 
   @Test
-  public void parseGapicYamlPath_returnsFirstOneFound() {
+  void parseGapicYamlPath_returnsFirstOneFound() {
     String gapicPathOne = "/tmp/something_gapic.yaml";
     String gapicPathTwo = "/tmp/other_gapic.yaml";
     assertEquals(
@@ -119,7 +119,7 @@ public class PluginArgumentParserTest {
   }
 
   @Test
-  public void parseGapicYamlPath_similarFileAppearsFirst() {
+  void parseGapicYamlPath_similarFileAppearsFirst() {
     String jsonPath = "/tmp/foo_grpc_service_config.json";
     String gapicPath = "/tmp/something_gapic.yaml";
     String rawArgument =
@@ -134,7 +134,7 @@ public class PluginArgumentParserTest {
   }
 
   @Test
-  public void parseGapicYamlPath_restAreEmpty() {
+  void parseGapicYamlPath_restAreEmpty() {
     String jsonPath = "";
     String gapicPath = "/tmp/something_gapic.yaml";
     String rawArgument =
@@ -143,7 +143,7 @@ public class PluginArgumentParserTest {
   }
 
   @Test
-  public void parseGapicYamlPath_noneFound() {
+  void parseGapicYamlPath_noneFound() {
     String jsonPath = "/tmp/foo_grpc_service_config.json";
     String gapicPath = "";
     String rawArgument =
@@ -152,7 +152,7 @@ public class PluginArgumentParserTest {
   }
 
   @Test
-  public void parseServiceYamlPath_onlyOnePresent() {
+  void parseServiceYamlPath_onlyOnePresent() {
     String servicePath = "/tmp/something.yaml";
     assertEquals(
         servicePath,
@@ -160,7 +160,7 @@ public class PluginArgumentParserTest {
   }
 
   @Test
-  public void parseServiceYamlPath_returnsFirstOneFound() {
+  void parseServiceYamlPath_returnsFirstOneFound() {
     String servicePathOne = "/tmp/something.yaml";
     String servicePathTwo = "/tmp/other.yaml";
     assertEquals(
@@ -174,7 +174,7 @@ public class PluginArgumentParserTest {
   }
 
   @Test
-  public void parseServiceYamlPath_gapicFilePresent() {
+  void parseServiceYamlPath_gapicFilePresent() {
     String gapicPath = "/tmp/something_gapic.yaml";
     String servicePath = "/tmp/something.yaml";
     // Both passed under the service yaml flag.
@@ -203,7 +203,7 @@ public class PluginArgumentParserTest {
   }
 
   @Test
-  public void parseServiceYamlPath_similarFileAppearsFirst() {
+  void parseServiceYamlPath_similarFileAppearsFirst() {
     String jsonPath = "/tmp/foo_grpc_service_config.json";
     String gapicPath = "/tmp/something_gapic.yaml";
     String servicePath = "/tmp/something.yaml";
@@ -220,7 +220,7 @@ public class PluginArgumentParserTest {
   }
 
   @Test
-  public void parseServiceYamlPath_noneFound() {
+  void parseServiceYamlPath_noneFound() {
     String jsonPath = "/tmp/foo_grpc_service_config.json";
     String gapicPath = "";
     String rawArgument =
@@ -229,7 +229,7 @@ public class PluginArgumentParserTest {
   }
 
   @Test
-  public void hasMetadataFlag() {
+  void hasMetadataFlag() {
     CodeGeneratorRequest request =
         CodeGeneratorRequest.newBuilder()
             .setParameter(String.join(",", KEY_METADATA, "does-not-matter"))
@@ -238,7 +238,7 @@ public class PluginArgumentParserTest {
   }
 
   @Test
-  public void hasNumericEnumFlag() {
+  void hasNumericEnumFlag() {
     CodeGeneratorRequest request =
         CodeGeneratorRequest.newBuilder()
             .setParameter(String.join(",", KEY_NUMERIC_ENUM, "does-not-matter"))
@@ -247,7 +247,7 @@ public class PluginArgumentParserTest {
   }
 
   @Test
-  public void hasFlag_noneFound() {
+  void hasFlag_noneFound() {
     String jsonPath = "/tmp/foo_grpc_service_config.json";
     String gapicPath = "";
     String rawArgument =
@@ -261,7 +261,7 @@ public class PluginArgumentParserTest {
   }
 
   @Test
-  public void hasFlag_flagFound() {
+  void hasFlag_flagFound() {
     String jsonPath = "/tmp/foo_grpc_service_config.json";
     String gapicPath = "";
     String rawArgument =

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/ResourceNameParserTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/ResourceNameParserTest.java
@@ -31,21 +31,21 @@ import com.google.testgapic.v1beta1.LockerProto;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class ResourceNameParserTest {
+class ResourceNameParserTest {
   private static final String MAIN_PACKAGE = "com.google.testgapic.v1beta1";
 
   private FileDescriptor lockerServiceFileDescriptor;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     lockerServiceFileDescriptor = LockerProto.getDescriptor();
   }
 
   @Test
-  public void parseResourceNames_basicOnePattern() {
+  void parseResourceNames_basicOnePattern() {
     Map<String, ResourceName> typeStringsToResourceNames =
         ResourceNameParser.parseResourceNamesFromFile(lockerServiceFileDescriptor);
     assertEquals(4, typeStringsToResourceNames.size());
@@ -63,7 +63,7 @@ public class ResourceNameParserTest {
   }
 
   @Test
-  public void parseResourceNames_basicTwoPatterns() {
+  void parseResourceNames_basicTwoPatterns() {
     Map<String, ResourceName> typeStringsToResourceNames =
         ResourceNameParser.parseResourceNamesFromFile(lockerServiceFileDescriptor);
     assertEquals(4, typeStringsToResourceNames.size());
@@ -81,7 +81,7 @@ public class ResourceNameParserTest {
   }
 
   @Test
-  public void parseResourceNames_wildcard() {
+  void parseResourceNames_wildcard() {
     Map<String, ResourceName> typeStringsToResourceNames =
         ResourceNameParser.parseResourceNamesFromFile(lockerServiceFileDescriptor);
     assertEquals(4, typeStringsToResourceNames.size());
@@ -101,7 +101,7 @@ public class ResourceNameParserTest {
   }
 
   @Test
-  public void parseResourceNames_deletedTopic() {
+  void parseResourceNames_deletedTopic() {
     Map<String, ResourceName> typeStringsToResourceNames =
         ResourceNameParser.parseResourceNamesFromFile(lockerServiceFileDescriptor);
     assertEquals(4, typeStringsToResourceNames.size());
@@ -117,7 +117,7 @@ public class ResourceNameParserTest {
   }
 
   @Test
-  public void parseResourceNames_messageResourceDefinition() {
+  void parseResourceNames_messageResourceDefinition() {
     String pakkage = TypeParser.getPackage(lockerServiceFileDescriptor);
     List<Descriptor> messageDescriptors = lockerServiceFileDescriptor.getMessageTypes();
     Map<String, ResourceName> typeStringsToResourceNames =
@@ -137,7 +137,7 @@ public class ResourceNameParserTest {
   }
 
   @Test
-  public void parseResourceNames_badMessageResourceNameDefinitionMissingNameField() {
+  void parseResourceNames_badMessageResourceNameDefinitionMissingNameField() {
     FileDescriptor protoFileDescriptor = BadMessageResnameDefProto.getDescriptor();
     List<Descriptor> messageDescriptors = protoFileDescriptor.getMessageTypes();
     Descriptor messageDescriptor = messageDescriptors.get(0);
@@ -149,7 +149,7 @@ public class ResourceNameParserTest {
   }
 
   @Test
-  public void parseResourceNameFromMessage_basicResourceDefinition() {
+  void parseResourceNameFromMessage_basicResourceDefinition() {
     String pakkage = TypeParser.getPackage(lockerServiceFileDescriptor);
     List<Descriptor> messageDescriptors = lockerServiceFileDescriptor.getMessageTypes();
     Descriptor documentMessageDescriptor = messageDescriptors.get(0);
@@ -161,7 +161,7 @@ public class ResourceNameParserTest {
   }
 
   @Test
-  public void parseResourceNamesFromMessage_noResourceDefinition() {
+  void parseResourceNamesFromMessage_noResourceDefinition() {
     String pakkage = TypeParser.getPackage(lockerServiceFileDescriptor);
     List<Descriptor> messageDescriptors = lockerServiceFileDescriptor.getMessageTypes();
     Descriptor folderMessageDescriptor = messageDescriptors.get(1);
@@ -172,7 +172,7 @@ public class ResourceNameParserTest {
   }
 
   @Test
-  public void parseResourceNameFromMessage_nonNameResourceReferenceField() {
+  void parseResourceNameFromMessage_nonNameResourceReferenceField() {
     String pakkage = TypeParser.getPackage(lockerServiceFileDescriptor);
     List<Descriptor> messageDescriptors = lockerServiceFileDescriptor.getMessageTypes();
     Descriptor binderMessageDescriptor = messageDescriptors.get(2);
@@ -184,7 +184,7 @@ public class ResourceNameParserTest {
   }
 
   @Test
-  public void parseResourceNamesFromMessage_noNameOrResourceReferenceField() {
+  void parseResourceNamesFromMessage_noNameOrResourceReferenceField() {
     FileDescriptor protoFileDescriptor = BadMessageResnameDefProto.getDescriptor();
     String pakkage = TypeParser.getPackage(protoFileDescriptor);
     List<Descriptor> messageDescriptors = protoFileDescriptor.getMessageTypes();
@@ -197,14 +197,14 @@ public class ResourceNameParserTest {
   }
 
   @Test
-  public void getVariableName_basicPattern() {
+  void getVariableName_basicPattern() {
     Optional<String> nameOpt = ResourceNameParser.getVariableNameFromPattern("projects/{project}");
     assertTrue(nameOpt.isPresent());
     assertEquals("project", nameOpt.get());
   }
 
   @Test
-  public void getVariableName_basicPatternLonger() {
+  void getVariableName_basicPatternLonger() {
     Optional<String> nameOpt =
         ResourceNameParser.getVariableNameFromPattern(
             "projects/{project}/billingAccounts/{billing_account}");
@@ -213,7 +213,7 @@ public class ResourceNameParserTest {
   }
 
   @Test
-  public void getVariableName_differentCasedName() {
+  void getVariableName_differentCasedName() {
     Optional<String> nameOpt =
         ResourceNameParser.getVariableNameFromPattern(
             "projects/{project}/billingAccounts/{billingAccOunt}");
@@ -222,7 +222,7 @@ public class ResourceNameParserTest {
   }
 
   @Test
-  public void getVariableName_singletonEnding() {
+  void getVariableName_singletonEnding() {
     Optional<String> nameOpt =
         ResourceNameParser.getVariableNameFromPattern("projects/{project}/cmekSettings");
     assertTrue(nameOpt.isPresent());
@@ -230,7 +230,7 @@ public class ResourceNameParserTest {
   }
 
   @Test
-  public void getVariableName_onlyLiterals() {
+  void getVariableName_onlyLiterals() {
     Optional<String> nameOpt =
         ResourceNameParser.getVariableNameFromPattern("projects/project/locations/location");
     assertTrue(nameOpt.isPresent());
@@ -238,7 +238,7 @@ public class ResourceNameParserTest {
   }
 
   @Test
-  public void getVariableName_deletedTopic() {
+  void getVariableName_deletedTopic() {
     Optional<String> nameOpt =
         ResourceNameParser.getVariableNameFromPattern(ResourceNameConstants.DELETED_TOPIC_LITERAL);
     assertTrue(nameOpt.isPresent());
@@ -246,7 +246,7 @@ public class ResourceNameParserTest {
   }
 
   @Test
-  public void getVariableName_wildcard() {
+  void getVariableName_wildcard() {
     Optional<String> nameOpt =
         ResourceNameParser.getVariableNameFromPattern(ResourceNameConstants.WILDCARD_PATTERN);
     assertFalse(nameOpt.isPresent());

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/ResourceReferenceParserTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/ResourceReferenceParserTest.java
@@ -26,21 +26,21 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class ResourceReferenceParserTest {
+class ResourceReferenceParserTest {
   private static final String MAIN_PACKAGE = "com.google.testgapic.v1beta1";
 
   private FileDescriptor lockerServiceFileDescriptor;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     lockerServiceFileDescriptor = LockerProto.getDescriptor();
   }
 
   @Test
-  public void parseParentResourceName_createFromPattern() {
+  void parseParentResourceName_createFromPattern() {
     String resourceNamePackage = String.format("%s.common", MAIN_PACKAGE);
     String domainName = "cloudbilling.googleapis.com";
     String description = "This is the resource name description";
@@ -76,7 +76,7 @@ public class ResourceReferenceParserTest {
   }
 
   @Test
-  public void parseParentResourceName_parentResourceNameExists() {
+  void parseParentResourceName_parentResourceNameExists() {
     Map<String, ResourceName> typeStringsToResourceNames =
         ResourceNameParser.parseResourceNamesFromFile(lockerServiceFileDescriptor);
 
@@ -103,7 +103,7 @@ public class ResourceReferenceParserTest {
   }
 
   @Test
-  public void parseParentResourceName_badPattern() {
+  void parseParentResourceName_badPattern() {
     Optional<ResourceName> parentResourceNameOpt =
         ResourceReferenceParser.parseParentResourceName(
             "projects/{project}/billingAccounts",
@@ -117,19 +117,19 @@ public class ResourceReferenceParserTest {
   }
 
   @Test
-  public void resolvePackages_resourcePackageIsSubpackageOfService() {
+  void resolvePackages_resourcePackageIsSubpackageOfService() {
     String resourcePackage = "com.google.testgapic.v1beta1.common";
     assertEquals(
         resourcePackage, ResourceReferenceParser.resolvePackages(resourcePackage, MAIN_PACKAGE));
   }
 
   @Test
-  public void resolvePackages_resourcePackageIsSameAsService() {
+  void resolvePackages_resourcePackageIsSameAsService() {
     assertEquals(MAIN_PACKAGE, ResourceReferenceParser.resolvePackages(MAIN_PACKAGE, MAIN_PACKAGE));
   }
 
   @Test
-  public void resolvePackages_resourcePackageIsNotSubpackageOfService() {
+  void resolvePackages_resourcePackageIsNotSubpackageOfService() {
     assertEquals(
         MAIN_PACKAGE, ResourceReferenceParser.resolvePackages("com.google.cloud", MAIN_PACKAGE));
   }

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/RoutingRuleParserTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/RoutingRuleParserTest.java
@@ -25,9 +25,9 @@ import com.google.protobuf.Descriptors.FileDescriptor;
 import com.google.protobuf.Descriptors.MethodDescriptor;
 import com.google.protobuf.Descriptors.ServiceDescriptor;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class RoutingRuleParserTest {
+class RoutingRuleParserTest {
 
   private static final FileDescriptor TESTING_FILE_DESCRIPTOR =
       RoutingRuleParserTestingOuterClass.getDescriptor();
@@ -35,13 +35,13 @@ public class RoutingRuleParserTest {
       TESTING_FILE_DESCRIPTOR.getServices().get(0);
 
   @Test
-  public void parse_shouldReturnNullRoutingHeadersIfMethodHasNoRoutingRules() {
+  void parse_shouldReturnNullRoutingHeadersIfMethodHasNoRoutingRules() {
     RoutingHeaderRule actual = getRoutingHeaders(0);
     assertThat(actual).isNull();
   }
 
   @Test
-  public void parse_shouldSetPathTemplateToWildcardIfNotDefined() {
+  void parse_shouldSetPathTemplateToWildcardIfNotDefined() {
     RoutingHeaderRule actual = getRoutingHeaders(1);
     RoutingHeaderParam expected =
         RoutingHeaderParam.create("name", "name", String.format("{%s=**}", "name"));
@@ -49,7 +49,7 @@ public class RoutingRuleParserTest {
   }
 
   @Test
-  public void parse_shouldThrowExceptionIfPathTemplateHasZeroNamedSegment() {
+  void parse_shouldThrowExceptionIfPathTemplateHasZeroNamedSegment() {
     IllegalArgumentException illegalArgumentException =
         assertThrows(IllegalArgumentException.class, () -> getRoutingHeaders(2));
     assertThat(illegalArgumentException.getMessage())
@@ -60,7 +60,7 @@ public class RoutingRuleParserTest {
   }
 
   @Test
-  public void parse_shouldThrowExceptionIfPathTemplateHasMoreThanOneNamedSegment() {
+  void parse_shouldThrowExceptionIfPathTemplateHasMoreThanOneNamedSegment() {
     IllegalArgumentException illegalArgumentException =
         assertThrows(IllegalArgumentException.class, () -> getRoutingHeaders(3));
     assertThat(illegalArgumentException.getMessage())
@@ -71,7 +71,7 @@ public class RoutingRuleParserTest {
   }
 
   @Test
-  public void parse_shouldParseRoutingRulesWithOneParameter() {
+  void parse_shouldParseRoutingRulesWithOneParameter() {
     RoutingHeaderRule actual = getRoutingHeaders(4);
     RoutingHeaderParam expected =
         RoutingHeaderParam.create("name", "rename", "/v1beta1/{rename=tests/*}");
@@ -79,7 +79,7 @@ public class RoutingRuleParserTest {
   }
 
   @Test
-  public void parse_shouldParseRoutingRulesWithMultipleParameter() {
+  void parse_shouldParseRoutingRulesWithMultipleParameter() {
     RoutingHeaderRule actual = getRoutingHeaders(5);
     RoutingHeaderParam expectedHeader1 =
         RoutingHeaderParam.create("name", "rename", "/v1beta1/{rename=tests/*}");
@@ -91,7 +91,7 @@ public class RoutingRuleParserTest {
   }
 
   @Test
-  public void parse_shouldParseRoutingRulesWithNestedFields() {
+  void parse_shouldParseRoutingRulesWithNestedFields() {
     RoutingHeaderRule actual = getRoutingHeaders(6);
     RoutingHeaderParam expectedHeader1 =
         RoutingHeaderParam.create("account.name", "rename", "/v1beta1/{rename=tests/*}");
@@ -99,7 +99,7 @@ public class RoutingRuleParserTest {
   }
 
   @Test
-  public void parse_shouldThrowExceptionIfFieldValidationFailed() {
+  void parse_shouldThrowExceptionIfFieldValidationFailed() {
     assertThrows(Exception.class, () -> getRoutingHeaders(7));
   }
 

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/ServiceConfigParserTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/ServiceConfigParserTest.java
@@ -25,15 +25,15 @@ import io.grpc.serviceconfig.ServiceConfig;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ServiceConfigParserTest {
+class ServiceConfigParserTest {
 
   private static final String JSON_DIRECTORY = "src/test/resources/";
   private static final double EPSILON = 1e-4;
 
   @Test
-  public void parseServiceConfig_basic() {
+  void parseServiceConfig_basic() {
     String jsonFilename = "retrying_grpc_service_config.json";
     Path jsonPath = Paths.get(JSON_DIRECTORY, jsonFilename);
     Optional<ServiceConfig> configOpt = ServiceConfigParser.parseFile(jsonPath.toString());
@@ -60,7 +60,7 @@ public class ServiceConfigParserTest {
   }
 
   @Test
-  public void parseServiceConfig_showcase() {
+  void parseServiceConfig_showcase() {
     String jsonFilename = "showcase_grpc_service_config.json";
     Path jsonPath = Paths.get(JSON_DIRECTORY, jsonFilename);
     Optional<ServiceConfig> configOpt = ServiceConfigParser.parseFile(jsonPath.toString());
@@ -79,7 +79,7 @@ public class ServiceConfigParserTest {
   }
 
   @Test
-  public void parseBadServiceConfig_missingFile() {
+  void parseBadServiceConfig_missingFile() {
     String jsonFilename = "does_not_exist_grpc_service_config.json";
     Path jsonPath = Paths.get(JSON_DIRECTORY, jsonFilename);
     Optional<ServiceConfig> configOpt = ServiceConfigParser.parseFile(jsonPath.toString());
@@ -87,7 +87,7 @@ public class ServiceConfigParserTest {
   }
 
   @Test
-  public void parseBadServiceConfig_malformedJson() {
+  void parseBadServiceConfig_malformedJson() {
     String jsonFilename = "malformed_grpc_service_config.json";
     Path jsonPath = Paths.get(JSON_DIRECTORY, jsonFilename);
     Optional<ServiceConfig> configOpt = ServiceConfigParser.parseFile(jsonPath.toString());
@@ -95,7 +95,7 @@ public class ServiceConfigParserTest {
   }
 
   @Test
-  public void parseBadServiceConfig_badProtoFields() {
+  void parseBadServiceConfig_badProtoFields() {
     String jsonFilename = "bad_proto_fields_grpc_service_config.json";
     Path jsonPath = Paths.get(JSON_DIRECTORY, jsonFilename);
     Optional<ServiceConfig> configOpt = ServiceConfigParser.parseFile(jsonPath.toString());
@@ -103,7 +103,7 @@ public class ServiceConfigParserTest {
   }
 
   @Test
-  public void parseBadServiceConfig_nullOrEmptyPath() {
+  void parseBadServiceConfig_nullOrEmptyPath() {
     Optional<ServiceConfig> configOpt = ServiceConfigParser.parseFile(null);
     assertFalse(configOpt.isPresent());
 

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/ServiceYamlParserTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/ServiceYamlParserTest.java
@@ -24,14 +24,14 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ServiceYamlParserTest {
+class ServiceYamlParserTest {
 
   private static final String YAML_DIRECTORY = "src/test/resources/";
 
   @Test
-  public void parseServiceYaml_basic() {
+  void parseServiceYaml_basic() {
     String yamlFilename = "logging.yaml";
     Path yamlPath = Paths.get(YAML_DIRECTORY, yamlFilename);
     Optional<com.google.api.Service> serviceYamlProtoOpt =
@@ -45,7 +45,7 @@ public class ServiceYamlParserTest {
   // TODO: Add more scenarios (e.g. null MethodSettings, null PublishingSettings, incorrect
   // FieldNames, etc.)
   @Test
-  public void parseServiceYaml_autoPopulatedFields() {
+  void parseServiceYaml_autoPopulatedFields() {
     String yamlFilename = "auto_populate_field_testing.yaml";
     Path yamlPath = Paths.get(YAML_DIRECTORY, yamlFilename);
     Optional<com.google.api.Service> serviceYamlProtoOpt =

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/SourceCodeInfoParserTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/SourceCodeInfoParserTest.java
@@ -32,10 +32,10 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class SourceCodeInfoParserTest {
+class SourceCodeInfoParserTest {
 
   private static final String BASIC_PROTO = "basic.proto";
   private static final String PROTO_DESCRIPTOR_SET = "test-proto.descriptorset";
@@ -43,14 +43,14 @@ public class SourceCodeInfoParserTest {
   private SourceCodeInfoParser parser;
   private FileDescriptor protoFile;
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeEach
+  void setUp() throws Exception {
     parser = new SourceCodeInfoParser();
     protoFile = buildFileDescriptor();
   }
 
   @Test
-  public void getServiceInfo() {
+  void getServiceInfo() {
     SourceCodeInfoLocation location = parser.getLocation(protoFile.findServiceByName("FooService"));
     assertEquals(
         "This is a service description.\n It takes up multiple lines, like so.",
@@ -61,7 +61,7 @@ public class SourceCodeInfoParserTest {
   }
 
   @Test
-  public void getMethodInfo() {
+  void getMethodInfo() {
     ServiceDescriptor service = protoFile.findServiceByName("FooService");
     SourceCodeInfoLocation location = parser.getLocation(service.findMethodByName("FooMethod"));
     assertEquals(
@@ -74,7 +74,7 @@ public class SourceCodeInfoParserTest {
   }
 
   @Test
-  public void getOuterMessageInfo() {
+  void getOuterMessageInfo() {
     Descriptor message = protoFile.findMessageTypeByName("FooMessage");
     SourceCodeInfoLocation location = parser.getLocation(message);
     assertEquals(
@@ -95,7 +95,7 @@ public class SourceCodeInfoParserTest {
   }
 
   @Test
-  public void getInnerMessageInfo() {
+  void getInnerMessageInfo() {
     Descriptor message = protoFile.findMessageTypeByName("FooMessage");
     assertThat(message).isNotNull();
     message = message.findNestedTypeByName("BarMessage");
@@ -113,7 +113,7 @@ public class SourceCodeInfoParserTest {
   }
 
   @Test
-  public void getOuterEnumInfo() {
+  void getOuterEnumInfo() {
     EnumDescriptor protoEnum = protoFile.findEnumTypeByName("OuterEnum");
     SourceCodeInfoLocation location = parser.getLocation(protoEnum);
     assertEquals("This is an outer enum.", location.getLeadingComments());
@@ -124,7 +124,7 @@ public class SourceCodeInfoParserTest {
   }
 
   @Test
-  public void getInnerEnumInfo() {
+  void getInnerEnumInfo() {
     Descriptor message = protoFile.findMessageTypeByName("FooMessage");
     EnumDescriptor protoEnum = message.findEnumTypeByName("FoodEnum");
     SourceCodeInfoLocation location = parser.getLocation(protoEnum);
@@ -138,7 +138,7 @@ public class SourceCodeInfoParserTest {
   }
 
   @Test
-  public void getOnoeofInfo() {
+  void getOnoeofInfo() {
     Descriptor message = protoFile.findMessageTypeByName("FooMessage");
     OneofDescriptor protoOneof = message.getOneofs().get(0);
     SourceCodeInfoLocation location = parser.getLocation(protoOneof);

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/TypeParserTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/TypeParserTest.java
@@ -31,9 +31,9 @@ import com.google.showcase.v1beta1.EchoOuterClass;
 import com.google.test.collisions.CollisionsOuterClass;
 import com.google.testgapic.v1beta1.NestedMessageProto;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class TypeParserTest {
+class TypeParserTest {
   // TODO(miraleung): Backfill with more tests (e.g. field, message, methods) for Parser.java.
 
   private static final FileDescriptor COLLISIONS_FILE_DESCRIPTOR =
@@ -46,7 +46,7 @@ public class TypeParserTest {
       COLLISIONS_FILE_DESCRIPTOR.getServices().get(0);
 
   @Test
-  public void parseMessageType_basic() {
+  void parseMessageType_basic() {
     FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     ServiceDescriptor echoService = echoFileDescriptor.getServices().get(0);
     assertEquals("Echo", echoService.getName());
@@ -57,7 +57,7 @@ public class TypeParserTest {
   }
 
   @Test
-  public void parseMessageType_nested() {
+  void parseMessageType_nested() {
     FileDescriptor fileDescriptor = NestedMessageProto.getDescriptor();
     Descriptor messageDescriptor = fileDescriptor.getMessageTypes().get(0);
     assertEquals("Outer", messageDescriptor.getName());
@@ -71,7 +71,7 @@ public class TypeParserTest {
   }
 
   @Test
-  public void parseLroResponseMetadataType_shortName_shouldMatchSamePackage() {
+  void parseLroResponseMetadataType_shortName_shouldMatchSamePackage() {
     Map<String, Message> messageTypes = Parser.parseMessages(COLLISIONS_FILE_DESCRIPTOR);
     messageTypes.putAll(Parser.parseMessages(DESCRIPTOR_PROTOS_FILE_DESCRIPTOR));
     messageTypes.putAll(Parser.parseMessages(LOCATION_PROTO_FILE_DESCRIPTOR));
@@ -97,7 +97,7 @@ public class TypeParserTest {
   }
 
   @Test
-  public void parseLroResponseMetadataType_shortName_shouldNotMatch() {
+  void parseLroResponseMetadataType_shortName_shouldNotMatch() {
     Map<String, Message> messageTypes = Parser.parseMessages(COLLISIONS_FILE_DESCRIPTOR);
     messageTypes.putAll(Parser.parseMessages(DESCRIPTOR_PROTOS_FILE_DESCRIPTOR));
     MethodDescriptor shortNameMatchShouldThrowLro = COLLISIONS_SERVICE.getMethods().get(1);
@@ -116,7 +116,7 @@ public class TypeParserTest {
   }
 
   @Test
-  public void parseLroResponseMetadataType_shortName_withFullyQualifiedCollision() {
+  void parseLroResponseMetadataType_shortName_withFullyQualifiedCollision() {
     Map<String, Message> messageTypes = Parser.parseMessages(COLLISIONS_FILE_DESCRIPTOR);
     messageTypes.putAll(Parser.parseMessages(DESCRIPTOR_PROTOS_FILE_DESCRIPTOR));
     messageTypes.putAll(Parser.parseMessages(LOCATION_PROTO_FILE_DESCRIPTOR));

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protowriter/WriterTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protowriter/WriterTest.java
@@ -7,60 +7,59 @@ import static org.junit.Assert.assertThrows;
 import com.google.api.generator.gapic.model.ReflectConfig;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.JarOutputStream;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-public class WriterTest {
+class WriterTest {
   private static final TypeToken<List<ReflectConfig>> REFLECT_CONFIG_JSON_FORMAT =
       new TypeToken<List<ReflectConfig>>() {};
 
-  @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
+  @TempDir Path tempDir;
 
   private JarOutputStream jarOutputStream;
 
-  private File file;
+  private Path path;
 
-  @Before
-  public void createJarOutputStream() throws IOException {
-    file = tempFolder.newFile("test.jar");
-    jarOutputStream = new JarOutputStream(Files.newOutputStream(file.toPath()));
+  @BeforeEach
+  void createJarOutputStream() throws IOException {
+    path = tempDir.resolve("test.jar");
+    jarOutputStream = new JarOutputStream(Files.newOutputStream(path));
   }
 
-  @After
-  public void assertJarOutputStream_isClosed() {
+  @AfterEach
+  void assertJarOutputStream_isClosed() {
     assertThrows(
         IOException.class, () -> jarOutputStream.putNextEntry(new JarEntry("should.fail")));
   }
 
   @Test
-  public void reflectConfig_notWritten_ifEmptyInput() throws IOException {
+  void reflectConfig_notWritten_ifEmptyInput() throws IOException {
     Writer.writeReflectConfigFile("com.google", Collections.emptyList(), jarOutputStream);
 
     jarOutputStream.finish();
     jarOutputStream.flush();
     jarOutputStream.close();
 
-    try (JarFile jarFile = new JarFile(file)) {
+    try (JarFile jarFile = new JarFile(path.toFile())) {
       assertThat(jarFile.entries().hasMoreElements()).isFalse();
     }
   }
 
   @Test
-  public void reflectConfig_isWritten() throws IOException {
+  void reflectConfig_isWritten() throws IOException {
     Writer.writeReflectConfigFile(
         "com.google",
         Collections.singletonList(new ReflectConfig("com.google.Class")),
@@ -70,7 +69,7 @@ public class WriterTest {
     jarOutputStream.flush();
     jarOutputStream.close();
 
-    try (JarFile jarFile = new JarFile(file)) {
+    try (JarFile jarFile = new JarFile(path.toFile())) {
       Enumeration<JarEntry> entries = jarFile.entries();
       assertThat(entries.hasMoreElements()).isTrue();
       JarEntry entry = entries.nextElement();

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protowriter/WriterTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protowriter/WriterTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertThrows;
 import com.google.api.generator.gapic.model.ReflectConfig;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
@@ -28,15 +29,14 @@ class WriterTest {
       new TypeToken<List<ReflectConfig>>() {};
 
   @TempDir Path tempDir;
-
   private JarOutputStream jarOutputStream;
-
-  private Path path;
+  private File file;
 
   @BeforeEach
   void createJarOutputStream() throws IOException {
-    path = tempDir.resolve("test.jar");
+    Path path = tempDir.resolve("test.jar");
     jarOutputStream = new JarOutputStream(Files.newOutputStream(path));
+    file = path.toFile();
   }
 
   @AfterEach
@@ -53,7 +53,7 @@ class WriterTest {
     jarOutputStream.flush();
     jarOutputStream.close();
 
-    try (JarFile jarFile = new JarFile(path.toFile())) {
+    try (JarFile jarFile = new JarFile(file)) {
       assertThat(jarFile.entries().hasMoreElements()).isFalse();
     }
   }
@@ -69,7 +69,7 @@ class WriterTest {
     jarOutputStream.flush();
     jarOutputStream.close();
 
-    try (JarFile jarFile = new JarFile(path.toFile())) {
+    try (JarFile jarFile = new JarFile(file)) {
       Enumeration<JarEntry> entries = jarFile.entries();
       assertThat(entries.hasMoreElements()).isTrue();
       JarEntry entry = entries.nextElement();

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/utils/JavaStyleTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/utils/JavaStyleTest.java
@@ -17,11 +17,11 @@ package com.google.api.generator.gapic.utils;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class JavaStyleTest {
+class JavaStyleTest {
   @Test
-  public void emptyOrNull() {
+  void emptyOrNull() {
     String value = "";
     assertEquals("", JavaStyle.toLowerCamelCase(value));
     assertEquals("", JavaStyle.toUpperCamelCase(value));
@@ -32,42 +32,42 @@ public class JavaStyleTest {
   }
 
   @Test
-  public void singleWord() {
+  void singleWord() {
     String value = "dog";
     assertEquals("dog", JavaStyle.toLowerCamelCase(value));
     assertEquals("Dog", JavaStyle.toUpperCamelCase(value));
   }
 
   @Test
-  public void fromLowerSnake() {
+  void fromLowerSnake() {
     String value = "factory_decorator_delegate_impl";
     assertEquals("factoryDecoratorDelegateImpl", JavaStyle.toLowerCamelCase(value));
     assertEquals("FactoryDecoratorDelegateImpl", JavaStyle.toUpperCamelCase(value));
   }
 
   @Test
-  public void fromUpperSnake() {
+  void fromUpperSnake() {
     String value = "FACTORY_DECORATOR_DELEGATE_IMPL";
     assertEquals("factoryDecoratorDelegateImpl", JavaStyle.toLowerCamelCase(value));
     assertEquals("FactoryDecoratorDelegateImpl", JavaStyle.toUpperCamelCase(value));
   }
 
   @Test
-  public void fromLowerCamelCase() {
+  void fromLowerCamelCase() {
     String value = "factoryDecoratorDelegateImpl";
     assertEquals("factoryDecoratorDelegateImpl", JavaStyle.toLowerCamelCase(value));
     assertEquals("FactoryDecoratorDelegateImpl", JavaStyle.toUpperCamelCase(value));
   }
 
   @Test
-  public void fromUpperCamelCase() {
+  void fromUpperCamelCase() {
     String value = "FactoryDecoratorDelegateImpl";
     assertEquals("factoryDecoratorDelegateImpl", JavaStyle.toLowerCamelCase(value));
     assertEquals("FactoryDecoratorDelegateImpl", JavaStyle.toUpperCamelCase(value));
   }
 
   @Test
-  public void wordAndNumber() {
+  void wordAndNumber() {
     String value = "dog2";
     assertEquals("dog2", JavaStyle.toLowerCamelCase(value));
     assertEquals("Dog2", JavaStyle.toUpperCamelCase(value));
@@ -77,14 +77,14 @@ public class JavaStyleTest {
   }
 
   @Test
-  public void upperWordAndNumber() {
+  void upperWordAndNumber() {
     String value = "Dog_v2";
     assertEquals("dogV2", JavaStyle.toLowerCamelCase(value));
     assertEquals("DogV2", JavaStyle.toUpperCamelCase(value));
   }
 
   @Test
-  public void upperWordAndCharsAfterDigit() {
+  void upperWordAndCharsAfterDigit() {
     String value = "dogV2cc";
     assertEquals("dogV2Cc", JavaStyle.toLowerCamelCase(value));
     assertEquals("DogV2Cc", JavaStyle.toUpperCamelCase(value));
@@ -103,7 +103,7 @@ public class JavaStyleTest {
   }
 
   @Test
-  public void acronyms() {
+  void acronyms() {
     String value = "iam_http_xml_dog";
     assertEquals("iamHttpXmlDog", JavaStyle.toLowerCamelCase(value));
     assertEquals("IamHttpXmlDog", JavaStyle.toUpperCamelCase(value));
@@ -113,7 +113,7 @@ public class JavaStyleTest {
   }
 
   @Test
-  public void keyword() {
+  void keyword() {
     String value = "import";
     assertEquals("import_", JavaStyle.toLowerCamelCase(value));
     assertEquals("Import", JavaStyle.toUpperCamelCase(value));

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/utils/ResourceReferenceUtilsTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/utils/ResourceReferenceUtilsTest.java
@@ -19,47 +19,47 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ResourceReferenceUtilsTest {
+class ResourceReferenceUtilsTest {
 
   @Test
-  public void parseParentPattern_basic() {
+  void parseParentPattern_basic() {
     String parentPattern = "projects/{project}";
     String pattern = String.format("%s/folders/{folder}", parentPattern);
     assertEquals(parentPattern, ResourceReferenceUtils.parseParentPattern(pattern).get());
   }
 
   @Test
-  public void parseParentPattern_wildcard() {
+  void parseParentPattern_wildcard() {
     Optional<String> parentPatternOpt =
         ResourceReferenceUtils.parseParentPattern(ResourceNameConstants.WILDCARD_PATTERN);
     assertFalse(parentPatternOpt.isPresent());
   }
 
   @Test
-  public void parseParentPattern_deletedTopicLiteral() {
+  void parseParentPattern_deletedTopicLiteral() {
     Optional<String> parentPatternOpt =
         ResourceReferenceUtils.parseParentPattern(ResourceNameConstants.DELETED_TOPIC_LITERAL);
     assertFalse(parentPatternOpt.isPresent());
   }
 
   @Test
-  public void parseParentPattern_noParents() {
+  void parseParentPattern_noParents() {
     Optional<String> parentPatternOpt =
         ResourceReferenceUtils.parseParentPattern("projects/{project}");
     assertFalse(parentPatternOpt.isPresent());
   }
 
   @Test
-  public void parseParentPattern_insufficientPathComponents() {
+  void parseParentPattern_insufficientPathComponents() {
     Optional<String> parentPatternOpt =
         ResourceReferenceUtils.parseParentPattern("projects/foobars/{foobar}");
     assertFalse(parentPatternOpt.isPresent());
   }
 
   @Test
-  public void parseParentPattern_lastComponentIsNotAVariable() {
+  void parseParentPattern_lastComponentIsNotAVariable() {
     Optional<String> parentPatternOpt =
         ResourceReferenceUtils.parseParentPattern("projects/{project}/foobars");
     assertTrue(parentPatternOpt.isPresent());

--- a/gapic-generator-java/src/test/java/com/google/api/generator/test/framework/Differ.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/test/framework/Differ.java
@@ -23,10 +23,10 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 
-public class Differ {
+class Differ {
   private static final String LINE_SPLITTER = "\\r?\\n";
 
-  public static List<String> diff(Path goldenFilePath, String codegen) {
+  static List<String> diff(Path goldenFilePath, String codegen) {
     List<String> revised = Arrays.asList(codegen.split(LINE_SPLITTER));
     List<String> original = null;
     try {
@@ -38,7 +38,7 @@ public class Differ {
     return diffTwoStringLists(original, revised);
   }
 
-  public static List<String> diff(String expectedStr, String actualStr) {
+  static List<String> diff(String expectedStr, String actualStr) {
     List<String> revised = Arrays.asList(actualStr.split(LINE_SPLITTER));
     List<String> original = Arrays.asList(expectedStr.split(LINE_SPLITTER));
     return diffTwoStringLists(original, revised);
@@ -60,7 +60,7 @@ public class Differ {
 
     private static final long serialVersionUID = 7423787084310530945L;
 
-    public GoldenFileReadException(String errorMessage, Throwable cause) {
+    GoldenFileReadException(String errorMessage, Throwable cause) {
       super(errorMessage, cause);
     }
   }
@@ -69,7 +69,7 @@ public class Differ {
 
     private static final long serialVersionUID = -7480557222244987342L;
 
-    public ComputeDiffException(String errorMessage, Throwable cause) {
+    ComputeDiffException(String errorMessage, Throwable cause) {
       super(errorMessage, cause);
     }
   }

--- a/gapic-generator-java/src/test/java/com/google/api/generator/test/framework/SingleJUnitTestRunner.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/test/framework/SingleJUnitTestRunner.java
@@ -18,10 +18,10 @@ import org.junit.runner.JUnitCore;
 import org.junit.runner.Request;
 import org.junit.runner.Result;
 
-public class SingleJUnitTestRunner {
+class SingleJUnitTestRunner {
   // SingleJUnitTestRunner runs single JUnit test whose class name is passed through `args`.
   // This is used to prepare codegen for updating goldens files.
-  public static void main(String... args) {
+  static void main(String... args) {
     // Check whether the test class name is passed correctly e.g.
     // `com.google.api.generator.gapic.composer.ComposerTest`
     if (args.length < 1) {
@@ -41,14 +41,14 @@ public class SingleJUnitTestRunner {
     }
   }
 
-  public static class JUnitClassNotFoundException extends RuntimeException {
-    public JUnitClassNotFoundException(String errorMessage) {
+  static class JUnitClassNotFoundException extends RuntimeException {
+    JUnitClassNotFoundException(String errorMessage) {
       super(errorMessage);
     }
   }
 
-  public static class MissingRequiredArgException extends RuntimeException {
-    public MissingRequiredArgException(String errorMessage) {
+  static class MissingRequiredArgException extends RuntimeException {
+    MissingRequiredArgException(String errorMessage) {
       super(errorMessage);
     }
   }

--- a/gapic-generator-java/src/test/java/com/google/api/generator/util/TrieTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/util/TrieTest.java
@@ -23,11 +23,11 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class TrieTest {
+class TrieTest {
   @Test
-  public void insertAndSearch_stringTrie() {
+  void insertAndSearch_stringTrie() {
     Trie<String> trie = new Trie<>();
 
     Function<String, List<String>> wordToCharListFn = w -> Arrays.asList(w.split("(?!^)"));
@@ -46,7 +46,7 @@ public class TrieTest {
   }
 
   @Test
-  public void insertAndSearch_multiStringTrie() {
+  void insertAndSearch_multiStringTrie() {
     Trie<String> trie = new Trie<>();
     assertFalse(trie.search(Arrays.asList("user", "identity", "name")));
 
@@ -67,7 +67,7 @@ public class TrieTest {
   }
 
   @Test
-  public void dfsTraverseAndReduce_emptyTrie() {
+  void dfsTraverseAndReduce_emptyTrie() {
     // Add up points in the tree, where each parent gets (num child node points) * 2 + 1.
     Function<String, Integer> parentPreprocFn = nodeVal -> new Integer(0);
     BiFunction<String, Integer, Integer> leafReduceFn =
@@ -81,7 +81,7 @@ public class TrieTest {
   }
 
   @Test
-  public void dfsTraverseAndReduce_singleNodeTrie() {
+  void dfsTraverseAndReduce_singleNodeTrie() {
     // Add up points in the tree, where each parent gets (num child node points) * 2 + 1.
     Function<String, Integer> parentPreprocFn = nodeVal -> new Integer(0);
     BiFunction<String, Integer, Integer> leafReduceFn =
@@ -96,7 +96,7 @@ public class TrieTest {
   }
 
   @Test
-  public void dfsTraverseAndReduce_oneParentOneChildBranchTrie() {
+  void dfsTraverseAndReduce_oneParentOneChildBranchTrie() {
     Function<String, String> toUpperCaseFn = s -> s.substring(0, 1).toUpperCase() + s.substring(1);
     Function<String, StringBuilder> parentPreprocFn =
         nodeVal ->
@@ -137,7 +137,7 @@ public class TrieTest {
   }
 
   @Test
-  public void dfsTraverseAndReduce_oneDeepBranchTrie() {
+  void dfsTraverseAndReduce_oneDeepBranchTrie() {
     // Add up points in the tree, where each parent gets (num child node points) * 2 + 1.
     int simpleBaseValue = 0;
     Function<String, Integer> simpleParentPreprocFn = nodeVal -> new Integer(0);
@@ -195,7 +195,7 @@ public class TrieTest {
   }
 
   @Test
-  public void dfsTraverseAndReduce_depthAndBreathTrie() {
+  void dfsTraverseAndReduce_depthAndBreathTrie() {
     Function<String, String> toUpperCaseFn = s -> s.substring(0, 1).toUpperCase() + s.substring(1);
     Function<String, StringBuilder> parentPreprocFn =
         nodeVal ->


### PR DESCRIPTION
Fixes: https://github.com/googleapis/sdk-platform-java/issues/2725

# Scope
This *only* modifies the unit tests inside the gapic-generator-java module. It does not modify the generated unit tests output from the generator. JUnit4 is still needed with default scope as it's used to generate the unit tests from the TestComposer: https://github.com/googleapis/sdk-platform-java/blob/96e6626eb2dda867b5d8d81f3ec706b5a995a3c2/gapic-generator-java/pom.xml#L446-L450

# Changes
- Change the scope for Unit Tests from public to package-private
- Parameterized tests updated to use `@ParameterizedTests`
- Import updated to `org.junit.jupiter.api.*`