### PR TITLE
chore: revert disable renovate for grpc and guava versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -96,8 +96,7 @@
       "matchPackagePatterns": [
         "^com.google.guava:"
       ],
-      "versioning": "docker",
-      "enabled": false
+      "versioning": "docker"
     },
     {
       "matchPackagePatterns": [
@@ -163,8 +162,7 @@
       "matchPackagePatterns": [
         "^io.grpc"
       ],
-      "groupName": "gRPC dependencies",
-      "enabled": false
+      "groupName": "gRPC dependencies"
     },
     {
       "matchPackagePatterns": [


### PR DESCRIPTION
Reverts googleapis/sdk-platform-java#2618 now that https://github.com/apache/beam/releases/tag/v2.57.0 is out