### PR TITLE
chore: exclude `google-api-client-bom` from google api dependencies group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -161,7 +161,11 @@
     },
     {
       "matchPackagePatterns": [
-        "^com.google.api"
+        "com.google.api.grpc:grpc-google-common-protos",
+        "com.google.api.grpc:grpc-google-iam-v1",
+        "com.google.api.grpc:proto-google-common-protos",
+        "com.google.api.grpc:proto-google-iam-v1",
+        "com.google.api:api-common"
       ],
       "groupName": "Google API dependencies"
     },


### PR DESCRIPTION
In this PR:
- Exclude `google-api-client-bom` from google api dependencies group