### PR TITLE
docs: Update the Javadoc of ObsoleteApi.java

### DIFF
--- a/api-common-java/src/main/java/com/google/api/core/ObsoleteApi.java
+++ b/api-common-java/src/main/java/com/google/api/core/ObsoleteApi.java
@@ -60,6 +60,6 @@ import java.lang.annotation.Target;
 })
 @Documented
 public @interface ObsoleteApi {
-  /** Context information such as links to a discussion thread, tracking issue, etc. */
+  /** Context information such as reasons and alternatives.*/
   String value();
 }


### PR DESCRIPTION
Update the Javadoc of ObsoleteApi.java. It's preferred to provide reasons and alternatives directly in the description, rather than links, as links are not stable.

