### PR TITLE
chore: skip formatting test-jdk17 files in firestore

### DIFF
--- a/hermetic_build/library_generation/owlbot/bin/format_source.sh
+++ b/hermetic_build/library_generation/owlbot/bin/format_source.sh
@@ -36,6 +36,9 @@ do
   elif [[ $file =~ .*/samples/snippets/src/.*/java/com/example/spanner/.*.java ]];
   then
     echo "File skipped formatting: $file"
+  elif [[ $file =~ .*/test-jdk17/java/com/google/cloud/firestore/.*java ]];
+    then
+      echo "File skipped formatting: $file"
   else
    echo $file >> $tmp_file
   fi


### PR DESCRIPTION
In firestore, [RecordMapperTest.java](https://github.com/googleapis/java-firestore/blob/main/google-cloud-firestore/src/test-jdk17/java/com/google/cloud/firestore/RecordMapperTest.java) has Java Records which is incompatible with java formatter 1.7. 

This PR is to skip these files.