### PR TITLE
deps: update grpc dependencies to v1.67.1 in dependencies.properties

### DIFF
--- a/gax-java/dependencies.properties
+++ b/gax-java/dependencies.properties
@@ -28,7 +28,7 @@ version.gax_httpjson=2.54.2-SNAPSHOT
 
 version.com_google_protobuf=3.25.5
 version.google_java_format=1.15.0
-version.io_grpc=1.66.0
+version.io_grpc=1.67.1
 
 # Maven artifacts.
 # Note, the actual name of each property matters (bazel build scripts depend on it).


### PR DESCRIPTION
In previous https://github.com/googleapis/sdk-platform-java/pull/3258, missed to update version in gax-java/dependencies.properties 