### PR TITLE
fix: improve warnings for Direct Path xDS set via env

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,7 @@ jobs:
         # Set the Env Var for this step only
         env:
           GOOGLE_CLOUD_UNIVERSE_DOMAIN: random.com
+          GOOGLE_CLOUD_ENABLE_DIRECT_PATH_XDS: true
       - run: bazelisk version
       - name: Install Maven modules
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,6 +81,7 @@ jobs:
         # Set the Env Var for this step only
         env:
           GOOGLE_CLOUD_UNIVERSE_DOMAIN: random.com
+          GOOGLE_CLOUD_ENABLE_DIRECT_PATH_XDS: true
       - run: bazelisk version
       - name: Install Maven modules
         run: |
@@ -131,6 +132,7 @@ jobs:
         # Set the Env Var for this step only
         env:
           GOOGLE_CLOUD_UNIVERSE_DOMAIN: random.com
+          GOOGLE_CLOUD_ENABLE_DIRECT_PATH_XDS: true
 
   build-java8-gapic-generator-java:
     name: "build(8) for gapic-generator-java"

--- a/gax-java/gax-grpc/pom.xml
+++ b/gax-java/gax-grpc/pom.xml
@@ -128,6 +128,30 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <!-- These tests require an Env Var to be set. Use -PenvVarTest to ONLY run these tests -->
+          <test>!InstantiatingGrpcChannelProviderTest#testLogDirectPathMisconfig_AttemptDirectPathNotSetAndAttemptDirectPathXdsSetViaEnv_warns</test>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>envVarTest</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <test>InstantiatingGrpcChannelProviderTest#testLogDirectPathMisconfig_AttemptDirectPathNotSetAndAttemptDirectPathXdsSetViaEnv_warns</test>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
+++ b/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
@@ -296,8 +296,9 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
   private void logDirectPathMisconfig() {
     if (isDirectPathXdsEnabled()) {
       if (!isDirectPathEnabled()) {
-        // Only two cases are possible: Direct path xDS enabled via env var or via builder.
-        // Case 1: Direct Path is only enabled via XDS env var. We will _warn_ the user that this is
+        // This misconfiguration occurs when Direct Path xDS is enabled, but Direct Path is not
+        // Direct Path xDS can be enabled two ways: via environment variable or via builder.
+        // Case 1: Direct Path is only enabled via xDS env var. We will _warn_ the user that this is
         // a misconfiguration if they intended to set the env var.
         if (isDirectPathXdsEnabledViaEnv()) {
           LOG.log(

--- a/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
+++ b/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
@@ -297,8 +297,7 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
     if (isDirectPathXdsEnabled()) {
       if (!isDirectPathEnabled()) {
         // Case 1: Direct Path is only enabled via XDS env var. We will _warn_ the user that this is
-        // a
-        // misconfiguration if they intended to set the env var.
+        // a misconfiguration if they intended to set the env var.
         if (isDirectPathXdsEnabledViaEnv()) {
           LOG.log(
               Level.WARNING,
@@ -314,7 +313,7 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
               "DirectPath is misconfigured. Please set the attemptDirectPath option along with the"
                   + " attemptDirectPathXds option.");
         } else {
-        } // impossible
+        } // impossible - added this `else` for readability.
       } else {
         // Case 3: credential is not correctly set
         if (!isCredentialDirectPathCompatible()) {

--- a/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
+++ b/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
@@ -308,7 +308,8 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
                   + " was found and set to TRUE, but DirectPath was not enabled for this client. If this is intended for "
                   + "this client, please note that this is a misconfiguration and set the attemptDirectPath option as well.");
         }
-        // Case 2: Direct Path xDS was enabled via Builder. Direct Path Traffic Director must be set (enabled with `setAttemptDirectPath(true)`) along with xDS.
+        // Case 2: Direct Path xDS was enabled via Builder. Direct Path Traffic Director must be set
+        // (enabled with `setAttemptDirectPath(true)`) along with xDS.
         // Here we warn the user about this.
         else if (isDirectPathXdsEnabledViaBuilderOption()) {
           LOG.log(

--- a/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
+++ b/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
@@ -308,8 +308,7 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
                   + " was found and set to TRUE, but DirectPath was not enabled for this client. If this is intended for "
                   + "this client, please note that this is a misconfiguration and set the attemptDirectPath option as well.");
         }
-        // Case 2: Direct Path xDS was enabled via Builder. Direct Path TD (via gRPCLB) must be set
-        // along with xDS.
+        // Case 2: Direct Path xDS was enabled via Builder. Direct Path Traffic Director must be set (enabled with `setAttemptDirectPath(true)`) along with xDS.
         // Here we warn the user about this.
         else if (isDirectPathXdsEnabledViaBuilderOption()) {
           LOG.log(

--- a/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
+++ b/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
@@ -315,8 +315,8 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
       else if (!isDirectPathEnabled()) {
         LOG.log(
             Level.WARNING,
-            "DirectPath is misconfigured. Please set both the "
-                + "attemptDirectPath and the attemptDirectPathXds options.");
+            "DirectPath is misconfigured. Please set the attemptDirectPath option along with the"
+                + " attemptDirectPathXds option.");
       } else {
         // Case 3: credential is not correctly set
         if (!isCredentialDirectPathCompatible()) {

--- a/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
+++ b/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
@@ -296,6 +296,7 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
   private void logDirectPathMisconfig() {
     if (isDirectPathXdsEnabled()) {
       if (!isDirectPathEnabled()) {
+        // Only two cases are possible: Direct path xDS enabled via env var or via builder.
         // Case 1: Direct Path is only enabled via XDS env var. We will _warn_ the user that this is
         // a misconfiguration if they intended to set the env var.
         if (isDirectPathXdsEnabledViaEnv()) {
@@ -306,13 +307,14 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
                   + " was found and set to TRUE, but DirectPath was not enabled for this client. If this is intended for "
                   + "this client, please note that this is a misconfiguration and set the attemptDirectPath option as well.");
         }
-        // Case 2: Direct Path TD must be set along with xDS. Here we warn the user about this.
+        // Case 2: Direct Path xDS was enabled via Builder. Direct Path TD (via gRPCLB) must be set
+        // along with xDS.
+        // Here we warn the user about this.
         else if (isDirectPathXdsEnabledViaBuilderOption()) {
           LOG.log(
               Level.WARNING,
               "DirectPath is misconfigured. The DirectPath XDS option was set, but the attemptDirectPath option was not. Please set both the attemptDirectPath and attemptDirectPathXds options.");
-        } else {
-        } // impossible - added this `else` for readability.
+        }
       } else {
         // Case 3: credential is not correctly set
         if (!isCredentialDirectPathCompatible()) {

--- a/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
+++ b/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
@@ -310,8 +310,7 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
         else if (isDirectPathXdsEnabledViaBuilderOption()) {
           LOG.log(
               Level.WARNING,
-              "DirectPath is misconfigured. Please set the attemptDirectPath option along with the"
-                  + " attemptDirectPathXds option.");
+              "DirectPath is misconfigured. The DirectPath XDS option was set, but the attemptDirectPath option was not. Please set both the attemptDirectPath and attemptDirectPathXds options.");
         } else {
         } // impossible - added this `else` for readability.
       } else {

--- a/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
+++ b/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
@@ -285,6 +285,13 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
     return Boolean.parseBoolean(directPathXdsEnv);
   }
 
+  /**
+   * This method tells if Direct Path xDS was enabled. There are two ways of enabling it: via
+   * environment variable (by setting GOOGLE_CLOUD_ENABLE_DIRECT_PATH_XDS=true) or when building
+   * this channel provider (via the {@link Builder#setAttemptDirectPathXds()} method).
+   *
+   * @return true if Direct Path xDS was either enabled via env var or via builder option
+   */
   @InternalApi
   public boolean isDirectPathXdsEnabled() {
     return isDirectPathXdsEnabledViaEnv() || isDirectPathXdsEnabledViaBuilderOption();

--- a/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
+++ b/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
@@ -303,7 +303,7 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
               Level.WARNING,
               "Env var "
                   + DIRECT_PATH_ENV_ENABLE_XDS
-                  + " was found. If this is intended for "
+                  + " was found and set to TRUE, but DirectPath was not enabled for this client. If this is intended for "
                   + "this client, please note that this is a misconfiguration and set the attemptDirectPath option as well.");
         }
         // Case 2: Direct Path TD must be set along with xDS. Here we warn the user about this.

--- a/gax-java/gax-grpc/src/test/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProviderTest.java
+++ b/gax-java/gax-grpc/src/test/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProviderTest.java
@@ -620,7 +620,7 @@ class InstantiatingGrpcChannelProviderTest extends AbstractMtlsTransportChannelT
     createAndCloseTransportChannel(provider);
     assertThat(logHandler.getAllMessages())
         .contains(
-            "DirectPath is misconfigured. Please set both the attemptDirectPath and the attemptDirectPathXds options.");
+            "DirectPath is misconfigured. Please set the attemptDirectPath option along with the attemptDirectPathXds option.");
     InstantiatingGrpcChannelProvider.LOG.removeHandler(logHandler);
   }
 

--- a/gax-java/gax-grpc/src/test/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProviderTest.java
+++ b/gax-java/gax-grpc/src/test/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProviderTest.java
@@ -641,21 +641,6 @@ class InstantiatingGrpcChannelProviderTest extends AbstractMtlsTransportChannelT
   }
 
   @Test
-  void testLogDirectPathMisconfig_AttemptDirectPathSetAndAttemptDirectPathXdsNotSet_warns()
-      throws Exception {
-    FakeLogHandler logHandler = new FakeLogHandler();
-    InstantiatingGrpcChannelProvider.LOG.addHandler(logHandler);
-    InstantiatingGrpcChannelProvider provider =
-        createChannelProviderBuilderForDirectPathLogTests().setAttemptDirectPath(true).build();
-    createAndCloseTransportChannel(provider);
-    assertThat(logHandler.getAllMessages())
-        .contains(
-            "DirectPath is misconfigured. Please set both the attemptDirectPath and the "
-                + "attemptDirectPathXds options.");
-    InstantiatingGrpcChannelProvider.LOG.removeHandler(logHandler);
-  }
-
-  @Test
   void testLogDirectPathMisconfig_shouldNotLogInTheBuilder() {
     FakeLogHandler logHandler = new FakeLogHandler();
     InstantiatingGrpcChannelProvider.LOG.addHandler(logHandler);

--- a/gax-java/gax-grpc/src/test/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProviderTest.java
+++ b/gax-java/gax-grpc/src/test/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProviderTest.java
@@ -620,7 +620,7 @@ class InstantiatingGrpcChannelProviderTest extends AbstractMtlsTransportChannelT
     createAndCloseTransportChannel(provider);
     assertThat(logHandler.getAllMessages())
         .contains(
-            "DirectPath is misconfigured. Please set the attemptDirectPath option along with the attemptDirectPathXds option.");
+            "DirectPath is misconfigured. The DirectPath XDS option was set, but the attemptDirectPath option was not. Please set both the attemptDirectPath and attemptDirectPathXds options.");
     InstantiatingGrpcChannelProvider.LOG.removeHandler(logHandler);
   }
 

--- a/gax-java/gax-grpc/src/test/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProviderTest.java
+++ b/gax-java/gax-grpc/src/test/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProviderTest.java
@@ -635,8 +635,8 @@ class InstantiatingGrpcChannelProviderTest extends AbstractMtlsTransportChannelT
     createAndCloseTransportChannel(provider);
     assertThat(logHandler.getAllMessages())
         .contains(
-            "Env var GOOGLE_CLOUD_ENABLE_DIRECT_PATH_XDS was found. If this is intended for this client, please note "
-                + "that this is a misconfiguration and set the attemptDirectPath option as well.");
+            "Env var GOOGLE_CLOUD_ENABLE_DIRECT_PATH_XDS was found and set to TRUE, but DirectPath was not enabled for this client. If this is intended for "
+                + "this client, please note that this is a misconfiguration and set the attemptDirectPath option as well.");
     InstantiatingGrpcChannelProvider.LOG.removeHandler(logHandler);
   }
 


### PR DESCRIPTION
Fixes #2427

### Context
If `GOOGLE_CLOUD_ENABLE_DIRECT_PATH_XDS` is set in the environment aiming to enable Direct Path xDS in another client, we want to just warn the user that _if this is intended_, it can be a misconfiguration and that the gRPCLB Direct Path setting should be enabled as well.

### Approach
As said in the context, we will _warn_ the user that it _could_ be a misconfiguration _if_ the env var setting was meant for the client in question. Other warn cases remain the same.

### Coverage
Due to the fact that part of the method in question is tested via a special env var test (not detected by SonarCloud), it will show as uncovered. See this screenshot for coverage of all tests combined
![image](https://github.com/googleapis/sdk-platform-java/assets/22083784/af24e721-6495-4030-8804-c013b14679d7)
