### PR TITLE
fix: generator setting incorrect name/class for sample due to region tag (2nd attempt)

### DIFF
--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientHeaderSampleComposer.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientHeaderSampleComposer.java
@@ -338,7 +338,7 @@ public class ServiceClientHeaderSampleComposer {
         RegionTag.builder()
             .setServiceName(service.name())
             .setRpcName(rpcName)
-            .setOverloadDisambiguation("setCredentialsProvider")
+            .setOverloadDisambiguation("useHttpJsonTransport")
             .build();
     return Sample.builder().setBody(sampleBody).setRegionTag(regionTag).build();
   }

--- a/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservice/create/SyncCreateUseHttpJsonTransport.java
+++ b/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservice/create/SyncCreateUseHttpJsonTransport.java
@@ -14,27 +14,28 @@
  * limitations under the License.
  */
 
-package com.google.cloud.example.library.v1.samples;
+package com.google.cloud.apigeeconnect.v1.samples;
 
-// [START example_v1_generated_LibraryService_Create_SetCredentialsProvider1_sync]
-import com.google.cloud.example.library.v1.LibraryServiceClient;
-import com.google.cloud.example.library.v1.LibraryServiceSettings;
+// [START apigeeconnect_v1_generated_ConnectionService_Create_UseHttpJsonTransport_sync]
+import com.google.cloud.apigeeconnect.v1.ConnectionServiceClient;
+import com.google.cloud.apigeeconnect.v1.ConnectionServiceSettings;
 
-public class SyncCreateSetCredentialsProvider1 {
+public class SyncCreateUseHttpJsonTransport {
 
   public static void main(String[] args) throws Exception {
-    syncCreateSetCredentialsProvider1();
+    syncCreateUseHttpJsonTransport();
   }
 
-  public static void syncCreateSetCredentialsProvider1() throws Exception {
+  public static void syncCreateUseHttpJsonTransport() throws Exception {
     // This snippet has been automatically generated and should be regarded as a code template only.
     // It will require modifications to work:
     // - It may require correct/in-range values for request initialization.
     // - It may require specifying regional endpoints when creating the service client as shown in
     // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
-    LibraryServiceSettings libraryServiceSettings =
-        LibraryServiceSettings.newHttpJsonBuilder().build();
-    LibraryServiceClient libraryServiceClient = LibraryServiceClient.create(libraryServiceSettings);
+    ConnectionServiceSettings connectionServiceSettings =
+        ConnectionServiceSettings.newHttpJsonBuilder().build();
+    ConnectionServiceClient connectionServiceClient =
+        ConnectionServiceClient.create(connectionServiceSettings);
   }
 }
-// [END example_v1_generated_LibraryService_Create_SetCredentialsProvider1_sync]
+// [END apigeeconnect_v1_generated_ConnectionService_Create_UseHttpJsonTransport_sync]

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/create/SyncCreateUseHttpJsonTransport.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/create/SyncCreateUseHttpJsonTransport.java
@@ -16,17 +16,17 @@
 
 package com.google.cloud.asset.v1.samples;
 
-// [START cloudasset_v1_generated_AssetService_Create_SetCredentialsProvider1_sync]
+// [START cloudasset_v1_generated_AssetService_Create_UseHttpJsonTransport_sync]
 import com.google.cloud.asset.v1.AssetServiceClient;
 import com.google.cloud.asset.v1.AssetServiceSettings;
 
-public class SyncCreateSetCredentialsProvider1 {
+public class SyncCreateUseHttpJsonTransport {
 
   public static void main(String[] args) throws Exception {
-    syncCreateSetCredentialsProvider1();
+    syncCreateUseHttpJsonTransport();
   }
 
-  public static void syncCreateSetCredentialsProvider1() throws Exception {
+  public static void syncCreateUseHttpJsonTransport() throws Exception {
     // This snippet has been automatically generated and should be regarded as a code template only.
     // It will require modifications to work:
     // - It may require correct/in-range values for request initialization.
@@ -36,4 +36,4 @@ public class SyncCreateSetCredentialsProvider1 {
     AssetServiceClient assetServiceClient = AssetServiceClient.create(assetServiceSettings);
   }
 }
-// [END cloudasset_v1_generated_AssetService_Create_SetCredentialsProvider1_sync]
+// [END cloudasset_v1_generated_AssetService_Create_UseHttpJsonTransport_sync]

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/create/SyncCreateUseHttpJsonTransport.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/create/SyncCreateUseHttpJsonTransport.java
@@ -14,26 +14,27 @@
  * limitations under the License.
  */
 
-package com.google.cloud.redis.v1beta1.samples;
+package com.google.cloud.iam.credentials.v1.samples;
 
-// [START redis_v1beta1_generated_CloudRedis_Create_SetCredentialsProvider1_sync]
-import com.google.cloud.redis.v1beta1.CloudRedisClient;
-import com.google.cloud.redis.v1beta1.CloudRedisSettings;
+// [START iamcredentials_v1_generated_IAMCredentials_Create_UseHttpJsonTransport_sync]
+import com.google.cloud.iam.credentials.v1.IamCredentialsClient;
+import com.google.cloud.iam.credentials.v1.IamCredentialsSettings;
 
-public class SyncCreateSetCredentialsProvider1 {
+public class SyncCreateUseHttpJsonTransport {
 
   public static void main(String[] args) throws Exception {
-    syncCreateSetCredentialsProvider1();
+    syncCreateUseHttpJsonTransport();
   }
 
-  public static void syncCreateSetCredentialsProvider1() throws Exception {
+  public static void syncCreateUseHttpJsonTransport() throws Exception {
     // This snippet has been automatically generated and should be regarded as a code template only.
     // It will require modifications to work:
     // - It may require correct/in-range values for request initialization.
     // - It may require specifying regional endpoints when creating the service client as shown in
     // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
-    CloudRedisSettings cloudRedisSettings = CloudRedisSettings.newHttpJsonBuilder().build();
-    CloudRedisClient cloudRedisClient = CloudRedisClient.create(cloudRedisSettings);
+    IamCredentialsSettings iamCredentialsSettings =
+        IamCredentialsSettings.newHttpJsonBuilder().build();
+    IamCredentialsClient iamCredentialsClient = IamCredentialsClient.create(iamCredentialsSettings);
   }
 }
-// [END redis_v1beta1_generated_CloudRedis_Create_SetCredentialsProvider1_sync]
+// [END iamcredentials_v1_generated_IAMCredentials_Create_UseHttpJsonTransport_sync]

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/create/SyncCreateUseHttpJsonTransport.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/create/SyncCreateUseHttpJsonTransport.java
@@ -14,28 +14,27 @@
  * limitations under the License.
  */
 
-package com.google.cloud.apigeeconnect.v1.samples;
+package com.google.cloud.example.library.v1.samples;
 
-// [START apigeeconnect_v1_generated_ConnectionService_Create_SetCredentialsProvider1_sync]
-import com.google.cloud.apigeeconnect.v1.ConnectionServiceClient;
-import com.google.cloud.apigeeconnect.v1.ConnectionServiceSettings;
+// [START example_v1_generated_LibraryService_Create_UseHttpJsonTransport_sync]
+import com.google.cloud.example.library.v1.LibraryServiceClient;
+import com.google.cloud.example.library.v1.LibraryServiceSettings;
 
-public class SyncCreateSetCredentialsProvider1 {
+public class SyncCreateUseHttpJsonTransport {
 
   public static void main(String[] args) throws Exception {
-    syncCreateSetCredentialsProvider1();
+    syncCreateUseHttpJsonTransport();
   }
 
-  public static void syncCreateSetCredentialsProvider1() throws Exception {
+  public static void syncCreateUseHttpJsonTransport() throws Exception {
     // This snippet has been automatically generated and should be regarded as a code template only.
     // It will require modifications to work:
     // - It may require correct/in-range values for request initialization.
     // - It may require specifying regional endpoints when creating the service client as shown in
     // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
-    ConnectionServiceSettings connectionServiceSettings =
-        ConnectionServiceSettings.newHttpJsonBuilder().build();
-    ConnectionServiceClient connectionServiceClient =
-        ConnectionServiceClient.create(connectionServiceSettings);
+    LibraryServiceSettings libraryServiceSettings =
+        LibraryServiceSettings.newHttpJsonBuilder().build();
+    LibraryServiceClient libraryServiceClient = LibraryServiceClient.create(libraryServiceSettings);
   }
 }
-// [END apigeeconnect_v1_generated_ConnectionService_Create_SetCredentialsProvider1_sync]
+// [END example_v1_generated_LibraryService_Create_UseHttpJsonTransport_sync]

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/create/SyncCreateUseHttpJsonTransport.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/create/SyncCreateUseHttpJsonTransport.java
@@ -14,27 +14,26 @@
  * limitations under the License.
  */
 
-package com.google.cloud.iam.credentials.v1.samples;
+package com.google.cloud.redis.v1beta1.samples;
 
-// [START iamcredentials_v1_generated_IAMCredentials_Create_SetCredentialsProvider1_sync]
-import com.google.cloud.iam.credentials.v1.IamCredentialsClient;
-import com.google.cloud.iam.credentials.v1.IamCredentialsSettings;
+// [START redis_v1beta1_generated_CloudRedis_Create_UseHttpJsonTransport_sync]
+import com.google.cloud.redis.v1beta1.CloudRedisClient;
+import com.google.cloud.redis.v1beta1.CloudRedisSettings;
 
-public class SyncCreateSetCredentialsProvider1 {
+public class SyncCreateUseHttpJsonTransport {
 
   public static void main(String[] args) throws Exception {
-    syncCreateSetCredentialsProvider1();
+    syncCreateUseHttpJsonTransport();
   }
 
-  public static void syncCreateSetCredentialsProvider1() throws Exception {
+  public static void syncCreateUseHttpJsonTransport() throws Exception {
     // This snippet has been automatically generated and should be regarded as a code template only.
     // It will require modifications to work:
     // - It may require correct/in-range values for request initialization.
     // - It may require specifying regional endpoints when creating the service client as shown in
     // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
-    IamCredentialsSettings iamCredentialsSettings =
-        IamCredentialsSettings.newHttpJsonBuilder().build();
-    IamCredentialsClient iamCredentialsClient = IamCredentialsClient.create(iamCredentialsSettings);
+    CloudRedisSettings cloudRedisSettings = CloudRedisSettings.newHttpJsonBuilder().build();
+    CloudRedisClient cloudRedisClient = CloudRedisClient.create(cloudRedisSettings);
   }
 }
-// [END iamcredentials_v1_generated_IAMCredentials_Create_SetCredentialsProvider1_sync]
+// [END redis_v1beta1_generated_CloudRedis_Create_UseHttpJsonTransport_sync]


### PR DESCRIPTION
Fixes #1272

Tested by following instructions https://github.com/googleapis/sdk-platform-java/blob/main/gapic-generator-java/DEVELOPMENT.md#running-the-plugin-under-googleapis-with-local-gapic-generator-java

Ran 
```
bazelisk build //google/cloud/tpu/v2:google-cloud-tpu-v2-java
```
Generated samples, included new google-cloud-tpu-v2-java/samples/snippets/generated/com/google/cloud/tpu/v2/tpu/create/SyncCreateUseHttpJsonTransport.java

```
/*
 * Copyright 2024 Google LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
 *      https://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */

package com.google.cloud.tpu.v2.samples;

// [START tpu_v2_generated_Tpu_Create_UseHttpJsonTransport_sync]
import com.google.cloud.tpu.v2.TpuClient;
import com.google.cloud.tpu.v2.TpuSettings;

public class SyncCreateUseHttpJsonTransport {

  public static void main(String[] args) throws Exception {
    syncCreateUseHttpJsonTransport();
  }

  public static void syncCreateUseHttpJsonTransport() throws Exception {
    // This snippet has been automatically generated and should be regarded as a code template only.
    // It will require modifications to work:
    // - It may require correct/in-range values for request initialization.
    // - It may require specifying regional endpoints when creating the service client as shown in
    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
    TpuSettings tpuSettings = TpuSettings.newHttpJsonBuilder().build();
    TpuClient tpuClient = TpuClient.create(tpuSettings);
  }
}
// [END tpu_v2_generated_Tpu_Create_UseHttpJsonTransport_sync]
```
