### PR TITLE
fix: Move the logic of getting systemProductName from static block to static method

### DIFF
--- a/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
+++ b/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
@@ -83,19 +83,7 @@ import org.threeten.bp.Duration;
  */
 public final class InstantiatingGrpcChannelProvider implements TransportChannelProvider {
 
-  static String systemProductName;
-
-  static {
-    try {
-      systemProductName =
-          Files.asCharSource(new File("/sys/class/dmi/id/product_name"), StandardCharsets.UTF_8)
-              .readFirstLine();
-    } catch (IOException e) {
-      // If not on Compute Engine, FileNotFoundException will be thrown. Use empty string
-      // as it won't match with the GCE_PRODUCTION_NAME constants
-      systemProductName = "";
-    }
-  }
+  private static String systemProductName;
 
   @VisibleForTesting
   static final Logger LOG = Logger.getLogger(InstantiatingGrpcChannelProvider.class.getName());
@@ -345,11 +333,27 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
   static boolean isOnComputeEngine() {
     String osName = System.getProperty("os.name");
     if ("Linux".equals(osName)) {
+      String systemProductName = getSystemProductName();
       // systemProductName will be empty string if not on Compute Engine
       return systemProductName.contains(GCE_PRODUCTION_NAME_PRIOR_2016)
           || systemProductName.contains(GCE_PRODUCTION_NAME_AFTER_2016);
     }
     return false;
+  }
+
+  private static String getSystemProductName() {
+    // The static field systemProductName should only be set in tests
+    if (systemProductName != null) {
+      return systemProductName;
+    }
+    try {
+      return Files.asCharSource(new File("/sys/class/dmi/id/product_name"), StandardCharsets.UTF_8)
+          .readFirstLine();
+    } catch (IOException e) {
+      // If not on Compute Engine, FileNotFoundException will be thrown. Use empty string
+      // as it won't match with the GCE_PRODUCTION_NAME constants
+      return "";
+    }
   }
 
   // Universe Domain configuration is currently only supported in the GDU


### PR DESCRIPTION
The static field `systemProductName` should only be used for testing purposes. In production environment, the logic of checking `isOnComputeEngine` should be exactly the same as before https://github.com/googleapis/sdk-platform-java/pull/2614.

Fixes b/346215860