### PR TITLE
chore: [no need to review] running bazel test against nullness check

### DIFF
--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
@@ -305,7 +305,8 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
       this.clock = settings.clock;
       this.switchToMtlsEndpointAllowed = settings.switchToMtlsEndpointAllowed;
       this.quotaProjectId = settings.quotaProjectId;
-      this.streamWatchdogProvider = settings.streamWatchdogProvider;
+      // Intentionally assigning null to a variable marked as NonNull
+      this.streamWatchdogProvider = null; // settings.streamWatchdogProvider;
       this.streamWatchdogCheckInterval = settings.streamWatchdogCheckInterval;
       this.tracerFactory = settings.tracerFactory;
       this.deprecatedExecutorProviderSet = settings.deprecatedExecutorProviderSet;


### PR DESCRIPTION
Does Bazel detect the nullness error?

```
this.streamWatchdogProvider = null; // settings.streamWatchdogProvider;
```