### PR TITLE
fix: generator setting incorrect name/class for sample due to region tag

### DIFF
--- a/.cloudbuild/library_generation/library_generation.Dockerfile
+++ b/.cloudbuild/library_generation/library_generation.Dockerfile
@@ -35,6 +35,7 @@ SHELL [ "/bin/bash", "-c" ]
 ARG OWLBOT_CLI_COMMITTISH=38fe6f89a2339ee75c77739b31b371f601b01bb3
 ARG PROTOC_VERSION=25.5
 ARG GRPC_VERSION=1.67.1
+ARG JAVA_FORMAT_VERSION=1.7
 ENV HOME=/home
 ENV OS_ARCHITECTURE="linux-x86_64"
 
@@ -100,6 +101,11 @@ RUN npm i && npm run compile && npm link
 RUN owl-bot copy-code --version
 RUN chmod -R o+rx ${NODE_PATH}
 RUN ln -sf ${NODE_PATH}/* /usr/local/bin
+
+# download the Java formatter
+ADD https://maven-central.storage-download.googleapis.com/maven2/com/google/googlejavaformat/google-java-format/${JAVA_FORMAT_VERSION}/google-java-format-${JAVA_FORMAT_VERSION}-all-deps.jar \
+  "${HOME}"/.library_generation/google-java-format.jar
+RUN chmod 755 "${HOME}"/.library_generation/google-java-format.jar
 
 # allow users to access the script folders
 RUN chmod -R o+rx /src

--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientHeaderSampleComposer.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientHeaderSampleComposer.java
@@ -338,7 +338,7 @@ public class ServiceClientHeaderSampleComposer {
         RegionTag.builder()
             .setServiceName(service.name())
             .setRpcName(rpcName)
-            .setOverloadDisambiguation("setCredentialsProvider")
+            .setOverloadDisambiguation("useHttpJsonTransport")
             .build();
     return Sample.builder().setBody(sampleBody).setRegionTag(regionTag).build();
   }

--- a/library_generation/DEVELOPMENT.md
+++ b/library_generation/DEVELOPMENT.md
@@ -51,9 +51,8 @@ This section explains how to run the entrypoint script
 ## Assumptions made by the scripts
 ### The Hermetic Build's well-known folder
 Located in `${HOME}/.library_generation`, this folder is assumed by the scripts
-to contain the generator JAR. 
-Please note that this is a recent feature and only this jar is expected to be
-there. 
+to contain certain tools.
+
 Developers must make sure this folder is properly configured before running the
 scripts locally.
 Note that this relies on the `HOME` en var which is always defined as per
@@ -73,7 +72,16 @@ The generation scripts will assume the jar is there.
 mv /path/to/jar "${HOME}/.library_generation/gapic-generator-java.jar"
 ```
 
+#### Put the java formatter jar in its well-known location
 
+Download google-java-format-{version}-all-deps.jar from [Maven Central](https://central.sonatype.com/artifact/com.google.googlejavaformat/google-java-format)
+or [GitHub releases](https://github.com/google/google-java-format/releases).
+Then `mv` the jar into the well-known location of the jar.
+The generation scripts will assume the jar is there.
+
+```shell
+mv /path/to/jar "${HOME}/.library_generation/google-java-format.jar"
+```
 
 ## Installing prerequisites
 

--- a/library_generation/README.md
+++ b/library_generation/README.md
@@ -8,7 +8,6 @@ google-cloud-java) from a configuration file.
 
 - OS: Linux
 - Java runtime environment (8 or above)
-- Apache Maven (used in formatting source code)
 - Python (3.11.6 or above)
 - Docker 
 - Git

--- a/library_generation/owlbot/bin/entrypoint.sh
+++ b/library_generation/owlbot/bin/entrypoint.sh
@@ -65,7 +65,7 @@ echo "...done"
 
 # write or restore clirr-ignored-differences.xml
 echo "Generating clirr-ignored-differences.xml..."
-${scripts_root}/owlbot/bin/write_clirr_ignore.sh "${scripts_root}"
+"${scripts_root}"/owlbot/bin/write_clirr_ignore.sh "${scripts_root}"
 echo "...done"
 
 # fix license headers
@@ -73,12 +73,6 @@ echo "Fixing missing license headers..."
 python3 "${scripts_root}/owlbot/src/fix-license-headers.py"
 echo "...done"
 
-# Ensure formatting on all .java files in the repository.
-# Here we manually set the user.home system variable. Unfortunately, Maven
-# user.home inference involves the /etc/passwd file (confirmed empirically),
-# instead of the presumable $HOME env var, which may not work properly
-# when `docker run`ning with the -u flag because we may incur in users
-# not registered in the container's /etc/passwd file
 echo "Reformatting source..."
-mvn fmt:format -Duser.home="${HOME}" -V --batch-mode --no-transfer-progress
+"${scripts_root}"/owlbot/bin/format_source.sh "${scripts_root}"
 echo "...done"

--- a/library_generation/owlbot/bin/format_source.sh
+++ b/library_generation/owlbot/bin/format_source.sh
@@ -22,9 +22,11 @@ set -e
 
 # Find all the java files relative to the current directory and format them
 # using google-java-format
-list="$(find . -name '*.java' -not -path ".*/samples/snippets/generated/**/*" )"
 scripts_root=$1
-tmpfile=$(mktemp)
+
+source "${scripts_root}/utils/utilities.sh"
+list="$(find . -name '*.java' -not -path ".*/samples/snippets/generated/**/*" )"
+tmp_file=$(mktemp)
 
 for file in $list;
 do
@@ -35,19 +37,11 @@ do
   then
     echo "File skipped formatting: $file"
   else
-   echo $file >> $tmpfile
+   echo $file >> $tmp_file
   fi
 done
 
-# download the google-java-format tool
-if [ ! -f "${scripts_root}/owlbot/google-java-format.jar" ]; then
-  echo 'downloading google-java-format'
-  java_format_version=$(cat "${scripts_root}/configuration/java-format-version")
-  wget -O "${scripts_root}/owlbot/google-java-format.jar" https://repo1.maven.org/maven2/com/google/googlejavaformat/google-java-format/${java_format_version}/google-java-format-${java_format_version}-all-deps.jar
+# use formatter downloaded in the Dockerfile.
+cat $tmp_file | xargs java -jar "$(get_java_formatter_location)" --replace
 
-fi
-
-# format the source
-cat $tmpfile | xargs java -jar "${scripts_root}/owlbot/google-java-format.jar" --replace
-
-rm $tmpfile
+rm $tmp_file

--- a/library_generation/test/generate_library_unit_tests.sh
+++ b/library_generation/test/generate_library_unit_tests.sh
@@ -12,6 +12,7 @@ source "${script_dir}"/test_utilities.sh
 readonly SIMULATED_HOME=$(mktemp -d)
 mkdir "${SIMULATED_HOME}/.library_generation"
 touch "${SIMULATED_HOME}/.library_generation/gapic-generator-java.jar"
+touch "${SIMULATED_HOME}/.library_generation/google-java-format.jar"
 HOME="${SIMULATED_HOME}" source "${script_dir}"/../utils/utilities.sh
 
 # Unit tests

--- a/library_generation/test/utilities_unit_tests.py
+++ b/library_generation/test/utilities_unit_tests.py
@@ -303,6 +303,14 @@ class UtilitiesTest(unittest.TestCase):
         self.assertEqual(["misc"], library_path)
         shutil.rmtree(repo_config.output_folder)
 
+    def test_get_java_generator_location_success(self):
+        location = util.sh_util("get_gapic_generator_location")
+        self.assertRegex(location, r"/.library_generation/gapic-generator-java.jar$")
+
+    def test_get_java_formatter_location_success(self):
+        location = util.sh_util("get_java_formatter_location")
+        self.assertRegex(location, r"/.library_generation/google-java-format.jar$")
+
     def __setup_postprocessing_prerequisite_files(
         self,
         combination: int,

--- a/showcase/scripts/generate_showcase.sh
+++ b/showcase/scripts/generate_showcase.sh
@@ -55,10 +55,14 @@ if [ ! -d google ];then
   rm -rdf googleapis
 fi
 
-# copy the generator into its well-known location. For more details,
+# copy the generator and formatter into its well-known location.
+# For more details,
 # refer to library_generation/DEVELOPMENT.md
+java_formatter_name="google-java-format.jar"
+java_formatter_version="1.7"
 well_known_folder="${HOME}/.library_generation"
 well_known_generator_jar_location="${well_known_folder}/gapic-generator-java.jar"
+well_known_formatter_jar_location="${well_known_folder}/${java_formatter_name}"
 if [[ ! -d "${well_known_folder}" ]]; then
   mkdir "${well_known_folder}"
 fi
@@ -66,19 +70,27 @@ if [[ -f "${well_known_generator_jar_location}" ]]; then
   echo "replacing well-known generator jar with the latest one"
   rm "${well_known_generator_jar_location}"
 fi
+if [[ -f "${well_known_formatter_jar_location}" ]]; then
+  echo "replacing well-known formatter jar with the latest one"
+  rm "${well_known_formatter_jar_location}"
+fi
 maven_repository="$(mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout)"
 generator_version=$(get_version_from_versions_txt "gapic-generator-java")
-source_jar_path="${maven_repository}/com/google/api/gapic-generator-java/${generator_version}/gapic-generator-java-${generator_version}.jar"
+generator_jar_path="${maven_repository}/com/google/api/gapic-generator-java/${generator_version}/gapic-generator-java-${generator_version}.jar"
 
-if [[ ! -f "${source_jar_path}" ]]; then
+if [[ ! -f "${generator_jar_path}" ]]; then
   echo "generator jar not found in its assumed location"
-  echo "in the local repository: ${source_jar_path}"
+  echo "in the local repository: ${generator_jar_path}"
   echo "(did you run mvn install in this repository's root?)"
   exit 1
 fi
 # transfer the snapshot jar into its well-known location
-cp "${source_jar_path}" "${well_known_generator_jar_location}"
-
+cp "${generator_jar_path}" "${well_known_generator_jar_location}"
+# transfer java formatter to its well-known location
+download_from \
+  "https://maven-central.storage-download.googleapis.com/maven2/com/google/googlejavaformat/google-java-format/${java_formatter_version}/google-java-format-${java_formatter_version}-all-deps.jar" \
+  "${java_formatter_name}"
+cp "${java_formatter_name}" "${well_known_formatter_jar_location}"
 gapic_additional_protos="google/iam/v1/iam_policy.proto google/cloud/location/locations.proto"
 
 path_to_generator_parent_pom="${SCRIPT_DIR}/../../gapic-generator-java-pom-parent/pom.xml"

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/create/SyncCreateUseHttpJsonTransport.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/create/SyncCreateUseHttpJsonTransport.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.asset.v1.samples;
+
+// [START cloudasset_v1_generated_AssetService_Create_UseHttpJsonTransport_sync]
+import com.google.cloud.asset.v1.AssetServiceClient;
+import com.google.cloud.asset.v1.AssetServiceSettings;
+
+public class SyncCreateUseHttpJsonTransport {
+
+  public static void main(String[] args) throws Exception {
+    syncCreateUseHttpJsonTransport();
+  }
+
+  public static void syncCreateUseHttpJsonTransport() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    AssetServiceSettings assetServiceSettings = AssetServiceSettings.newHttpJsonBuilder().build();
+    AssetServiceClient assetServiceClient = AssetServiceClient.create(assetServiceSettings);
+  }
+}
+// [END cloudasset_v1_generated_AssetService_Create_UseHttpJsonTransport_sync]


### PR DESCRIPTION
Fixes #1272

Tested by following instructions https://github.com/googleapis/sdk-platform-java/blob/main/gapic-generator-java/DEVELOPMENT.md#running-the-plugin-under-googleapis-with-local-gapic-generator-java

Ran 
```
bazelisk build //google/cloud/tpu/v2:google-cloud-tpu-v2-java
```
Generated samples, included new google-cloud-tpu-v2-java/samples/snippets/generated/com/google/cloud/tpu/v2/tpu/create/SyncCreateUseHttpJsonTransport.java

```
/*
 * Copyright 2024 Google LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
 *      https://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */

package com.google.cloud.tpu.v2.samples;

// [START tpu_v2_generated_Tpu_Create_UseHttpJsonTransport_sync]
import com.google.cloud.tpu.v2.TpuClient;
import com.google.cloud.tpu.v2.TpuSettings;

public class SyncCreateUseHttpJsonTransport {

  public static void main(String[] args) throws Exception {
    syncCreateUseHttpJsonTransport();
  }

  public static void syncCreateUseHttpJsonTransport() throws Exception {
    // This snippet has been automatically generated and should be regarded as a code template only.
    // It will require modifications to work:
    // - It may require correct/in-range values for request initialization.
    // - It may require specifying regional endpoints when creating the service client as shown in
    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
    TpuSettings tpuSettings = TpuSettings.newHttpJsonBuilder().build();
    TpuClient tpuClient = TpuClient.create(tpuSettings);
  }
}
// [END tpu_v2_generated_Tpu_Create_UseHttpJsonTransport_sync]
```
