### PR TITLE
chore: Update root pom.xml template to use maven deploy v3.1.3

### DIFF
--- a/library_generation/templates/root-pom.xml.j2
+++ b/library_generation/templates/root-pom.xml.j2
@@ -25,7 +25,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.1.2</version>
+        <version>3.1.3</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/library_generation/test/resources/test_monorepo_postprocessing/pom-golden.xml
+++ b/library_generation/test/resources/test_monorepo_postprocessing/pom-golden.xml
@@ -25,7 +25,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.1.2</version>
+        <version>3.1.3</version>
         <configuration>
           <skip>true</skip>
         </configuration>


### PR DESCRIPTION
Issue discovered in https://github.com/googleapis/google-cloud-java/actions/runs/10908789692/job/30275696533?pr=11081

```
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.1.3</version>
+        <version>3.1.2</version>
         <configuration>
           <skip>true</skip>
         </configuration>
```