### PR TITLE
chore: do not exit early if there's no code change

### DIFF
--- a/.github/scripts/hermetic_library_generation.sh
+++ b/.github/scripts/hermetic_library_generation.sh
@@ -101,11 +101,9 @@ git add --all -- ':!pr_description.txt' ':!hermetic_library_generation.sh'
 changed_files=$(git diff --cached --name-only)
 if [[ "${changed_files}" == "" ]]; then
     echo "There is no generated code change."
-    echo "Skip committing to the pull request."
-    exit 0
 fi
 
-git commit -m "${message}"
+git commit --allow-empty -m "${message}"
 git push
 # set pr body if pr_description.txt is generated.
 if [[ -f "pr_description.txt" ]]; then

--- a/.github/scripts/hermetic_library_generation.sh
+++ b/.github/scripts/hermetic_library_generation.sh
@@ -99,12 +99,14 @@ docker run \
 rm -rdf output googleapis "${baseline_generation_config}"
 git add --all -- ':!pr_description.txt' ':!hermetic_library_generation.sh'
 changed_files=$(git diff --cached --name-only)
-if [[ "${changed_files}" == "" ]]; then
-    echo "There is no generated code change."
+if [[ "${changed_files}" != "" ]]; then
+    echo "Commit changes..."
+    git commit -m "${message}"
+    git push
+else
+    echo "There is no generated code change, skip commit."
 fi
 
-git commit --allow-empty -m "${message}"
-git push
 # set pr body if pr_description.txt is generated.
 if [[ -f "pr_description.txt" ]]; then
   pr_num=$(gh pr list -s open -H "${current_branch}" -q . --json number | jq ".[] | .number")


### PR DESCRIPTION
In this PR:
- Do not exit if there's no code change.

Context: we found an issue in bigtable (https://github.com/googleapis/java-bigtable/pull/2336) such that PR description is overwritten by subsequent commit due to config updates. However, the generation associated with that [commit](https://github.com/googleapis/java-bigtable/pull/2336/commits/b6e7e1d566c4f2364e3eb8f766fec31c396ded57) didn't have code change (because the code change is already committed) and exit early so the PR description is not changed back.