### PR TITLE
fix: retain all fields during ServiceOptions.tobuilder

### DIFF
--- a/java-core/google-cloud-core/src/main/java/com/google/cloud/ServiceOptions.java
+++ b/java-core/google-cloud-core/src/main/java/com/google/cloud/ServiceOptions.java
@@ -741,22 +741,32 @@ public abstract class ServiceOptions<
   protected int baseHashCode() {
     return Objects.hash(
         projectId,
+        universeDomain,
         host,
         credentials,
         retrySettings,
         serviceFactoryClassName,
         serviceRpcFactoryClassName,
+        transportOptions,
+        headerProvider,
+        clientLibToken,
+        apiTracerFactory,
         clock,
         quotaProjectId);
   }
 
   protected boolean baseEquals(ServiceOptions<?, ?> other) {
     return Objects.equals(projectId, other.projectId)
+        && Objects.equals(universeDomain, other.universeDomain)
         && Objects.equals(host, other.host)
         && Objects.equals(credentials, other.credentials)
         && Objects.equals(retrySettings, other.retrySettings)
         && Objects.equals(serviceFactoryClassName, other.serviceFactoryClassName)
         && Objects.equals(serviceRpcFactoryClassName, other.serviceRpcFactoryClassName)
+        && Objects.equals(transportOptions, other.transportOptions)
+        && Objects.equals(headerProvider, other.headerProvider)
+        && Objects.equals(clientLibToken, other.clientLibToken)
+        && Objects.equals(apiTracerFactory, other.apiTracerFactory)
         && Objects.equals(clock, other.clock)
         && Objects.equals(quotaProjectId, other.quotaProjectId);
   }

--- a/java-core/google-cloud-core/src/main/java/com/google/cloud/ServiceOptions.java
+++ b/java-core/google-cloud-core/src/main/java/com/google/cloud/ServiceOptions.java
@@ -157,6 +157,7 @@ public abstract class ServiceOptions<
       serviceRpcFactory = options.serviceRpcFactory;
       clock = options.clock;
       transportOptions = options.transportOptions;
+      headerProvider = options.headerProvider;
       clientLibToken = options.clientLibToken;
       quotaProjectId = options.quotaProjectId;
       apiTracerFactory = options.apiTracerFactory;

--- a/java-core/google-cloud-core/src/test/java/com/google/cloud/ServiceOptionsTest.java
+++ b/java-core/google-cloud-core/src/test/java/com/google/cloud/ServiceOptionsTest.java
@@ -37,6 +37,8 @@ import com.google.api.client.testing.http.MockLowLevelHttpRequest;
 import com.google.api.client.testing.http.MockLowLevelHttpResponse;
 import com.google.api.core.ApiClock;
 import com.google.api.core.CurrentMillisClock;
+import com.google.api.gax.rpc.FixedHeaderProvider;
+import com.google.api.gax.tracing.ApiTracer;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.spi.ServiceRpcFactory;
 import com.google.common.collect.ArrayListMultimap;
@@ -204,6 +206,11 @@ class ServiceOptionsTest {
           .setProjectId("project-id")
           .setRetrySettings(ServiceOptions.getNoRetrySettings())
           .setQuotaProjectId("quota-project-id")
+          .setHeaderProvider(FixedHeaderProvider.create("testHeader", "testValue"))
+          .setUniverseDomain("test-universe-domain")
+          .setTransportOptions(new TransportOptions() {})
+          .setClientLibToken("gccl")
+          .setApiTracerFactory(((apiTracer, spanName, operationType) -> new ApiTracer() {}))
           .build();
   private static final TestServiceOptions OPTIONS_NO_CREDENTIALS =
       TestServiceOptions.newBuilder()


### PR DESCRIPTION
See #2821 

This PR originally created to ensure headerProvider is correctly copied, but expanded to ensure all fields are used in equals and hashCode comparisons for the associated copy tests.