### PR TITLE
chore: add options.logging in cloud build trigger configs

### DIFF
--- a/.cloudbuild/graalvm/cloudbuild-test-a-downstream-kms.yaml
+++ b/.cloudbuild/graalvm/cloudbuild-test-a-downstream-kms.yaml
@@ -18,6 +18,7 @@ substitutions:
   _JAVA_SHARED_CONFIG_VERSION: '1.11.3'
 options:
   machineType: 'E2_HIGHCPU_8'
+  logging: CLOUD_LOGGING_ONLY
 steps:
   - name: gcr.io/cloud-builders/docker
     args: [

--- a/.cloudbuild/graalvm/cloudbuild-test-a-downstream-kmsinventory.yaml
+++ b/.cloudbuild/graalvm/cloudbuild-test-a-downstream-kmsinventory.yaml
@@ -18,6 +18,7 @@ substitutions:
   _JAVA_SHARED_CONFIG_VERSION: '1.11.3'
 options:
   machineType: 'E2_HIGHCPU_8'
+  logging: CLOUD_LOGGING_ONLY
 steps:
   - name: gcr.io/cloud-builders/docker
     args: [

--- a/.cloudbuild/graalvm/cloudbuild-test-a.yaml
+++ b/.cloudbuild/graalvm/cloudbuild-test-a.yaml
@@ -18,6 +18,7 @@ substitutions:
   _JAVA_SHARED_CONFIG_VERSION: '1.11.3'
 options:
   machineType: 'E2_HIGHCPU_8'
+  logging: CLOUD_LOGGING_ONLY
 steps:
   - name: gcr.io/cloud-builders/docker
     args: [
@@ -42,3 +43,4 @@ steps:
     args: [ './.kokoro/presubmit/showcase-native.sh' ]
     waitFor: [ "graalvm-a-build" ]
     id: native-showcase
+

--- a/.cloudbuild/graalvm/cloudbuild-test-b-downstream-kms.yaml
+++ b/.cloudbuild/graalvm/cloudbuild-test-b-downstream-kms.yaml
@@ -18,6 +18,7 @@ substitutions:
   _JAVA_SHARED_CONFIG_VERSION: '1.11.3'
 options:
   machineType: 'E2_HIGHCPU_8'
+  logging: CLOUD_LOGGING_ONLY
 steps:
   - name: gcr.io/cloud-builders/docker
     args: [

--- a/.cloudbuild/graalvm/cloudbuild-test-b-downstream-kmsinventory.yaml
+++ b/.cloudbuild/graalvm/cloudbuild-test-b-downstream-kmsinventory.yaml
@@ -18,6 +18,7 @@ substitutions:
   _JAVA_SHARED_CONFIG_VERSION: '1.11.3'
 options:
   machineType: 'E2_HIGHCPU_8'
+  logging: CLOUD_LOGGING_ONLY
 steps:
   - name: gcr.io/cloud-builders/docker
     args: [

--- a/.cloudbuild/graalvm/cloudbuild-test-b.yaml
+++ b/.cloudbuild/graalvm/cloudbuild-test-b.yaml
@@ -18,6 +18,7 @@ substitutions:
   _JAVA_SHARED_CONFIG_VERSION: '1.11.3'
 options:
   machineType: 'E2_HIGHCPU_8'
+  logging: CLOUD_LOGGING_ONLY
 steps:
   - name: gcr.io/cloud-builders/docker
     args: [

--- a/.cloudbuild/graalvm/cloudbuild.yaml
+++ b/.cloudbuild/graalvm/cloudbuild.yaml
@@ -45,6 +45,8 @@ steps:
     id: graalvm-b-build
     waitFor: [ "-" ]
 
+options:
+  logging: CLOUD_LOGGING_ONLY
 
 images:
   - gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:${_SHARED_DEPENDENCIES_VERSION}


### PR DESCRIPTION
Emulating solution in https://github.com/googleapis/java-shared-config/pull/921 to address the following error:

```
generic::invalid_argument: if 'build.service_account' is specified, the build must either (a) specify 'build.logs_bucket', (b) use the REGIONAL_USER_OWNED_BUCKET build.options.default_logs_bucket_behavior option, or (c) use either CLOUD_LOGGING_ONLY / NONE logging options
```