### PR TITLE
chore: update ITDynamicRoutingHeaders to use new standalone Interceptor classes

### DIFF
--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITApiKeyCredentials.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITApiKeyCredentials.java
@@ -169,7 +169,7 @@ class ITApiKeyCredentials {
 
     ArrayList<String> headerValues =
         (ArrayList<String>)
-            httpJsonInterceptor.metadata.getHeaders().get(HTTP_RESPONSE_HEADER_STRING);
+            httpJsonInterceptor.responseMetadata.getHeaders().get(HTTP_RESPONSE_HEADER_STRING);
     String headerValue = headerValues.get(0);
     assertThat(headerValue).isEqualTo(API_KEY);
   }
@@ -211,7 +211,7 @@ class ITApiKeyCredentials {
 
     ArrayList<String> headerValues =
         (ArrayList<String>)
-            httpJsonInterceptor.metadata.getHeaders().get(HTTP_RESPONSE_HEADER_STRING);
+            httpJsonInterceptor.responseMetadata.getHeaders().get(HTTP_RESPONSE_HEADER_STRING);
     String headerValue = headerValues.get(0);
     assertThat(headerValue).isEqualTo(API_KEY);
     assertThat(headerValues.size()).isEqualTo(1);

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITApiVersionHeaders.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITApiVersionHeaders.java
@@ -115,7 +115,8 @@ class ITApiVersionHeaders {
   void testHttpJson_matchesHeaderName() {
     httpJsonClient.echo(EchoRequest.newBuilder().build());
     ArrayList headerValues =
-        (ArrayList) httpJsonInterceptor.metadata.getHeaders().get(HTTP_RESPONSE_HEADER_STRING);
+        (ArrayList)
+            httpJsonInterceptor.responseMetadata.getHeaders().get(HTTP_RESPONSE_HEADER_STRING);
     String headerValue = (String) headerValues.get(0);
     assertThat(headerValue).isEqualTo(EXPECTED_ECHO_API_VERSION);
   }
@@ -134,7 +135,7 @@ class ITApiVersionHeaders {
         RepeatRequest.newBuilder().setInfo(ComplianceData.newBuilder().setFString("test")).build();
     httpJsonComplianceClient.repeatDataSimplePath(request);
     assertThat(API_VERSION_HEADER_KEY)
-        .isNotIn(httpJsonComplianceInterceptor.metadata.getHeaders().keySet());
+        .isNotIn(httpJsonComplianceInterceptor.responseMetadata.getHeaders().keySet());
   }
 
   @Test
@@ -224,7 +225,10 @@ class ITApiVersionHeaders {
 
       ArrayList headerValues =
           (ArrayList)
-              httpJsonComplianceInterceptor.metadata.getHeaders().get(HTTP_RESPONSE_HEADER_STRING);
+              httpJsonComplianceInterceptor
+                  .responseMetadata
+                  .getHeaders()
+                  .get(HTTP_RESPONSE_HEADER_STRING);
       String headerValue = (String) headerValues.get(0);
       assertThat(headerValue).isEqualTo(CUSTOM_API_VERSION);
     }

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/util/HttpJsonCapturingClientInterceptor.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/util/HttpJsonCapturingClientInterceptor.java
@@ -47,7 +47,8 @@ import io.grpc.Status;
 
 /** Implements a client interceptor to retrieve the response headers from a HTTP client request. */
 public class HttpJsonCapturingClientInterceptor implements HttpJsonClientInterceptor {
-    public HttpJsonMetadata metadata;
+    public HttpJsonMetadata responseMetadata;
+    public HttpJsonMetadata requestMetadata;
 
     @Override
     public <RequestT, ResponseT> HttpJsonClientCall<RequestT, ResponseT> interceptCall(
@@ -64,7 +65,7 @@ public class HttpJsonCapturingClientInterceptor implements HttpJsonClientInterce
                                 ResponseT>(responseListener) {
                             @Override
                             public void onHeaders(HttpJsonMetadata responseHeaders) {
-                                metadata = responseHeaders;
+                                responseMetadata = responseHeaders;
                                 super.onHeaders(responseHeaders);
                             }
 
@@ -80,6 +81,7 @@ public class HttpJsonCapturingClientInterceptor implements HttpJsonClientInterce
                         };
 
                 super.start(forwardingResponseListener, requestHeaders);
+                requestMetadata = requestHeaders;
             }
         };
     }


### PR DESCRIPTION
HttpJsonCapturingClientInterceptor and GrpcCapturingClientInterceptor were introduced in #3137,  this PR updates the rest of the showcase tests to use the new common classes.

Fixes #2743 ☕️