### PR TITLE
chore: remove platformdirs

### DIFF
--- a/library_generation/requirements.txt
+++ b/library_generation/requirements.txt
@@ -11,7 +11,6 @@ MarkupSafe==2.1.5
 mypy-extensions==1.0.0
 packaging==23.2
 pathspec==0.12.1
-platformdirs==4.2.1
 PyYAML==6.0.1
 smmap==5.0.1
 typing==3.7.4.3


### PR DESCRIPTION
In this PR:
- Remove a redundant dependency, `platformdirs`.