### PR TITLE
feat: Metrics tracer addAttribute map overload

### DIFF
--- a/gax-java/gax/src/main/java/com/google/api/gax/tracing/MetricsTracer.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/tracing/MetricsTracer.java
@@ -245,6 +245,15 @@ public class MetricsTracer implements ApiTracer {
     attributes.put(key, value);
   };
 
+  /**
+   * Add attributes that will be attached to all metrics. This is expected to be called by
+   * handwritten client teams to add additional attributes that are not supposed be collected by
+   * Gax.
+   */
+  public void addAttributes(Map<String, String> attributes) {
+    attributes.putAll(attributes);
+  };
+
   @VisibleForTesting
   Map<String, String> getAttributes() {
     return attributes;

--- a/gax-java/gax/src/main/java/com/google/api/gax/tracing/MetricsTracer.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/tracing/MetricsTracer.java
@@ -251,7 +251,7 @@ public class MetricsTracer implements ApiTracer {
    * Gax.
    */
   public void addAttributes(Map<String, String> attributes) {
-    attributes.putAll(attributes);
+    this.attributes.putAll(attributes);
   };
 
   @VisibleForTesting

--- a/gax-java/gax/src/test/java/com/google/api/gax/tracing/MetricsTracerTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/tracing/MetricsTracerTest.java
@@ -43,6 +43,7 @@ import com.google.api.gax.rpc.NotFoundException;
 import com.google.api.gax.rpc.StatusCode.Code;
 import com.google.api.gax.rpc.testing.FakeStatusCode;
 import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -226,6 +227,16 @@ class MetricsTracerTest {
   void testAddAttributes_recordsAttributes() {
     metricsTracer.addAttributes("FakeTableId", "12345");
     assertThat(metricsTracer.getAttributes().get("FakeTableId")).isEqualTo("12345");
+  }
+
+  @Test
+  void testAddAttributes_recordsAttributesWithMap() {
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put("FakeTableId", "12345");
+    attributes.put("FakeInstanceId", "67890");
+    metricsTracer.addAttributes(attributes);
+    assertThat(metricsTracer.getAttributes().get("FakeTableId")).isEqualTo("12345");
+    assertThat(metricsTracer.getAttributes().get("FakeInstanceId")).isEqualTo("67890");
   }
 
   @Test


### PR DESCRIPTION
This PR adds an overload for adding multiple attributes at once. 

Earlier the client had to call the `addAttributes` method in a loop to add each attributes. Below overload takes a map and add all the attributes at once

```
public void addAttributes(Map<String, String> attributes) {
    this.attributes.putAll(attributes);
  };
 ```