### PR TITLE
fix: use BuildKit instead of legacy builder to build the Hermetic Build images

### DIFF
--- a/.cloudbuild/library_generation/cloudbuild-library-generation-push-prod.yaml
+++ b/.cloudbuild/library_generation/cloudbuild-library-generation-push-prod.yaml
@@ -30,6 +30,8 @@ steps:
       "--file", ".cloudbuild/library_generation/library_generation.Dockerfile", "."]
     id: library-generation-build
     waitFor: ["-"]
+    env: 
+      - 'DOCKER_BUILDKIT=1'
 
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/.cloudbuild/library_generation/cloudbuild-library-generation-push.yaml
+++ b/.cloudbuild/library_generation/cloudbuild-library-generation-push.yaml
@@ -30,6 +30,8 @@ steps:
       "--file", ".cloudbuild/library_generation/library_generation.Dockerfile", "."]
     id: library-generation-build
     waitFor: ["-"]
+    env: 
+      - 'DOCKER_BUILDKIT=1'
 
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/hermetic_build/DEVELOPMENT.md
+++ b/hermetic_build/DEVELOPMENT.md
@@ -167,9 +167,6 @@ python hermetic_build/library_generation/cli/entry_point.py generate \
    ```
    Please note that the build only works when using the new
    [Docker BuildKit](https://docs.docker.com/build/buildkit/) (enabled through the `DOCKER_BUILDKIT` variable).
-   This is meant for local development only (in CloudTops) - GH Actions' Ubuntu-22.04 \
-   [comes with the latest Docker version](https://github.com/actions/runner-images/blob/e74605cd6d5407469cf224802f25057bafc23d70/images/ubuntu/Ubuntu2204-Readme.md?plain=1#L81-L83)
-   and is able to handle the build properly using the (updated) legacy builder.
    
 3. Set the version of gapic-generator-java
 

--- a/hermetic_build/library_generation/tests/integration_tests.py
+++ b/hermetic_build/library_generation/tests/integration_tests.py
@@ -202,7 +202,7 @@ class IntegrationTest(unittest.TestCase):
         subprocess.check_call(
             ["docker", "build", "-f", docker_file, "-t", image_tag, "."],
             cwd=cwd,
-            env=dict(os.environ, DOCKER_BUILDKIT="1")
+            env=dict(os.environ, DOCKER_BUILDKIT="1"),
         )
 
     @classmethod

--- a/hermetic_build/library_generation/tests/integration_tests.py
+++ b/hermetic_build/library_generation/tests/integration_tests.py
@@ -200,8 +200,9 @@ class IntegrationTest(unittest.TestCase):
         # we build the docker image without removing intermediate containers, so
         # we can re-test more quickly
         subprocess.check_call(
-            ["DOCKER_BUILDKIT=1", "docker", "build", "-f", docker_file, "-t", image_tag, "."],
+            ["docker", "build", "-f", docker_file, "-t", image_tag, "."],
             cwd=cwd,
+            env=dict(os.environ, DOCKER_BUILDKIT="1")
         )
 
     @classmethod

--- a/hermetic_build/library_generation/tests/integration_tests.py
+++ b/hermetic_build/library_generation/tests/integration_tests.py
@@ -200,7 +200,7 @@ class IntegrationTest(unittest.TestCase):
         # we build the docker image without removing intermediate containers, so
         # we can re-test more quickly
         subprocess.check_call(
-            ["docker", "build", "-f", docker_file, "-t", image_tag, "."],
+            ["DOCKER_BUILDKIT=1", "docker", "build", "-f", docker_file, "-t", image_tag, "."],
             cwd=cwd,
         )
 


### PR DESCRIPTION
Fixes the following error:

![image](https://github.com/user-attachments/assets/c4d20cbc-e3b3-48d6-9846-896854145857)

[Docker Buildkit](https://docs.docker.com/build/buildkit/) is a more advanced version and more actively maintained. We confirmed locally that the error occurs with an old version of the docker builder and that it is fixed when using `DOCKER_BUILDKIT=1`