### PR TITLE
chore: restore hermetic image tag to current SNAPSHOT

### DIFF
--- a/.cloudbuild/library_generation/cloudbuild-library-generation-push.yaml
+++ b/.cloudbuild/library_generation/cloudbuild-library-generation-push.yaml
@@ -15,7 +15,7 @@
 timeout: 7200s # 2 hours
 substitutions:
   _IMAGE_NAME: "gcr.io/cloud-devrel-public-resources/java-library-generation"
-  _GAPIC_GENERATOR_JAVA_VERSION: '2.42.0' # {x-version-update:gapic-generator-java:current}
+  _GAPIC_GENERATOR_JAVA_VERSION: '2.42.1-SNAPSHOT' # {x-version-update:gapic-generator-java:current}
   _SHA_IMAGE_ID: "${_IMAGE_NAME}:${COMMIT_SHA}"
   _LATEST_IMAGE_ID: "${_IMAGE_NAME}:latest"
   _VERSIONED_IMAGE_ID: "${_IMAGE_NAME}:${_GAPIC_GENERATOR_JAVA_VERSION}"


### PR DESCRIPTION
This is a follow up of https://github.com/googleapis/sdk-platform-java/pull/2952
