### PR TITLE
fix: restore hermetic build image publication

### DIFF
--- a/.cloudbuild/library_generation/cloudbuild-library-generation-push.yaml
+++ b/.cloudbuild/library_generation/cloudbuild-library-generation-push.yaml
@@ -15,7 +15,7 @@
 timeout: 7200s # 2 hours
 substitutions:
   _IMAGE_NAME: "gcr.io/cloud-devrel-public-resources/java-library-generation"
-  _GAPIC_GENERATOR_JAVA_VERSION: '2.41.1-SNAPSHOT' # {x-version-update:gapic-generator-java:current}
+  _GAPIC_GENERATOR_JAVA_VERSION: '2.42.0' # {x-version-update:gapic-generator-java:current}
   _SHA_IMAGE_ID: "${_IMAGE_NAME}:${COMMIT_SHA}"
   _LATEST_IMAGE_ID: "${_IMAGE_NAME}:latest"
   _VERSIONED_IMAGE_ID: "${_IMAGE_NAME}:${_GAPIC_GENERATOR_JAVA_VERSION}"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,7 @@
         ".cloudbuild/graalvm/cloudbuild.yaml",
         ".cloudbuild/graalvm/cloudbuild-test-a.yaml",
         ".cloudbuild/graalvm/cloudbuild-test-b.yaml",
-        ".cloudbuild/library_generation/cloudbuild-library-generation-release.yaml",
+        ".cloudbuild/library_generation/cloudbuild-library-generation-push.yaml",
         "generation_config.yaml"
       ]
     }


### PR DESCRIPTION
So far, the Release Please config did not consider `.cloudbuild/library_generation/cloudbuild-library-generation-push.yaml` to update the tags.

This PR fixes this and also updates the image tag to the current one (2.42.0).

### Follow ups
 - [ ] Restore the image tag to the current SNAPSHOT