### PR TITLE
chore: Correctly closing the release please config for gapic-generator-java in library generation Dockerfile

### DIFF
--- a/.cloudbuild/library_generation/library_generation.Dockerfile
+++ b/.cloudbuild/library_generation/library_generation.Dockerfile
@@ -20,7 +20,7 @@ WORKDIR /sdk-platform-java
 COPY . .
 # {x-version-update-start:gapic-generator-java:current}
 ENV DOCKER_GAPIC_GENERATOR_VERSION="2.44.1-SNAPSHOT" 
-# {x-version-update-end:gapic-generator-java:current}
+# {x-version-update-end}
 
 RUN mvn install -DskipTests -Dclirr.skip -Dcheckstyle.skip
 RUN cp "/root/.m2/repository/com/google/api/gapic-generator-java/${DOCKER_GAPIC_GENERATOR_VERSION}/gapic-generator-java-${DOCKER_GAPIC_GENERATOR_VERSION}.jar" \


### PR DESCRIPTION
Release please is incorrectly updating [GRPC and NPM versions](https://github.com/googleapis/sdk-platform-java/compare/396fd063e3babc80a5e8c00d72ab1241ad3a1988..ad830a8275ad2fa3d97dfb24bf26eedd950c10ee) in the library generation Dockerfile. Correctly closing it now per [this comment](https://github.com/googleapis/release-please/blob/34abdd3b7e35bd6638cc5d4c34b8b1ab5bdd29c2/src/updaters/java/java-update.ts#L28-L32) in release-please.