### PR TITLE
chore: remove image tag in hermetic code generation workflow

### DIFF
--- a/.github/scripts/hermetic_library_generation.sh
+++ b/.github/scripts/hermetic_library_generation.sh
@@ -22,7 +22,6 @@ set -e
 # The parameters of this script is:
 # 1. target_branch, the branch into which the pull request is merged.
 # 2. current_branch, the branch with which the pull request is associated.
-# 3. image_tag, the tag of gcr.io/cloud-devrel-public-resources/java-library-generation.
 # 3. [optional] generation_config, the path to the generation configuration,
 # the default value is generation_config.yaml in the repository root.
 while [[ $# -gt 0 ]]; do
@@ -34,10 +33,6 @@ case "${key}" in
     ;;
   --current_branch)
     current_branch="$2"
-    shift
-    ;;
-  --image_tag)
-    image_tag="$2"
     shift
     ;;
   --generation_config)
@@ -62,16 +57,12 @@ if [ -z "${current_branch}" ]; then
   exit 1
 fi
 
-if [ -z "${image_tag}" ]; then
-  echo "missing required argument --image_tag"
-  exit 1
-fi
-
 if [ -z "${generation_config}" ]; then
   generation_config=generation_config.yaml
   echo "Use default generation config: ${generation_config}"
 fi
 
+image_tag=local
 workspace_name="/workspace"
 baseline_generation_config="baseline_generation_config.yaml"
 docker_file="library_generation.Dockerfile"

--- a/.github/workflows/hermetic_library_generation.yaml
+++ b/.github/workflows/hermetic_library_generation.yaml
@@ -35,8 +35,7 @@ jobs:
         [ -z "$(git config user.name)" ] && git config --global user.name "cloud-java-bot"
         bash .github/scripts/hermetic_library_generation.sh \
           --target_branch "${base_ref}" \
-          --current_branch "${head_ref}" \
-          --image_tag latest
+          --current_branch "${head_ref}"
       env:
         base_ref: ${{ github.base_ref }}
         head_ref: ${{ github.head_ref }}

--- a/generation_config.yaml
+++ b/generation_config.yaml
@@ -39,3 +39,4 @@ libraries:
   GAPICs:
   - proto_path: google/iam/v1
   - proto_path: google/iam/v2
+  - proto_path: google/iam/v2beta

--- a/generation_config.yaml
+++ b/generation_config.yaml
@@ -39,4 +39,3 @@ libraries:
   GAPICs:
   - proto_path: google/iam/v1
   - proto_path: google/iam/v2
-  - proto_path: google/iam/v2beta


### PR DESCRIPTION
In this PR:
- remove the image tag in the hermetic code generation workflow.