### PR TITLE
chore: move the `attemptFailed` logic from BaseApiTracer to ApiTracer

### DIFF
--- a/gax-java/gax/src/main/java/com/google/api/gax/tracing/ApiTracer.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/tracing/ApiTracer.java
@@ -120,15 +120,14 @@ public interface ApiTracer {
   /**
    * Adds an annotation that the attempt failed, but another attempt will be made after the delay.
    *
-   * <p>Defaults to do the same as {@link #attemptFailed(Throwable, org.threeten.bp.Duration)}. This
-   * is because customers may have older/legacy code that directly implements {@link
-   * #attemptFailed(Throwable, org.threeten.bp.Duration)} and their overridden logic should be
-   * invoked in gax.
-   *
    * @param error the transient error that caused the attempt to fail.
    * @param delay the amount of time to wait before the next attempt will start.
    */
   default void attemptFailedDuration(Throwable error, java.time.Duration delay) {
+    // Defaults to do the same as attemptFailed(Throwable, org.threeten.bp.Duration). This
+    // is because customers may have older/legacy code that directly implements
+    // attemptFailed(Throwable, org.threeten.bp.Duration)} and their overridden logic should be
+    // invoked in gax.
     attemptFailed(error, toThreetenDuration(delay));
   };
 

--- a/gax-java/gax/src/main/java/com/google/api/gax/tracing/ApiTracer.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/tracing/ApiTracer.java
@@ -29,6 +29,8 @@
  */
 package com.google.api.gax.tracing;
 
+import static com.google.api.gax.util.TimeConversionUtils.toThreetenDuration;
+
 import com.google.api.core.InternalApi;
 import com.google.api.core.ObsoleteApi;
 
@@ -123,7 +125,7 @@ public interface ApiTracer {
    */
   default void attemptFailedDuration(Throwable error, java.time.Duration delay) {
     // defaults to do the same as attemptFailed(Throwable, org.threeten.bp.Duration)
-    //    attemptFailed(error, toThreetenDuration(delay));
+    attemptFailed(error, toThreetenDuration(delay));
   };
 
   /**

--- a/gax-java/gax/src/main/java/com/google/api/gax/tracing/ApiTracer.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/tracing/ApiTracer.java
@@ -120,11 +120,15 @@ public interface ApiTracer {
   /**
    * Adds an annotation that the attempt failed, but another attempt will be made after the delay.
    *
+   * <p>Defaults to do the same as {@link #attemptFailed(Throwable, org.threeten.bp.Duration)}. This
+   * is because customers may have older/legacy code that directly implements {@link
+   * #attemptFailed(Throwable, org.threeten.bp.Duration)} and their overridden logic should be
+   * invoked in gax.
+   *
    * @param error the transient error that caused the attempt to fail.
    * @param delay the amount of time to wait before the next attempt will start.
    */
   default void attemptFailedDuration(Throwable error, java.time.Duration delay) {
-    // defaults to do the same as attemptFailed(Throwable, org.threeten.bp.Duration)
     attemptFailed(error, toThreetenDuration(delay));
   };
 

--- a/gax-java/gax/src/main/java/com/google/api/gax/tracing/ApiTracer.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/tracing/ApiTracer.java
@@ -121,7 +121,10 @@ public interface ApiTracer {
    * @param error the transient error that caused the attempt to fail.
    * @param delay the amount of time to wait before the next attempt will start.
    */
-  default void attemptFailedDuration(Throwable error, java.time.Duration delay) {};
+  default void attemptFailedDuration(Throwable error, java.time.Duration delay) {
+    // defaults to do the same as attemptFailed(Throwable, org.threeten.bp.Duration)
+    //    attemptFailed(error, toThreetenDuration(delay));
+  };
 
   /**
    * Adds an annotation that the attempt failed and that no further attempts will be made because

--- a/gax-java/gax/src/main/java/com/google/api/gax/tracing/BaseApiTracer.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/tracing/BaseApiTracer.java
@@ -29,8 +29,6 @@
  */
 package com.google.api.gax.tracing;
 
-import static com.google.api.gax.util.TimeConversionUtils.toThreetenDuration;
-
 import com.google.api.core.InternalApi;
 import com.google.api.core.ObsoleteApi;
 
@@ -108,7 +106,7 @@ public class BaseApiTracer implements ApiTracer {
   @Override
   public void attemptFailedDuration(Throwable error, java.time.Duration delay) {
     // noop via attemptFailed(Throwable error, org.threeten.Duration)
-    attemptFailed(error, toThreetenDuration(delay));
+    //    attemptFailed(error, toThreetenDuration(delay));
   }
 
   /**

--- a/gax-java/gax/src/main/java/com/google/api/gax/tracing/BaseApiTracer.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/tracing/BaseApiTracer.java
@@ -103,12 +103,6 @@ public class BaseApiTracer implements ApiTracer {
     // noop
   }
 
-  @Override
-  public void attemptFailedDuration(Throwable error, java.time.Duration delay) {
-    // noop via attemptFailed(Throwable error, org.threeten.Duration)
-    //    attemptFailed(error, toThreetenDuration(delay));
-  }
-
   /**
    * This method is obsolete. Use {@link #attemptFailedDuration(Throwable, java.time.Duration)}
    * instead.


### PR DESCRIPTION
Follow up of https://github.com/googleapis/sdk-platform-java/pull/3016

On `bigtable` and `spanner`:
![image](https://github.com/googleapis/sdk-platform-java/assets/22083784/696c0cec-e83b-4563-a9fe-7f6a249f7bc6)
![image](https://github.com/googleapis/sdk-platform-java/assets/22083784/6170cb3b-2e18-478c-b1ff-9cef5f869dd0)


Thanks @blakeli0 and @lqiu96 for the directions.