### PR TITLE
fix: Expose Gax meter name

### DIFF
--- a/gax-java/gax/src/main/java/com/google/api/gax/tracing/OpenTelemetryMetricsRecorder.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/tracing/OpenTelemetryMetricsRecorder.java
@@ -55,6 +55,8 @@ import java.util.Map;
 @BetaApi
 @InternalApi
 public class OpenTelemetryMetricsRecorder implements MetricsRecorder {
+
+  public static final String GAX_METER_NAME = "gax-java";
   private final DoubleHistogram attemptLatencyRecorder;
   private final DoubleHistogram operationLatencyRecorder;
   private final LongCounter operationCountRecorder;
@@ -76,7 +78,7 @@ public class OpenTelemetryMetricsRecorder implements MetricsRecorder {
   public OpenTelemetryMetricsRecorder(OpenTelemetry openTelemetry, String serviceName) {
     Meter meter =
         openTelemetry
-            .meterBuilder("gax-java")
+            .meterBuilder(GAX_METER_NAME)
             .setInstrumentationVersion(GaxProperties.getGaxVersion())
             .build();
     this.attemptLatencyRecorder =


### PR DESCRIPTION
This can mitigate the ask to expose `Meter` as a constructor parameter in `OpenTelemetryMetricsRecorder`. Since `Meter` usually represents the libary that does the instrumentation, we can not expose it. However, we can expose the meter name as a public String, so that users of gax can create Otel views more easily with it.
