### PR TITLE
chore: Add Clirr exemptions for Protobuf 4.27.4 runtime

### DIFF
--- a/library_generation/owlbot/templates/clirr/clirr-ignored-differences.xml.j2
+++ b/library_generation/owlbot/templates/clirr/clirr-ignored-differences.xml.j2
@@ -15,5 +15,72 @@
     <differenceType>7012</differenceType>
     <className>{{proto_path}}/*OrBuilder</className>
     <method>boolean has*(*)</method>
+  </difference>
+  <!-- The following 7006 exemptions are related to Protobuf 4.27.4 upgrade -->
+  <difference>
+    <differenceType>7006</differenceType>
+    <className>{{proto_path}}/**</className>
+    <method>* getDefaultInstanceForType()</method>
+    <to>**</to>
+  </difference>
+  <difference>
+    <differenceType>7006</differenceType>
+    <className>{{proto_path}}/**</className>
+    <method>* addRepeatedField(*)</method>
+    <to>**</to>
+  </difference>
+  <difference>
+    <differenceType>7006</differenceType>
+    <className>{{proto_path}}/**</className>
+    <method>* clear()</method>
+    <to>**</to>
+  </difference>
+  <difference>
+    <differenceType>7006</differenceType>
+    <className>{{proto_path}}/**</className>
+    <method>* clear()</method>
+    <to>**</to>
+  </difference>
+  <difference>
+    <differenceType>7006</differenceType>
+    <className>{{proto_path}}/**</className>
+    <method>* clearField(*)</method>
+    <to>**</to>
+  </difference>
+  <difference>
+    <differenceType>7006</differenceType>
+    <className>{{proto_path}}/**</className>
+    <method>* clearOneof(*)</method>
+    <to>**</to>
+  </difference>
+  <difference>
+    <differenceType>7006</differenceType>
+    <className>{{proto_path}}/**</className>
+    <method>* clone()</method>
+    <to>**</to>
+  </difference>
+  <difference>
+    <differenceType>7006</differenceType>
+    <className>{{proto_path}}/**</className>
+    <method>* mergeUnknownFields(*)</method>
+    <to>**</to>
+  </difference>
+  <difference>
+    <differenceType>7006</differenceType>
+    <className>{{proto_path}}/**</className>
+    <method>* setField(*)</method>
+    <to>**</to>
+  </difference>
+  <difference>
+    <differenceType>7006</differenceType>
+    <className>{{proto_path}}/**</className>
+    <method>* setRepeatedField(*)</method>
+    <to>**</to>
+  </difference>
+  <difference>
+    <differenceType>7006</differenceType>
+    <className>{{proto_path}}/**</className>
+    <method>* setUnknownField(*)</method>
+    <to>**</to>
   </difference>{% endfor %}
 </differences>

--- a/library_generation/owlbot/templates/clirr/clirr-ignored-differences.xml.j2
+++ b/library_generation/owlbot/templates/clirr/clirr-ignored-differences.xml.j2
@@ -38,12 +38,6 @@
   <difference>
     <differenceType>7006</differenceType>
     <className>{{proto_path}}/**</className>
-    <method>* clear()</method>
-    <to>**</to>
-  </difference>
-  <difference>
-    <differenceType>7006</differenceType>
-    <className>{{proto_path}}/**</className>
     <method>* clearField(*)</method>
     <to>**</to>
   </difference>

--- a/library_generation/owlbot/templates/clirr/clirr-ignored-differences.xml.j2
+++ b/library_generation/owlbot/templates/clirr/clirr-ignored-differences.xml.j2
@@ -80,7 +80,7 @@
   <difference>
     <differenceType>7006</differenceType>
     <className>{{proto_path}}/**</className>
-    <method>* setUnknownField(*)</method>
+    <method>* setUnknownFields(*)</method>
     <to>**</to>
   </difference>{% endfor %}
 </differences>


### PR DESCRIPTION
Clirr is flagging a bunch of 7006 Method Return Type changed errors. The Protoc generated changes are source code compatible and should ignore these errors in our generated code.

See [this doc](https://docs.google.com/spreadsheets/d/1qEzUWLougtiqh0ocRaG4e8w12pr89o0T_tQvB6YDStE/edit?pli=1&gid=0#gid=0) for more information. After adding all the Clirr checks exemptions in this PR to the downstream handwritten libraries, we are no longer seeing an Clirr failures.