### PR TITLE
chore: remove .m2 folder mapping in library generation workflow

### DIFF
--- a/.github/scripts/hermetic_library_generation.sh
+++ b/.github/scripts/hermetic_library_generation.sh
@@ -98,7 +98,6 @@ docker run \
   --quiet \
   -u "$(id -u):$(id -g)" \
   -v "$(pwd):${workspace_name}" \
-  -v "${m2_folder}":/home/.m2 \
   -v "${api_def_dir}:${workspace_name}/googleapis" \
   -e GENERATOR_VERSION="${image_tag}" \
   gcr.io/cloud-devrel-public-resources/java-library-generation:"${image_tag}" \


### PR DESCRIPTION
https://github.com/googleapis/sdk-platform-java/pull/3271 renders this volume mapping unnecessary