### PR TITLE
chore: renovate bot should ignore requirement.txt

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
   "ignoreDeps": [
     "rules_pkg"
   ],
+  "ignorePaths": ["^library_generation/requirements\\.txt$"],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
Context: https://github.com/googleapis/sdk-platform-java/pull/3033/files
This [requirement.txt](https://github.com/googleapis/sdk-platform-java/blob/e8deeaf226149d2ae6f8424d7f738273d799dcde/library_generation/requirements.txt#L1-L6) is auto generated and should not be updated by renovate bot.
