### PR TITLE
feat: add toString to futures returned by operations

### DIFF
--- a/api-common-java/src/main/java/com/google/api/core/ApiFutureToListenableFuture.java
+++ b/api-common-java/src/main/java/com/google/api/core/ApiFutureToListenableFuture.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.core;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.util.concurrent.ListenableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
@@ -73,5 +74,12 @@ public class ApiFutureToListenableFuture<V> implements ListenableFuture<V> {
   public V get(long l, TimeUnit timeUnit)
       throws InterruptedException, ExecutionException, TimeoutException {
     return apiFuture.get(l, timeUnit);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(ApiFutureToListenableFuture.class.getSimpleName())
+        .add("apiFuture", apiFuture)
+        .toString();
   }
 }

--- a/api-common-java/src/main/java/com/google/api/core/ListenableFutureToApiFuture.java
+++ b/api-common-java/src/main/java/com/google/api/core/ListenableFutureToApiFuture.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.core;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.util.concurrent.ForwardingListenableFuture.SimpleForwardingListenableFuture;
 import com.google.common.util.concurrent.ListenableFuture;
 
@@ -38,5 +39,11 @@ public class ListenableFutureToApiFuture<V> extends SimpleForwardingListenableFu
     implements ApiFuture<V> {
   public ListenableFutureToApiFuture(ListenableFuture<V> delegate) {
     super(delegate);
+  }
+
+  public String toString() {
+    return MoreObjects.toStringHelper(ListenableFutureToApiFuture.class)
+        .add("delegate", delegate())
+        .toString();
   }
 }

--- a/api-common-java/src/test/java/com/google/api/core/ApiFutureToListenableFutureTest.java
+++ b/api-common-java/src/test/java/com/google/api/core/ApiFutureToListenableFutureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, Google Inc.
+ * Copyright 2024, Google Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -29,35 +29,26 @@
  */
 package com.google.api.core;
 
-import com.google.common.truth.Truth;
-import com.google.common.util.concurrent.AbstractFuture;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
-import org.junit.jupiter.api.Test;
+import static com.google.common.truth.Truth.assertThat;
 
-class ListenableFutureToApiFutureTest {
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
+public class ApiFutureToListenableFutureTest {
   @Test
-  void testGet() throws Exception {
-    SettableFuture<Integer> future = SettableFuture.create();
-    ListenableFutureToApiFuture<Integer> apiFuture = new ListenableFutureToApiFuture<>(future);
-    future.set(3);
-    Truth.assertThat(apiFuture.get()).isEqualTo(3);
-  }
-
-  @Test
-  void testToStringShowsUnderlyingFutureToString() {
-    String customInnerFutureDesc = "my-custom-toString-impl";
-    ListenableFuture<String> listenableFuture =
-        new AbstractFuture<String>() {
+  public void testThatInnerToStringIsNotLost() {
+    String customInnerToString = "my-custom-inner-tostring";
+    ApiFuture<String> apiFuture =
+        new AbstractApiFuture<String>() {
           @Override
           public String toString() {
-            return customInnerFutureDesc;
+            return customInnerToString;
           }
         };
-
-    ListenableFutureToApiFuture<String> apiFuture =
-        new ListenableFutureToApiFuture<>(listenableFuture);
-    Truth.assertThat(apiFuture.toString()).contains(customInnerFutureDesc);
+    ApiFutureToListenableFuture<String> listenableFuture =
+        new ApiFutureToListenableFuture<>(apiFuture);
+    assertThat(listenableFuture.toString()).contains(customInnerToString);
   }
 }

--- a/api-common-java/src/test/java/com/google/api/core/ApiFutureToListenableFutureTest.java
+++ b/api-common-java/src/test/java/com/google/api/core/ApiFutureToListenableFutureTest.java
@@ -33,9 +33,9 @@ import static com.google.common.truth.Truth.assertThat;
 
 import org.junit.jupiter.api.Test;
 
-public class ApiFutureToListenableFutureTest {
+class ApiFutureToListenableFutureTest {
   @Test
-  public void testThatInnerToStringIsNotLost() {
+  void testThatInnerToStringIsNotLost() {
     String customInnerToString = "my-custom-inner-tostring";
     ApiFuture<String> apiFuture =
         new AbstractApiFuture<String>() {

--- a/api-common-java/src/test/java/com/google/api/core/ApiFutureToListenableFutureTest.java
+++ b/api-common-java/src/test/java/com/google/api/core/ApiFutureToListenableFutureTest.java
@@ -31,11 +31,8 @@ package com.google.api.core;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
-@RunWith(JUnit4.class)
 public class ApiFutureToListenableFutureTest {
   @Test
   public void testThatInnerToStringIsNotLost() {

--- a/gax-java/gax/src/main/java/com/google/api/gax/retrying/BasicRetryingFuture.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/retrying/BasicRetryingFuture.java
@@ -274,7 +274,6 @@ class BasicRetryingFuture<ResponseT> extends AbstractFuture<ResponseT>
         .add("attemptResult", this.attemptResult)
         .add("attemptSettings", this.attemptSettings)
         .toString();
-
   }
 
   private class CompletionListener implements Runnable {

--- a/gax-java/gax/src/main/java/com/google/api/gax/retrying/BasicRetryingFuture.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/retrying/BasicRetryingFuture.java
@@ -35,6 +35,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.api.gax.tracing.ApiTracer;
+import com.google.common.base.MoreObjects;
 import com.google.common.util.concurrent.AbstractFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.util.concurrent.Callable;
@@ -263,6 +264,17 @@ class BasicRetryingFuture<ResponseT> extends AbstractFuture<ResponseT>
       // way) the exception will be thrown in a separate thread and will not be swallowed by this
       // catch block anyways.
     }
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this.getClass())
+        .add("super", pendingToString())
+        .add("latestCompletedAttemptResult", this.latestCompletedAttemptResult)
+        .add("attemptResult", this.attemptResult)
+        .add("attemptSettings", this.attemptSettings)
+        .toString();
+
   }
 
   private class CompletionListener implements Runnable {

--- a/library_generation/owlbot/templates/java_library/README.md
+++ b/library_generation/owlbot/templates/java_library/README.md
@@ -57,6 +57,7 @@ If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file:
     <groupId>{{ group_id }}</groupId>
     <artifactId>{{ artifact_id }}</artifactId>
   </dependency>
+</dependencies>
 ```
 
 If you are using Maven without the BOM, add this to your dependencies:


### PR DESCRIPTION
Sometimes an operation can get stuck indefinitely. The underlying reasons can vary significantly:
- the underlying attempt rpc can get stuck due to a bug in grpc (ie https://github.com/grpc/grpc-java/pull/11026)
- the operation can get stuck in layers above gax: https://github.com/googleapis/java-bigtable/pull/1939
- or it can get stuck in gax itself (dont have a pointer handy)

Guava futures provide some observability for ListenableFutures, but in creating the custom ApiFutures in gax, we lose that functionality. This PR sprinkles a few to toString to allow callers to inspect the internal state of the operation. For example with these changes, the toString() of the future returned from bigtableDataClient.mutateRows() changes from

> TransformFuture@652ce654[status=PENDING, info=[inputFuture=[com.google.api.core.ApiFutureToListenableFuture@522ba524], function=[com.google.api.core.ApiFutures$ApiFunctionToGuavaFunction@29c5ee1d]]]

to
> ListenableFutureToApiFuture{delegate=TransformFuture@7ac9af2a[status=PENDING, info=[inputFuture=[ApiFutureToListenableFuture{apiFuture=CallbackChainRetryingFuture{super=com.google.api.gax.retrying.CallbackChainRetryingFuture@7bb004b8[status=PENDING], latestCompletedAttemptResult=null, attemptResult=null, attemptSettings=TimedAttemptSettings{globalSettings=RetrySettings{totalTimeout=PT10M, initialRetryDelay=PT0.01S, retryDelayMultiplier=2.0, maxRetryDelay=PT1M, maxAttempts=0, jittered=true, initialRpcTimeout=PT1M, rpcTimeoutMultiplier=1.0, maxRpcTimeout=PT1M}, retryDelay=PT0S, rpcTimeout=PT1M, randomizedRetryDelay=PT0S, attemptCount=0, overallAttemptCount=0, firstAttemptStartTimeNanos=635709620001791}}}], function=[com.google.api.core.ApiFutures$ApiFunctionToGuavaFunction@652ce654]]]}

This allows us to reason about whats stuck. I'm working another PR that will add a close(timeout) to the Batcher that will use this functionality to identify why batcher.close() timed out

Thank you for opening a Pull Request! Before submitting your PR, please read our [contributing guidelines](https://github.com/googleapis/gapic-generator-java/blob/main/CONTRIBUTING.md). 

There are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/gapic-generator-java/issues/new/choose) before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️