### PR TITLE
fix: Disable automatically retrieving Universe Domain from Metadata Server

### DIFF
--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/EndpointContext.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/EndpointContext.java
@@ -153,7 +153,7 @@ public abstract class EndpointContext {
     }
     String credentialsUniverseDomain = Credentials.GOOGLE_DEFAULT_UNIVERSE;
     // If credentials is not NoCredentialsProvider, use the Universe Domain inside Credentials
-    if (credentials != null && (!(credentials instanceof ComputeEngineCredentials))) {
+    if (credentials != null) {
       credentialsUniverseDomain = credentials.getUniverseDomain();
     }
     if (!resolvedUniverseDomain().equals(credentialsUniverseDomain)) {

--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/EndpointContext.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/EndpointContext.java
@@ -148,7 +148,7 @@ public abstract class EndpointContext {
     }
     String credentialsUniverseDomain = Credentials.GOOGLE_DEFAULT_UNIVERSE;
     // If credentials is not NoCredentialsProvider, use the Universe Domain inside Credentials
-    // (TODO: b/349488459) - Disable automatic retries until 01/2025
+    // (TODO: b/349488459) - Disable automatic requests to MDS until 01/2025
     if (credentials != null && (!(credentials instanceof ComputeEngineCredentials))) {
       credentialsUniverseDomain = credentials.getUniverseDomain();
     }

--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/EndpointContext.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/EndpointContext.java
@@ -32,6 +32,7 @@ package com.google.api.gax.rpc;
 import com.google.api.core.InternalApi;
 import com.google.api.gax.rpc.mtls.MtlsProvider;
 import com.google.auth.Credentials;
+import com.google.auth.oauth2.ComputeEngineCredentials;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
@@ -147,7 +148,8 @@ public abstract class EndpointContext {
     }
     String credentialsUniverseDomain = Credentials.GOOGLE_DEFAULT_UNIVERSE;
     // If credentials is not NoCredentialsProvider, use the Universe Domain inside Credentials
-    if (credentials != null) {
+    // (TODO: b/349488459) - Disable automatic retries until 01/2025
+    if (credentials != null && (!(credentials instanceof ComputeEngineCredentials))) {
       credentialsUniverseDomain = credentials.getUniverseDomain();
     }
     if (!resolvedUniverseDomain().equals(credentialsUniverseDomain)) {

--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/EndpointContext.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/EndpointContext.java
@@ -146,9 +146,13 @@ public abstract class EndpointContext {
       // GDC-H has no universe domain, return
       return;
     }
+    // (TODO: b/349488459) - Disable automatic requests to MDS until 01/2025
+    // If MDS is required for Universe Domain, do not do any validation
+    if (credentials instanceof ComputeEngineCredentials) {
+      return;
+    }
     String credentialsUniverseDomain = Credentials.GOOGLE_DEFAULT_UNIVERSE;
     // If credentials is not NoCredentialsProvider, use the Universe Domain inside Credentials
-    // (TODO: b/349488459) - Disable automatic requests to MDS until 01/2025
     if (credentials != null && (!(credentials instanceof ComputeEngineCredentials))) {
       credentialsUniverseDomain = credentials.getUniverseDomain();
     }

--- a/gax-java/gax/src/test/java/com/google/api/gax/rpc/EndpointContextTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/rpc/EndpointContextTest.java
@@ -29,12 +29,14 @@
  */
 package com.google.api.gax.rpc;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.api.gax.rpc.mtls.MtlsProvider;
 import com.google.api.gax.rpc.testing.FakeMtlsProvider;
 import com.google.auth.Credentials;
+import com.google.auth.oauth2.ComputeEngineCredentials;
 import com.google.common.truth.Truth;
 import io.grpc.Status;
 import java.io.IOException;
@@ -436,5 +438,20 @@ class EndpointContextTest {
     assertThrows(
         UnauthenticatedException.class,
         () -> endpointContext.validateUniverseDomain(credentials, statusCode));
+  }
+
+  // (TODO: b/349488459) - Disable automatic requests to MDS until 01/2025
+  // Test is to ensure that no validation is being run for ComputeEngineCredentials
+  @Test
+  void hasValidUniverseDomain_computeEngineCredentials_noValidationOnUniverseDomain()
+      throws IOException {
+    Credentials credentials = Mockito.mock(ComputeEngineCredentials.class);
+    Mockito.when(credentials.getUniverseDomain()).thenReturn(Credentials.GOOGLE_DEFAULT_UNIVERSE);
+    EndpointContext endpointContext =
+        defaultEndpointContextBuilder
+            // Set a custom Universe Domain that doesn't match
+            .setUniverseDomain("test.com")
+            .build();
+    assertDoesNotThrow(() -> endpointContext.validateUniverseDomain(credentials, statusCode));
   }
 }


### PR DESCRIPTION
See internal ticket b/349488459 for more info.

External info:
ComputeEngineCredentials in client libraries should not validate the universe domain. Validating the universe domain requires retrieving it from Metadata Server (MDS) and this will be temporarily disabled. 

For users that using client libraries, there will be no automatic call to MDS. For users that use the Credentials directly and manually call `ComputeEngineCredentials.getUniverseDomain()` and the universe domain is not explicitly set, it will make a call to MDS.