### PR TITLE
feat: selectively generate libraries

### DIFF
--- a/library_generation/cli/entry_point.py
+++ b/library_generation/cli/entry_point.py
@@ -224,7 +224,7 @@ def _needs_full_repo_generation(config_change: ConfigChange) -> bool:
 def _parse_library_name_from(includes: str) -> Optional[list[str]]:
     if includes is None:
         return None
-    return includes.strip().split(",")
+    return [library_name.strip() for library_name in includes.split(",")]
 
 
 @main.command()

--- a/library_generation/generate_repo.py
+++ b/library_generation/generate_repo.py
@@ -12,9 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import shutil
-
+from typing import Optional
 import library_generation.utils.utilities as util
 from library_generation.generate_composed_library import generate_composed_library
 from library_generation.model.generation_config import GenerationConfig
@@ -26,7 +25,7 @@ def generate_from_yaml(
     config: GenerationConfig,
     repository_path: str,
     api_definitions_path: str,
-    target_library_names: list[str] = None,
+    target_library_names: Optional[list[str]],
 ) -> None:
     """
     Based on the generation config, generates libraries via

--- a/library_generation/test/cli/entry_point_unit_tests.py
+++ b/library_generation/test/cli/entry_point_unit_tests.py
@@ -104,7 +104,7 @@ class EntryPointTest(unittest.TestCase):
         generate_impl(
             baseline_generation_config_path=config_path,
             current_generation_config_path=config_path,
-            includes=None,
+            library_names=None,
             repository_path=".",
             api_definitions_path=".",
         )
@@ -117,15 +117,16 @@ class EntryPointTest(unittest.TestCase):
 
     @patch("library_generation.cli.entry_point.generate_from_yaml")
     @patch("library_generation.cli.entry_point.generate_pr_descriptions")
-    def test_generate_non_monorepo_without_changes_with_includes_triggers_full_generation(
+    def test_generate_non_monorepo_without_changes_with_includes_triggers_selective_generation(
         self,
         generate_pr_descriptions,
         generate_from_yaml,
     ):
         """
         this tests confirms the behavior of generation of non monorepos
-        (HW libraries). generate() should call generate_from_yaml()
-        with target_library_names=None in order to trigger the full generation
+        (HW libraries).
+        generate() should call generate_from_yaml() with
+        target_library_names equals includes.
         """
         config_path = f"{test_resource_dir}/generation_config.yaml"
         self.assertFalse(from_yaml(config_path).is_monorepo())
@@ -134,7 +135,7 @@ class EntryPointTest(unittest.TestCase):
         generate_impl(
             baseline_generation_config_path=config_path,
             current_generation_config_path=config_path,
-            includes="cloudasset,non-existent-library",
+            library_names="cloudasset,non-existent-library",
             repository_path=".",
             api_definitions_path=".",
         )
@@ -142,7 +143,7 @@ class EntryPointTest(unittest.TestCase):
             config=ANY,
             repository_path=ANY,
             api_definitions_path=ANY,
-            target_library_names=None,
+            target_library_names=["cloudasset", "non-existent-library"],
         )
 
     @patch("library_generation.cli.entry_point.generate_from_yaml")
@@ -168,7 +169,7 @@ class EntryPointTest(unittest.TestCase):
         generate_impl(
             baseline_generation_config_path=baseline_config_path,
             current_generation_config_path=current_config_path,
-            includes=None,
+            library_names=None,
             repository_path=".",
             api_definitions_path=".",
         )
@@ -181,15 +182,16 @@ class EntryPointTest(unittest.TestCase):
 
     @patch("library_generation.cli.entry_point.generate_from_yaml")
     @patch("library_generation.cli.entry_point.generate_pr_descriptions")
-    def test_generate_non_monorepo_with_changes_with_includes_triggers_full_generation(
+    def test_generate_non_monorepo_with_changes_with_includes_triggers_selective_generation(
         self,
         generate_pr_descriptions,
         generate_from_yaml,
     ):
         """
         this tests confirms the behavior of generation of non monorepos
-        (HW libraries). generate() should call generate_from_yaml()
-        with target_library_names=None in order to trigger the full generation
+        (HW libraries).
+        generate() should call generate_from_yaml() with
+        target_library_names equals includes
         """
         baseline_config_path = f"{test_resource_dir}/generation_config.yaml"
         current_config_path = (
@@ -202,7 +204,7 @@ class EntryPointTest(unittest.TestCase):
         generate_impl(
             baseline_generation_config_path=baseline_config_path,
             current_generation_config_path=current_config_path,
-            includes="cloudasset,non-existent-library",
+            library_names="cloudasset,non-existent-library",
             repository_path=".",
             api_definitions_path=".",
         )
@@ -210,7 +212,7 @@ class EntryPointTest(unittest.TestCase):
             config=ANY,
             repository_path=ANY,
             api_definitions_path=ANY,
-            target_library_names=None,
+            target_library_names=["cloudasset", "non-existent-library"],
         )
 
     @patch("library_generation.cli.entry_point.generate_from_yaml")
@@ -233,7 +235,7 @@ class EntryPointTest(unittest.TestCase):
         generate_impl(
             baseline_generation_config_path=config_path,
             current_generation_config_path=config_path,
-            includes=None,
+            library_names=None,
             repository_path=".",
             api_definitions_path=".",
         )
@@ -246,7 +248,7 @@ class EntryPointTest(unittest.TestCase):
 
     @patch("library_generation.cli.entry_point.generate_from_yaml")
     @patch("library_generation.cli.entry_point.generate_pr_descriptions")
-    def test_generate_monorepo_with_common_protos_with_includes_triggers_full_generation(
+    def test_generate_monorepo_with_common_protos_with_includes_triggers_selective_generation(
         self,
         generate_pr_descriptions,
         generate_from_yaml,
@@ -254,7 +256,7 @@ class EntryPointTest(unittest.TestCase):
         """
         this tests confirms the behavior of generation of a monorepo with
         common protos.
-        target_library_names is None even though includes is specified.
+        target_library_names is the same as includes.
         """
         config_path = f"{test_resource_dir}/monorepo_with_common_protos.yaml"
         self.assertTrue(from_yaml(config_path).is_monorepo())
@@ -263,7 +265,7 @@ class EntryPointTest(unittest.TestCase):
         generate_impl(
             baseline_generation_config_path=config_path,
             current_generation_config_path=config_path,
-            includes="iam,non-existent-library",
+            library_names="iam,non-existent-library",
             repository_path=".",
             api_definitions_path=".",
         )
@@ -271,12 +273,12 @@ class EntryPointTest(unittest.TestCase):
             config=ANY,
             repository_path=ANY,
             api_definitions_path=ANY,
-            target_library_names=None,
+            target_library_names=["iam", "non-existent-library"],
         )
 
     @patch("library_generation.cli.entry_point.generate_from_yaml")
     @patch("library_generation.cli.entry_point.generate_pr_descriptions")
-    def test_generate_monorepo_without_common_protos_does_not_trigger_full_generation(
+    def test_generate_monorepo_without_change_does_not_trigger_generation(
         self,
         generate_pr_descriptions,
         generate_from_yaml,
@@ -295,7 +297,7 @@ class EntryPointTest(unittest.TestCase):
         generate_impl(
             baseline_generation_config_path=config_path,
             current_generation_config_path=config_path,
-            includes=None,
+            library_names=None,
             repository_path=".",
             api_definitions_path=".",
         )
@@ -308,7 +310,7 @@ class EntryPointTest(unittest.TestCase):
 
     @patch("library_generation.cli.entry_point.generate_from_yaml")
     @patch("library_generation.cli.entry_point.generate_pr_descriptions")
-    def test_generate_monorepo_with_changed_config_and_includes_trigger_union_generation(
+    def test_generate_monorepo_without_change_with_includes_trigger_selective_generation(
         self,
         generate_pr_descriptions,
         generate_from_yaml,
@@ -316,52 +318,18 @@ class EntryPointTest(unittest.TestCase):
         """
         this tests confirms the behavior of generation of a monorepo without
         common protos.
-        target_library_names should be the union of changed libraries and
-        include libraries, regardless the library exists or not.
+        generate() should call generate_from_yaml() with
+        target_library_names=changed libraries which does not trigger the full
+        generation.
         """
-        current_config_path = f"{test_resource_dir}/monorepo_current.yaml"
-        baseline_config_path = f"{test_resource_dir}/monorepo_baseline.yaml"
-        self.assertTrue(from_yaml(current_config_path).is_monorepo())
-        self.assertTrue(from_yaml(baseline_config_path).is_monorepo())
+        config_path = f"{test_resource_dir}/monorepo_without_common_protos.yaml"
+        self.assertTrue(from_yaml(config_path).is_monorepo())
         # we call the implementation method directly since click
         # does special handling when a method is annotated with @main.command()
         generate_impl(
-            baseline_generation_config_path=baseline_config_path,
-            current_generation_config_path=current_config_path,
-            includes="cloudbuild,non-existent-library",
-            repository_path=".",
-            api_definitions_path=".",
-        )
-        generate_from_yaml.assert_called_with(
-            config=ANY,
-            repository_path=ANY,
-            api_definitions_path=ANY,
-            target_library_names=["asset", "cloudbuild", "non-existent-library"],
-        )
-
-    @patch("library_generation.cli.entry_point.generate_from_yaml")
-    @patch("library_generation.cli.entry_point.generate_pr_descriptions")
-    def test_generate_monorepo_with_changed_config_without_includes_trigger_selective_generation(
-        self,
-        generate_pr_descriptions,
-        generate_from_yaml,
-    ):
-        """
-        this tests confirms the behavior of generation of a monorepo without
-        common protos.
-        target_library_names should be the changed libraries if includes
-        is not specified.
-        """
-        current_config_path = f"{test_resource_dir}/monorepo_current.yaml"
-        baseline_config_path = f"{test_resource_dir}/monorepo_baseline.yaml"
-        self.assertTrue(from_yaml(current_config_path).is_monorepo())
-        self.assertTrue(from_yaml(baseline_config_path).is_monorepo())
-        # we call the implementation method directly since click
-        # does special handling when a method is annotated with @main.command()
-        generate_impl(
-            baseline_generation_config_path=baseline_config_path,
-            current_generation_config_path=current_config_path,
-            includes=None,
+            baseline_generation_config_path=config_path,
+            current_generation_config_path=config_path,
+            library_names="asset",
             repository_path=".",
             api_definitions_path=".",
         )
@@ -374,7 +342,7 @@ class EntryPointTest(unittest.TestCase):
 
     @patch("library_generation.cli.entry_point.generate_from_yaml")
     @patch("library_generation.cli.entry_point.generate_pr_descriptions")
-    def test_generate_monorepo_without_changed_config_with_includes_trigger_selective_generation(
+    def test_generate_monorepo_with_changed_config_without_includes_trigger_changed_generation(
         self,
         generate_pr_descriptions,
         generate_from_yaml,
@@ -385,14 +353,49 @@ class EntryPointTest(unittest.TestCase):
         target_library_names should be the changed libraries if includes
         is not specified.
         """
-        config_path = f"{test_resource_dir}/monorepo_without_common_protos.yaml"
-        self.assertTrue(from_yaml(config_path).is_monorepo())
+        current_config_path = f"{test_resource_dir}/monorepo_current.yaml"
+        baseline_config_path = f"{test_resource_dir}/monorepo_baseline.yaml"
+        self.assertTrue(from_yaml(current_config_path).is_monorepo())
+        self.assertTrue(from_yaml(baseline_config_path).is_monorepo())
         # we call the implementation method directly since click
         # does special handling when a method is annotated with @main.command()
         generate_impl(
-            baseline_generation_config_path=config_path,
-            current_generation_config_path=config_path,
-            includes="cloudbuild,non-existent-library",
+            baseline_generation_config_path=baseline_config_path,
+            current_generation_config_path=current_config_path,
+            library_names=None,
+            repository_path=".",
+            api_definitions_path=".",
+        )
+        generate_from_yaml.assert_called_with(
+            config=ANY,
+            repository_path=ANY,
+            api_definitions_path=ANY,
+            target_library_names=["asset"],
+        )
+
+    @patch("library_generation.cli.entry_point.generate_from_yaml")
+    @patch("library_generation.cli.entry_point.generate_pr_descriptions")
+    def test_generate_monorepo_with_changed_config_and_includes_trigger_selective_generation(
+        self,
+        generate_pr_descriptions,
+        generate_from_yaml,
+    ):
+        """
+        this tests confirms the behavior of generation of a monorepo without
+        common protos.
+        target_library_names should be the same as include libraries, regardless
+        the library exists or not.
+        """
+        current_config_path = f"{test_resource_dir}/monorepo_current.yaml"
+        baseline_config_path = f"{test_resource_dir}/monorepo_baseline.yaml"
+        self.assertTrue(from_yaml(current_config_path).is_monorepo())
+        self.assertTrue(from_yaml(baseline_config_path).is_monorepo())
+        # we call the implementation method directly since click
+        # does special handling when a method is annotated with @main.command()
+        generate_impl(
+            baseline_generation_config_path=baseline_config_path,
+            current_generation_config_path=current_config_path,
+            library_names="cloudbuild,non-existent-library",
             repository_path=".",
             api_definitions_path=".",
         )
@@ -423,7 +426,7 @@ class EntryPointTest(unittest.TestCase):
         generate_impl(
             baseline_generation_config_path=config_path,
             current_generation_config_path=config_path,
-            includes=None,
+            library_names=None,
             repository_path=".",
             api_definitions_path=".",
         )

--- a/library_generation/test/cli/entry_point_unit_tests.py
+++ b/library_generation/test/cli/entry_point_unit_tests.py
@@ -104,6 +104,37 @@ class EntryPointTest(unittest.TestCase):
         generate_impl(
             baseline_generation_config_path=config_path,
             current_generation_config_path=config_path,
+            includes=None,
+            repository_path=".",
+            api_definitions_path=".",
+        )
+        generate_from_yaml.assert_called_with(
+            config=ANY,
+            repository_path=ANY,
+            api_definitions_path=ANY,
+            target_library_names=None,
+        )
+
+    @patch("library_generation.cli.entry_point.generate_from_yaml")
+    @patch("library_generation.cli.entry_point.generate_pr_descriptions")
+    def test_generate_non_monorepo_without_changes_with_includes_triggers_full_generation(
+        self,
+        generate_pr_descriptions,
+        generate_from_yaml,
+    ):
+        """
+        this tests confirms the behavior of generation of non monorepos
+        (HW libraries). generate() should call generate_from_yaml()
+        with target_library_names=None in order to trigger the full generation
+        """
+        config_path = f"{test_resource_dir}/generation_config.yaml"
+        self.assertFalse(from_yaml(config_path).is_monorepo())
+        # we call the implementation method directly since click
+        # does special handling when a method is annotated with @main.command()
+        generate_impl(
+            baseline_generation_config_path=config_path,
+            current_generation_config_path=config_path,
+            includes="cloudasset,non-existent-library",
             repository_path=".",
             api_definitions_path=".",
         )
@@ -137,6 +168,41 @@ class EntryPointTest(unittest.TestCase):
         generate_impl(
             baseline_generation_config_path=baseline_config_path,
             current_generation_config_path=current_config_path,
+            includes=None,
+            repository_path=".",
+            api_definitions_path=".",
+        )
+        generate_from_yaml.assert_called_with(
+            config=ANY,
+            repository_path=ANY,
+            api_definitions_path=ANY,
+            target_library_names=None,
+        )
+
+    @patch("library_generation.cli.entry_point.generate_from_yaml")
+    @patch("library_generation.cli.entry_point.generate_pr_descriptions")
+    def test_generate_non_monorepo_with_changes_with_includes_triggers_full_generation(
+        self,
+        generate_pr_descriptions,
+        generate_from_yaml,
+    ):
+        """
+        this tests confirms the behavior of generation of non monorepos
+        (HW libraries). generate() should call generate_from_yaml()
+        with target_library_names=None in order to trigger the full generation
+        """
+        baseline_config_path = f"{test_resource_dir}/generation_config.yaml"
+        current_config_path = (
+            f"{test_resource_dir}/generation_config_library_modified.yaml"
+        )
+        self.assertFalse(from_yaml(current_config_path).is_monorepo())
+        self.assertFalse(from_yaml(baseline_config_path).is_monorepo())
+        # we call the implementation method directly since click
+        # does special handling when a method is annotated with @main.command()
+        generate_impl(
+            baseline_generation_config_path=baseline_config_path,
+            current_generation_config_path=current_config_path,
+            includes="cloudasset,non-existent-library",
             repository_path=".",
             api_definitions_path=".",
         )
@@ -167,6 +233,37 @@ class EntryPointTest(unittest.TestCase):
         generate_impl(
             baseline_generation_config_path=config_path,
             current_generation_config_path=config_path,
+            includes=None,
+            repository_path=".",
+            api_definitions_path=".",
+        )
+        generate_from_yaml.assert_called_with(
+            config=ANY,
+            repository_path=ANY,
+            api_definitions_path=ANY,
+            target_library_names=None,
+        )
+
+    @patch("library_generation.cli.entry_point.generate_from_yaml")
+    @patch("library_generation.cli.entry_point.generate_pr_descriptions")
+    def test_generate_monorepo_with_common_protos_with_includes_triggers_full_generation(
+        self,
+        generate_pr_descriptions,
+        generate_from_yaml,
+    ):
+        """
+        this tests confirms the behavior of generation of a monorepo with
+        common protos.
+        target_library_names is None even though includes is specified.
+        """
+        config_path = f"{test_resource_dir}/monorepo_with_common_protos.yaml"
+        self.assertTrue(from_yaml(config_path).is_monorepo())
+        # we call the implementation method directly since click
+        # does special handling when a method is annotated with @main.command()
+        generate_impl(
+            baseline_generation_config_path=config_path,
+            current_generation_config_path=config_path,
+            includes="iam,non-existent-library",
             repository_path=".",
             api_definitions_path=".",
         )
@@ -198,6 +295,135 @@ class EntryPointTest(unittest.TestCase):
         generate_impl(
             baseline_generation_config_path=config_path,
             current_generation_config_path=config_path,
+            includes=None,
+            repository_path=".",
+            api_definitions_path=".",
+        )
+        generate_from_yaml.assert_called_with(
+            config=ANY,
+            repository_path=ANY,
+            api_definitions_path=ANY,
+            target_library_names=[],
+        )
+
+    @patch("library_generation.cli.entry_point.generate_from_yaml")
+    @patch("library_generation.cli.entry_point.generate_pr_descriptions")
+    def test_generate_monorepo_with_changed_config_and_includes_trigger_union_generation(
+        self,
+        generate_pr_descriptions,
+        generate_from_yaml,
+    ):
+        """
+        this tests confirms the behavior of generation of a monorepo without
+        common protos.
+        target_library_names should be the union of changed libraries and
+        include libraries, regardless the library exists or not.
+        """
+        current_config_path = f"{test_resource_dir}/monorepo_current.yaml"
+        baseline_config_path = f"{test_resource_dir}/monorepo_baseline.yaml"
+        self.assertTrue(from_yaml(current_config_path).is_monorepo())
+        self.assertTrue(from_yaml(baseline_config_path).is_monorepo())
+        # we call the implementation method directly since click
+        # does special handling when a method is annotated with @main.command()
+        generate_impl(
+            baseline_generation_config_path=baseline_config_path,
+            current_generation_config_path=current_config_path,
+            includes="cloudbuild,non-existent-library",
+            repository_path=".",
+            api_definitions_path=".",
+        )
+        generate_from_yaml.assert_called_with(
+            config=ANY,
+            repository_path=ANY,
+            api_definitions_path=ANY,
+            target_library_names=["asset", "cloudbuild", "non-existent-library"],
+        )
+
+    @patch("library_generation.cli.entry_point.generate_from_yaml")
+    @patch("library_generation.cli.entry_point.generate_pr_descriptions")
+    def test_generate_monorepo_with_changed_config_without_includes_trigger_selective_generation(
+        self,
+        generate_pr_descriptions,
+        generate_from_yaml,
+    ):
+        """
+        this tests confirms the behavior of generation of a monorepo without
+        common protos.
+        target_library_names should be the changed libraries if includes
+        is not specified.
+        """
+        current_config_path = f"{test_resource_dir}/monorepo_current.yaml"
+        baseline_config_path = f"{test_resource_dir}/monorepo_baseline.yaml"
+        self.assertTrue(from_yaml(current_config_path).is_monorepo())
+        self.assertTrue(from_yaml(baseline_config_path).is_monorepo())
+        # we call the implementation method directly since click
+        # does special handling when a method is annotated with @main.command()
+        generate_impl(
+            baseline_generation_config_path=baseline_config_path,
+            current_generation_config_path=current_config_path,
+            includes=None,
+            repository_path=".",
+            api_definitions_path=".",
+        )
+        generate_from_yaml.assert_called_with(
+            config=ANY,
+            repository_path=ANY,
+            api_definitions_path=ANY,
+            target_library_names=["asset"],
+        )
+
+    @patch("library_generation.cli.entry_point.generate_from_yaml")
+    @patch("library_generation.cli.entry_point.generate_pr_descriptions")
+    def test_generate_monorepo_without_changed_config_with_includes_trigger_selective_generation(
+        self,
+        generate_pr_descriptions,
+        generate_from_yaml,
+    ):
+        """
+        this tests confirms the behavior of generation of a monorepo without
+        common protos.
+        target_library_names should be the changed libraries if includes
+        is not specified.
+        """
+        config_path = f"{test_resource_dir}/monorepo_without_common_protos.yaml"
+        self.assertTrue(from_yaml(config_path).is_monorepo())
+        # we call the implementation method directly since click
+        # does special handling when a method is annotated with @main.command()
+        generate_impl(
+            baseline_generation_config_path=config_path,
+            current_generation_config_path=config_path,
+            includes="cloudbuild,non-existent-library",
+            repository_path=".",
+            api_definitions_path=".",
+        )
+        generate_from_yaml.assert_called_with(
+            config=ANY,
+            repository_path=ANY,
+            api_definitions_path=ANY,
+            target_library_names=["cloudbuild", "non-existent-library"],
+        )
+
+    @patch("library_generation.cli.entry_point.generate_from_yaml")
+    @patch("library_generation.cli.entry_point.generate_pr_descriptions")
+    def test_generate_monorepo_without_changed_config_without_includes_does_not_trigger_generation(
+        self,
+        generate_pr_descriptions,
+        generate_from_yaml,
+    ):
+        """
+        this tests confirms the behavior of generation of a monorepo without
+        common protos.
+        target_library_names should be the changed libraries if includes
+        is not specified.
+        """
+        config_path = f"{test_resource_dir}/monorepo_without_common_protos.yaml"
+        self.assertTrue(from_yaml(config_path).is_monorepo())
+        # we call the implementation method directly since click
+        # does special handling when a method is annotated with @main.command()
+        generate_impl(
+            baseline_generation_config_path=config_path,
+            current_generation_config_path=config_path,
+            includes=None,
             repository_path=".",
             api_definitions_path=".",
         )

--- a/library_generation/test/generate_repo_unit_tests.py
+++ b/library_generation/test/generate_repo_unit_tests.py
@@ -40,6 +40,20 @@ class GenerateRepoTest(unittest.TestCase):
         target_libraries = get_target_libraries(config)
         self.assertEqual([one_library, another_library], target_libraries)
 
+    def test_get_target_library_given_an_non_existent_library_returns_only_existing_libraries(
+        self,
+    ):
+        one_library = GenerateRepoTest.__get_an_empty_library_config()
+        one_library.api_shortname = "one_library"
+        another_library = GenerateRepoTest.__get_an_empty_library_config()
+        another_library.api_shortname = "another_library"
+        config = GenerateRepoTest.__get_an_empty_generation_config()
+        config.libraries.extend([one_library, another_library])
+        target_libraries = get_target_libraries(
+            config, ["one_library", "another_library", "non_existent_library"]
+        )
+        self.assertEqual([one_library, another_library], target_libraries)
+
     @staticmethod
     def __get_an_empty_generation_config() -> GenerationConfig:
         return GenerationConfig(

--- a/library_generation/test/resources/test-config/monorepo_baseline.yaml
+++ b/library_generation/test/resources/test-config/monorepo_baseline.yaml
@@ -1,0 +1,30 @@
+gapic_generator_version: 2.34.0
+googleapis_commitish: 1a45bf7393b52407188c82e63101db7dc9c72026
+libraries_bom_version: 26.37.0
+libraries:
+  - api_shortname: cloudasset
+    name_pretty: Cloud Asset Inventory
+    product_documentation: "https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview"
+    api_description: "provides inventory services based on a time series database."
+    library_name: "asset"
+    client_documentation: "https://cloud.google.com/java/docs/reference/google-cloud-asset/latest/overview"
+    distribution_name: "com.google.cloud:google-cloud-asset"
+    release_level: preview
+    GAPICs:
+      - proto_path: google/cloud/asset/v1
+      - proto_path: google/cloud/asset/v1p1beta1
+      - proto_path: google/cloud/asset/v1p2beta1
+      - proto_path: google/cloud/asset/v1p5beta1
+      - proto_path: google/cloud/asset/v1p7beta1
+  - api_shortname: cloudbuild
+    name_pretty: Cloud Build
+    product_documentation: https://cloud.google.com/cloud-build/
+    api_description: lets you build software quickly across all languages. Get complete
+        control over defining custom workflows for building, testing, and deploying across
+        multiple environments such as VMs, serverless, Kubernetes, or Firebase.
+    release_level: stable
+    distribution_name: com.google.cloud:google-cloud-build
+    issue_tracker: https://issuetracker.google.com/savedsearches/5226584
+    GAPICs:
+       - proto_path: google/devtools/cloudbuild/v1
+       - proto_path: google/devtools/cloudbuild/v2

--- a/library_generation/test/resources/test-config/monorepo_current.yaml
+++ b/library_generation/test/resources/test-config/monorepo_current.yaml
@@ -1,0 +1,30 @@
+gapic_generator_version: 2.34.0
+googleapis_commitish: 1a45bf7393b52407188c82e63101db7dc9c72026
+libraries_bom_version: 26.37.0
+libraries:
+  - api_shortname: cloudasset
+    name_pretty: Cloud Asset Inventory
+    product_documentation: "https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview"
+    api_description: "provides inventory services based on a time series database."
+    library_name: "asset"
+    client_documentation: "https://cloud.google.com/java/docs/reference/google-cloud-asset/latest/overview"
+    distribution_name: "com.google.cloud:google-cloud-asset"
+    release_level: stable
+    GAPICs:
+      - proto_path: google/cloud/asset/v1
+      - proto_path: google/cloud/asset/v1p1beta1
+      - proto_path: google/cloud/asset/v1p2beta1
+      - proto_path: google/cloud/asset/v1p5beta1
+      - proto_path: google/cloud/asset/v1p7beta1
+  - api_shortname: cloudbuild
+    name_pretty: Cloud Build
+    product_documentation: https://cloud.google.com/cloud-build/
+    api_description: lets you build software quickly across all languages. Get complete
+        control over defining custom workflows for building, testing, and deploying across
+        multiple environments such as VMs, serverless, Kubernetes, or Firebase.
+    release_level: stable
+    distribution_name: com.google.cloud:google-cloud-build
+    issue_tracker: https://issuetracker.google.com/savedsearches/5226584
+    GAPICs:
+       - proto_path: google/devtools/cloudbuild/v1
+       - proto_path: google/devtools/cloudbuild/v2


### PR DESCRIPTION
In this PR:
- Allow selectively generate libraries by adding `--library-names` to CLI.

We have a request of partially releasing google-cloud-java (b/331628538), which requires only generating a selective list of libraries.

This change allows a user-defined list of libraries to be generated even if the corresponding library configs are the same.