### PR TITLE
chore: specify `options.logging` in cloud build

### DIFF
--- a/.cloudbuild/library_generation/cloudbuild-library-generation-push.yaml
+++ b/.cloudbuild/library_generation/cloudbuild-library-generation-push.yaml
@@ -31,6 +31,9 @@ steps:
     id: library-generation-build
     waitFor: ["-"]
 
+options:
+  logging: CLOUD_LOGGING_ONLY
+
 images:
   - ${_SHA_IMAGE_ID}
   - ${_LATEST_IMAGE_ID}


### PR DESCRIPTION
In this PR:
- Specify options.logging` in Cloud Build config.

The cloud build failed when pushing:
```
Error: Insufficient step blocks

  on ../../modules/infra_cloud_build/cloud_build.tf line 32, in resource "google_cloudbuild_trigger" "triggers":
  32:   build {

At least 1 "step" blocks are required.
  
Error: Insufficient step blocks

  on ../../modules/infra_cloud_build/cloud_build.tf line 32, in resource "google_cloudbuild_trigger" "triggers":
  32:   build {

At least 1 "step" blocks are required.
```

Try to resolve this issue following [this](https://yaqs.corp.google.com/eng/q/4648617514492755968#n1) answer in YAQS.