### PR TITLE
chore: do not use renovate to update protobuf

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,17 +21,6 @@
     {
       "customType": "regex",
       "fileMatch": [
-        "^gax-java/dependencies\\.properties$"
-      ],
-      "matchStrings": [
-        "version\\.com_google_protobuf=(?<currentValue>.+?)\\n"
-      ],
-      "depNameTemplate": "com.google.protobuf:protobuf-java",
-      "datasourceTemplate": "maven"
-    },
-    {
-      "customType": "regex",
-      "fileMatch": [
                "^\\.cloudbuild/library_generation/library_generation\\.Dockerfile$"
       ],
       "matchStrings": [

--- a/renovate.json
+++ b/renovate.json
@@ -21,18 +21,6 @@
     {
       "customType": "regex",
       "fileMatch": [
-               "^\\.cloudbuild/library_generation/library_generation\\.Dockerfile$"
-      ],
-      "matchStrings": [
-        "ARG PROTOC_VERSION=[\"']?(?<currentValue>.+?)[\"']?\\s+"
-      ],
-      "datasourceTemplate": "github-releases",
-      "depNameTemplate": "protocolbuffers/protobuf",
-      "extractVersionTemplate": "^v(?<version>.*)$"
-    },
-    {
-      "customType": "regex",
-      "fileMatch": [
         "^gax-java/dependencies\\.properties$"
       ],
       "matchStrings": [
@@ -81,6 +69,12 @@
       ],
       "matchPackagePatterns": [
         "*"
+      ],
+      "enabled": false
+    },
+    {
+      "matchPackagePatterns": [
+        "^com.google.protobuf:"
       ],
       "enabled": false
     },
@@ -141,13 +135,6 @@
         "^com.fasterxml.jackson.core"
       ],
       "groupName": "jackson dependencies"
-    },
-    {
-      "matchPackagePatterns": [
-        "^com.google.protobuf",
-		"^protocolbuffers/protobuf"
-      ],
-      "groupName": "Protobuf dependencies"
     },
     {
       "matchPackagePatterns": [


### PR DESCRIPTION
In this PR:
- Do not use renovate to update protobuf version in `gax-java/dependencies.properties`.

We need to make sure the protobuf version in `gax-java/dependency.properties` (used by the self-service client) is compatible with protoc/protobuf version defined in the generator. 

We'll manually change the version.

Verification:

```
export LOG_LEVEL=debug && npx --yes --package renovate -- renovate --platform=local

...
{
   "datasource": "maven",
   "depName": "com.google.protobuf:protobuf-bom",
   "currentValue": "3.25.4",
   "fileReplacePosition": 1523,
   "registryUrls": [
     "https://maven-central.storage-download.googleapis.com/maven2/",
     "https://maven-central.storage-download.googleapis.com/maven2",
     "https://repo1.maven.org/maven2",
     "https://repo.maven.apache.org/maven2"
   ],
   "depType": "import",
   "groupName": "protobuf.version",
   "editFile": "gapic-generator-java-pom-parent/pom.xml",
   "updates": [],
   "packageName": "com.google.protobuf:protobuf-bom",
   "skipReason": "disabled"
},
```