### PR TITLE
chore: change artifact registry repo

### DIFF
--- a/.cloudbuild/library_generation/cloudbuild-library-generation-push-prod.yaml
+++ b/.cloudbuild/library_generation/cloudbuild-library-generation-push-prod.yaml
@@ -14,7 +14,7 @@
 
 timeout: 7200s # 2 hours
 substitutions:
-  _IMAGE_NAME: "us-docker.pkg.dev/java-hermetic-build-prod/private-resources/java-library-generation"
+  _IMAGE_NAME: "us-docker.pkg.dev/java-hermetic-build-prod/public-resources/java-library-generation"
   _GAPIC_GENERATOR_JAVA_VERSION: '2.46.2-SNAPSHOT' # {x-version-update:gapic-generator-java:current}
   _SHA_IMAGE_ID: "${_IMAGE_NAME}:${COMMIT_SHA}"
   _LATEST_IMAGE_ID: "${_IMAGE_NAME}:latest"


### PR DESCRIPTION
In this PR:
- Change the artifact registry repo to which we publish library generation image.