### PR TITLE
chore: Revert disable renovate for protobuf dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -155,8 +155,7 @@
         "^com.google.protobuf",
 		"^protocolbuffers/protobuf"
       ],
-      "groupName": "Protobuf dependencies",
-      "enabled": false
+      "groupName": "Protobuf dependencies"
     },
     {
       "matchPackagePatterns": [


### PR DESCRIPTION
Reverts googleapis/sdk-platform-java#2666 now that https://github.com/apache/beam/releases/tag/v2.57.0 is out