### PR TITLE
chore: randomize temp output directory

### DIFF
--- a/.cloudbuild/library_generation/library_generation.Dockerfile
+++ b/.cloudbuild/library_generation/library_generation.Dockerfile
@@ -62,7 +62,7 @@ ENV HOME=/home
 ENV OS_ARCHITECTURE="linux-x86_64"
 
 # install OS tools
-RUN apk update && apk add unzip curl rsync openjdk11 jq bash nodejs npm git uuidgen
+RUN apk update && apk add unzip curl rsync openjdk11 jq bash nodejs npm git
 
 SHELL [ "/bin/bash", "-c" ]
 

--- a/.cloudbuild/library_generation/library_generation.Dockerfile
+++ b/.cloudbuild/library_generation/library_generation.Dockerfile
@@ -62,7 +62,7 @@ ENV HOME=/home
 ENV OS_ARCHITECTURE="linux-x86_64"
 
 # install OS tools
-RUN apk update && apk add unzip curl rsync openjdk11 jq bash nodejs npm git
+RUN apk update && apk add unzip curl rsync openjdk11 jq bash nodejs npm git uuidgen
 
 SHELL [ "/bin/bash", "-c" ]
 

--- a/hermetic_build/library_generation/generate_library.sh
+++ b/hermetic_build/library_generation/generate_library.sh
@@ -115,7 +115,7 @@ if [ -z "${os_architecture}" ]; then
   os_architecture=$(detect_os_architecture)
 fi
 
-temp_destination_path="${output_folder}/temp_preprocessed"
+temp_destination_path="${output_folder}/temp_preprocessed/$(uuidgen)"
 mkdir -p "${output_folder}/${destination_path}"
 if [ -d "${temp_destination_path}" ]; then
   # we don't want the preprocessed sources of a previous run

--- a/hermetic_build/library_generation/generate_library.sh
+++ b/hermetic_build/library_generation/generate_library.sh
@@ -115,7 +115,9 @@ if [ -z "${os_architecture}" ]; then
   os_architecture=$(detect_os_architecture)
 fi
 random_suffix=$(LC_ALL=C tr -dc 'a-zA-Z' < /dev/urandom | fold -w 20 | head -n 1)
+echo "1"
 temp_destination_path="${output_folder}/temp_preprocessed/${random_suffix}"
+echo "2"
 mkdir -p "${output_folder}/${destination_path}"
 if [ -d "${temp_destination_path}" ]; then
   # we don't want the preprocessed sources of a previous run

--- a/hermetic_build/library_generation/generate_library.sh
+++ b/hermetic_build/library_generation/generate_library.sh
@@ -114,7 +114,7 @@ fi
 if [ -z "${os_architecture}" ]; then
   os_architecture=$(detect_os_architecture)
 fi
-random_suffix=$(LC_ALL=C tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 10 | head -n 1)
+random_suffix=$(LC_ALL=C tr -dc 'a-zA-Z' < /dev/urandom | fold -w 20 | head -n 1)
 temp_destination_path="${output_folder}/temp_preprocessed/${random_suffix}"
 mkdir -p "${output_folder}/${destination_path}"
 if [ -d "${temp_destination_path}" ]; then

--- a/hermetic_build/library_generation/generate_library.sh
+++ b/hermetic_build/library_generation/generate_library.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eo pipefail
+set -xeo pipefail
 
 # parse input parameters
 while [[ $# -gt 0 ]]; do

--- a/hermetic_build/library_generation/generate_library.sh
+++ b/hermetic_build/library_generation/generate_library.sh
@@ -114,10 +114,8 @@ fi
 if [ -z "${os_architecture}" ]; then
   os_architecture=$(detect_os_architecture)
 fi
-random_suffix=$(LC_ALL=C tr -dc 'a-zA-Z' < /dev/urandom | fold -w 20 | head -n 1)
-echo "1"
+random_suffix=$(LC_ALL=C tr -dc 'a-zA-Z' < /dev/urandom | fold -w 20 | awk 'NR==1 {print; exit}')
 temp_destination_path="${output_folder}/temp_preprocessed/${random_suffix}"
-echo "2"
 mkdir -p "${output_folder}/${destination_path}"
 if [ -d "${temp_destination_path}" ]; then
   # we don't want the preprocessed sources of a previous run

--- a/hermetic_build/library_generation/generate_library.sh
+++ b/hermetic_build/library_generation/generate_library.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -xeo pipefail
+set -eo pipefail
 
 # parse input parameters
 while [[ $# -gt 0 ]]; do

--- a/hermetic_build/library_generation/generate_library.sh
+++ b/hermetic_build/library_generation/generate_library.sh
@@ -114,8 +114,8 @@ fi
 if [ -z "${os_architecture}" ]; then
   os_architecture=$(detect_os_architecture)
 fi
-random_suffix=$(LC_ALL=C tr -dc 'a-zA-Z' < /dev/urandom | head -c 20)
-temp_destination_path="${output_folder}/temp_preprocessed/${random_suffix}"
+
+temp_destination_path="${output_folder}/temp_preprocessed-$RANDOM"
 mkdir -p "${output_folder}/${destination_path}"
 if [ -d "${temp_destination_path}" ]; then
   # we don't want the preprocessed sources of a previous run

--- a/hermetic_build/library_generation/generate_library.sh
+++ b/hermetic_build/library_generation/generate_library.sh
@@ -114,7 +114,7 @@ fi
 if [ -z "${os_architecture}" ]; then
   os_architecture=$(detect_os_architecture)
 fi
-random_suffix=$(LC_ALL=C tr -dc 'a-zA-Z' < /dev/urandom | head -c 30 | fold -w 20 | head -n 1)
+random_suffix=$(LC_ALL=C tr -dc 'a-zA-Z' < /dev/urandom | head -c 20)
 temp_destination_path="${output_folder}/temp_preprocessed/${random_suffix}"
 mkdir -p "${output_folder}/${destination_path}"
 if [ -d "${temp_destination_path}" ]; then

--- a/hermetic_build/library_generation/generate_library.sh
+++ b/hermetic_build/library_generation/generate_library.sh
@@ -114,8 +114,8 @@ fi
 if [ -z "${os_architecture}" ]; then
   os_architecture=$(detect_os_architecture)
 fi
-
-temp_destination_path="${output_folder}/temp_preprocessed/$(uuidgen)"
+random_suffix=$(LC_ALL=C tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 10 | head -n 1)
+temp_destination_path="${output_folder}/temp_preprocessed/${random_suffix}"
 mkdir -p "${output_folder}/${destination_path}"
 if [ -d "${temp_destination_path}" ]; then
   # we don't want the preprocessed sources of a previous run

--- a/hermetic_build/library_generation/generate_library.sh
+++ b/hermetic_build/library_generation/generate_library.sh
@@ -114,7 +114,7 @@ fi
 if [ -z "${os_architecture}" ]; then
   os_architecture=$(detect_os_architecture)
 fi
-random_suffix=$(LC_ALL=C tr -dc 'a-zA-Z' < /dev/urandom | fold -w 20 | awk 'NR==1 {print; exit}')
+random_suffix=$(LC_ALL=C tr -dc 'a-zA-Z' < /dev/urandom | head -c 30 | fold -w 20 | head -n 1)
 temp_destination_path="${output_folder}/temp_preprocessed/${random_suffix}"
 mkdir -p "${output_folder}/${destination_path}"
 if [ -d "${temp_destination_path}" ]; then


### PR DESCRIPTION
In this PR:
- Use `$RANDOM` (a shell variable that generates a random integer between 0 and 32767) to randomize temp output directory to support parallel generation.