### PR TITLE
chore: add HW repo templates

### DIFF
--- a/library_generation/owlbot/templates/java_library/.github/CODEOWNERS
+++ b/library_generation/owlbot/templates/java_library/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# Code owners file.
+# This file controls who is tagged for review for any given pull request.
+
+# For syntax help see:
+# https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
+{% if 'codeowner_team' in metadata['repo'] %}
+# The {{ metadata['repo']['codeowner_team'] }} is the default owner for changes in this repo
+*                       @googleapis/yoshi-java {{ metadata['repo']['codeowner_team'] }}
+{% if 'library_type' in metadata['repo'] and metadata['repo']['library_type'] != 'GAPIC_AUTO' %}
+# for handwritten libraries, keep codeowner_team in .repo-metadata.json as owner
+**/*.java               {{ metadata['repo']['codeowner_team'] }}
+{% endif %}
+{% else %}
+*                       @googleapis/yoshi-java
+{% endif %}
+# The java-samples-reviewers team is the default owner for samples changes
+samples/**/*.java       @googleapis/java-samples-reviewers
+
+# Generated snippets should not be owned by samples reviewers
+samples/snippets/generated/       @googleapis/yoshi-java

--- a/library_generation/owlbot/templates/java_library/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/library_generation/owlbot/templates/java_library/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,56 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+{% if migrated_split_repo %}
+:bus: This library has moved to
+[google-cloud-java/{{ metadata['repo']['repo_short'] }}](
+https://github.com/googleapis/google-cloud-java/tree/main/{{ metadata['repo']['repo_short'] }}).
+This repository will be archived in the future.
+{% endif %}
+Thanks for stopping by to let us know something could be better!
+
+**PLEASE READ**: If you have a support contract with Google, please create an issue in the [support console](https://cloud.google.com/support/) instead of filing on GitHub. This will ensure a timely response.
+
+Please run down the following list and make sure you've tried the usual "quick fixes":
+
+  - Search the issues already opened: https://github.com/googleapis/{{metadata['repo']['repo_short']}}/issues
+  - Check for answers on StackOverflow: http://stackoverflow.com/questions/tagged/google-cloud-platform
+
+If you are still having issues, please include as much information as possible:
+
+#### Environment details
+
+1. Specify the API at the beginning of the title. For example, "BigQuery: ...").
+   General, Core, and Other are also allowed as types
+2. OS type and version:
+3. Java version:
+4. {{metadata['repo']['name']}} version(s):
+
+#### Steps to reproduce
+
+  1. ?
+  2. ?
+
+#### Code example
+
+```java
+// example
+```
+
+#### Stack trace
+```
+Any relevant stacktrace here.
+```
+
+#### External references such as API reference guides
+
+- ?
+
+#### Any additional information below
+
+
+Following these steps guarantees the quickest resolution possible.
+
+Thanks!

--- a/library_generation/owlbot/templates/java_library/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/library_generation/owlbot/templates/java_library/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,26 @@
+---
+name: Feature request
+about: Suggest an idea for this library
+
+---
+{% if migrated_split_repo %}
+:bus: This library has moved to
+[google-cloud-java/{{ metadata['repo']['repo_short'] }}](
+https://github.com/googleapis/google-cloud-java/tree/main/{{ metadata['repo']['repo_short'] }}).
+This repository will be archived in the future.
+{% endif %}
+Thanks for stopping by to let us know something could be better!
+
+**PLEASE READ**: If you have a support contract with Google, please create an issue in the [support console](https://cloud.google.com/support/) instead of filing on GitHub. This will ensure a timely response.
+
+**Is your feature request related to a problem? Please describe.**
+What the problem is. Example: I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+What you want to happen.
+
+**Describe alternatives you've considered**
+Any alternative solutions or features you've considered.
+
+**Additional context**
+Any other context or screenshots about the feature request.

--- a/library_generation/owlbot/templates/java_library/.github/ISSUE_TEMPLATE/support_request.md
+++ b/library_generation/owlbot/templates/java_library/.github/ISSUE_TEMPLATE/support_request.md
@@ -1,0 +1,7 @@
+---
+name: Support request
+about: If you have a support contract with Google, please create an issue in the Google Cloud Support console.
+
+---
+
+**PLEASE READ**: If you have a support contract with Google, please create an issue in the [support console](https://cloud.google.com/support/) instead of filing on GitHub. This will ensure a timely response.

--- a/library_generation/owlbot/templates/java_library/.github/PULL_REQUEST_TEMPLATE.md
+++ b/library_generation/owlbot/templates/java_library/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
+- [ ] Make sure to open an issue as a [bug/issue](https://github.com/{{ metadata['repo']['repo'] }}/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
+- [ ] Ensure the tests and linter pass
+- [ ] Code coverage does not decrease (if any source code was changed)
+- [ ] Appropriate docs were updated (if necessary)
+
+Fixes #<issue_number_goes_here> ☕️
+
+If you write sample code, please follow the [samples format](
+https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).

--- a/library_generation/owlbot/templates/java_library/.github/auto-label.yaml
+++ b/library_generation/owlbot/templates/java_library/.github/auto-label.yaml
@@ -1,0 +1,15 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+requestsize:
+  enabled: true

--- a/library_generation/owlbot/templates/java_library/.github/blunderbuss.yml
+++ b/library_generation/owlbot/templates/java_library/.github/blunderbuss.yml
@@ -1,0 +1,7 @@
+# Configuration for the Blunderbuss GitHub app. For more info see
+# https://github.com/googleapis/repo-automation-bots/tree/main/packages/blunderbuss
+assign_prs_by:
+- labels:
+  - samples
+  to:
+  - googleapis/java-samples-reviewers

--- a/library_generation/owlbot/templates/java_library/.github/dependabot.yml
+++ b/library_generation/owlbot/templates/java_library/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    # Disable version updates for Maven dependencies
+    # we use renovate-bot as well as shared-dependencies BOM to update maven dependencies.
+    ignore:
+      - dependency-name: "*"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    # Disable version updates for pip dependencies
+    # If a security vulnerability comes in, we will be notified about 
+    # it via template in the synthtool repository.
+    ignore:
+      - dependency-name: "*"

--- a/library_generation/owlbot/templates/java_library/.github/generated-files-bot.yml
+++ b/library_generation/owlbot/templates/java_library/.github/generated-files-bot.yml
@@ -1,0 +1,12 @@
+externalManifests:
+- type: json
+  file: 'synth.metadata'
+  jsonpath: '$.generatedFiles[*]'
+- type: json
+  file: '.github/readme/synth.metadata/synth.metadata'
+  jsonpath: '$.generatedFiles[*]'
+ignoreAuthors:
+- 'renovate-bot'
+- 'yoshi-automation'
+- 'release-please[bot]'
+- 'gcf-owl-bot[bot]'

--- a/library_generation/owlbot/templates/java_library/.github/release-please.yml
+++ b/library_generation/owlbot/templates/java_library/.github/release-please.yml
@@ -1,0 +1,3 @@
+bumpMinorPreMajor: true
+handleGHRelease: true
+releaseType: java-yoshi

--- a/library_generation/owlbot/templates/java_library/.github/release-trigger.yml
+++ b/library_generation/owlbot/templates/java_library/.github/release-trigger.yml
@@ -1,0 +1,2 @@
+enabled: true
+multiScmName: {{ metadata['repo']['repo_short'] }}

--- a/library_generation/owlbot/templates/java_library/.github/sync-repo-settings.yaml
+++ b/library_generation/owlbot/templates/java_library/.github/sync-repo-settings.yaml
@@ -1,0 +1,64 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Whether or not rebase-merging is enabled on this repository.
+# Defaults to `true`
+rebaseMergeAllowed: false
+
+# Whether or not squash-merging is enabled on this repository.
+# Defaults to `true`
+squashMergeAllowed: true
+
+# Whether or not PRs are merged with a merge commit on this repository.
+# Defaults to `false`
+mergeCommitAllowed: false
+
+# Rules for main branch protection
+branchProtectionRules:
+# Identifies the protection rule pattern. Name of the branch to be protected.
+# Defaults to `main`
+- pattern: main
+  # Can admins overwrite branch protection.
+  # Defaults to `true`
+  isAdminEnforced: true
+  # Number of approving reviews required to update matching branches.
+  # Defaults to `1`
+  requiredApprovingReviewCount: 1
+  # Are reviews from code owners required to update matching branches.
+  # Defaults to `false`
+  requiresCodeOwnerReviews: true
+  # Require up to date branches
+  requiresStrictStatusChecks: false
+  # List of required status check contexts that must pass for commits to be accepted to matching branches.
+  requiredStatusCheckContexts:
+  - "dependencies (17)"
+  - "lint"
+  - "javadoc"
+  - "units (8)"
+  - "units (11)"
+  - "Kokoro - Test: Integration"
+  - "cla/google"
+  - "OwlBot Post Processor"
+  - "Kokoro - Test: Java GraalVM Native Image"
+  - "Kokoro - Test: Java 17 GraalVM Native Image"
+# List of explicit permissions to add (additive only)
+permissionRules:
+- team: yoshi-admins
+  permission: admin
+- team: yoshi-java-admins
+  permission: admin
+- team: yoshi-java
+  permission: push
+- team: java-samples-reviewers
+  permission: push
+

--- a/library_generation/owlbot/templates/java_library/.github/workflows/approve-readme.yaml
+++ b/library_generation/owlbot/templates/java_library/.github/workflows/approve-readme.yaml
@@ -1,0 +1,69 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Github action job to test core java library features on
+# downstream client libraries before they are released.
+on:
+  pull_request:
+name: auto-merge-readme
+jobs:
+  approve:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'googleapis' && github.head_ref == 'autosynth-readme'
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          github-token: {{ '${{secrets.YOSHI_APPROVER_TOKEN}}' }}
+          script: |
+            // only approve PRs from yoshi-automation
+            if (context.payload.pull_request.user.login !== "yoshi-automation") {
+              return;
+            }
+
+            // only approve PRs like "chore: release <release version>"
+            if (!context.payload.pull_request.title === "chore: regenerate README") {
+              return;
+            }
+
+            // only approve PRs with README.md and synth.metadata changes
+            const files = new Set(
+              (
+                await github.paginate(
+                  github.pulls.listFiles.endpoint({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: context.payload.pull_request.number,
+                  })
+                )
+              ).map(file => file.filename)
+            );
+            if (files.size != 2 || !files.has("README.md") || !files.has(".github/readme/synth.metadata/synth.metadata")) {
+              return;
+            }
+
+            // approve README regeneration PR
+            await github.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Rubber stamped PR!',
+              pull_number: context.payload.pull_request.number,
+              event: 'APPROVE'
+            });
+
+            // attach automerge label
+            await github.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: ['automerge']
+            });

--- a/library_generation/owlbot/templates/java_library/.github/workflows/ci.yaml
+++ b/library_generation/owlbot/templates/java_library/.github/workflows/ci.yaml
@@ -1,0 +1,123 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Github action job to test core java library features on
+# downstream client libraries before they are released.
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+name: ci
+jobs:
+  units:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [11, 17, 21]
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: ${{'{{matrix.java}}'}}
+    - run: java -version
+    - run: .kokoro/build.sh
+      env:
+        JOB_TYPE: test
+  units-java8:
+    # Building using Java 17 and run the tests with Java 8 runtime
+    name: "units (8)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 8
+          distribution: temurin
+      - name: "Set jvm system property environment variable for surefire plugin (unit tests)"
+        # Maven surefire plugin (unit tests) allows us to specify JVM to run the tests.
+        # https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#jvm
+        run: echo "SUREFIRE_JVM_OPT=-Djvm=${JAVA_HOME}/bin/java" >> $GITHUB_ENV
+        shell: bash
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: temurin
+      - run: .kokoro/build.sh
+        env:
+          JOB_TYPE: test
+  windows:
+    runs-on: windows-latest
+    steps:
+    - name: Support longpaths
+      run: git config --system core.longpaths true
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: 8
+    - run: java -version
+    - run: .kokoro/build.bat
+      env:
+        JOB_TYPE: test
+  dependencies:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [17]
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: ${{'{{matrix.java}}'}}
+    - run: java -version
+    - run: .kokoro/dependencies.sh
+  javadoc:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: 17
+    - run: java -version
+    - run: .kokoro/build.sh
+      env:
+        JOB_TYPE: javadoc
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: 11
+    - run: java -version
+    - run: .kokoro/build.sh
+      env:
+        JOB_TYPE: lint
+  clirr:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: 8
+    - run: java -version
+    - run: .kokoro/build.sh
+      env:
+        JOB_TYPE: clirr

--- a/library_generation/owlbot/templates/java_library/.github/workflows/renovate_config_check.yaml
+++ b/library_generation/owlbot/templates/java_library/.github/workflows/renovate_config_check.yaml
@@ -1,0 +1,25 @@
+name: Renovate Bot Config Validation
+
+on:
+  pull_request:
+    paths:
+      - 'renovate.json'
+
+jobs:
+  renovate_bot_config_validation:
+    runs-on: ubuntu-22.04
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - name: Install Renovate and Config Validator
+      run: |
+        npm install -g npm@latest
+        npm install --global renovate
+        renovate-config-validator

--- a/library_generation/owlbot/templates/java_library/.github/workflows/samples.yaml
+++ b/library_generation/owlbot/templates/java_library/.github/workflows/samples.yaml
@@ -1,0 +1,30 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Github action job to test core java library features on
+# downstream client libraries before they are released.
+on:
+  pull_request:
+name: samples
+jobs:
+  checkstyle:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 8
+      - name: Run checkstyle
+        run: mvn -P lint --quiet --batch-mode checkstyle:check
+        working-directory: samples/snippets

--- a/library_generation/owlbot/templates/java_library/.kokoro/build.sh
+++ b/library_generation/owlbot/templates/java_library/.kokoro/build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+cd github/synthtool
+
+# Disable buffering, so that the logs stream through.
+export PYTHONUNBUFFERED=1
+
+# Run tests
+nox -s lint test
+
+# remove all files, preventing kokoro from trying to sync them.
+rm -rf *

--- a/library_generation/owlbot/templates/java_library/.kokoro/common.cfg
+++ b/library_generation/owlbot/templates/java_library/.kokoro/common.cfg
@@ -1,0 +1,19 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Download trampoline resources.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
+
+# Use the trampoline script to run in docker.
+build_file: "synthtool/.kokoro/trampoline.sh"
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/python"
+}
+
+# Tell the trampoline which build file to use.
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/synthtool/.kokoro/build.sh"
+}

--- a/library_generation/owlbot/templates/java_library/.kokoro/continuous.cfg
+++ b/library_generation/owlbot/templates/java_library/.kokoro/continuous.cfg
@@ -1,0 +1,1 @@
+# Format: //devtools/kokoro/config/proto/build.proto

--- a/library_generation/owlbot/templates/java_library/.kokoro/presubmit.cfg
+++ b/library_generation/owlbot/templates/java_library/.kokoro/presubmit.cfg
@@ -1,0 +1,1 @@
+# Format: //devtools/kokoro/config/proto/build.proto

--- a/library_generation/owlbot/templates/java_library/.kokoro/trampoline.sh
+++ b/library_generation/owlbot/templates/java_library/.kokoro/trampoline.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -eo pipefail
+# Always run the cleanup script, regardless of the success of bouncing into
+# the container.
+function cleanup() {
+    chmod +x ${KOKORO_GFILE_DIR}/trampoline_cleanup.sh
+    ${KOKORO_GFILE_DIR}/trampoline_cleanup.sh
+    echo "cleanup";
+}
+trap cleanup EXIT
+python3 "${KOKORO_GFILE_DIR}/trampoline_v1.py"


### PR DESCRIPTION
In this PR we add the `.github` and `.kokoro` folders to
`library_generation/owlbot/templates/java_library` in order to enable
the hermetic build workflows in HW libraries.

The templates come from https://github.com/googleapis/synthtool/commit/dae1282201b64e4da3ad512632cb4dda70a832a1

**The hermetic build templates will come in a separate PR**