### PR TITLE
chore: cleanup header checks to use a common regex when validating headers

### DIFF
--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITVersionHeaders.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITVersionHeaders.java
@@ -240,22 +240,18 @@ class ITVersionHeaders {
 
   @Test
   void testGrpcCall_sendsCorrectApiClientHeader() {
-    Pattern defautlGrpcHeaderPattern =
-        Pattern.compile("gl-java/.* gapic/.*?--protobuf-\\d.* gax/.* grpc/.* protobuf/\\d.*");
     grpcClient.echo(EchoRequest.newBuilder().build());
     String headerValue = grpcInterceptor.metadata.get(API_CLIENT_HEADER_KEY);
-    assertTrue(defautlGrpcHeaderPattern.matcher(headerValue).matches());
+    assertTrue(GaxHttpJsonProperties.getDefaultApiClientHeaderPattern().matcher(headerValue).matches());
   }
 
   @Test
   void testHttpJson_sendsCorrectApiClientHeader() {
-    Pattern defautlHttpHeaderPattern =
-        Pattern.compile("gl-java/.* gapic/.*?--protobuf-\\d.* gax/.* rest/ protobuf/\\d.*");
     httpJsonClient.echo(EchoRequest.newBuilder().build());
     ArrayList<String> headerValues =
         (ArrayList<String>)
             httpJsonInterceptor.metadata.getHeaders().get(HTTP_CLIENT_API_HEADER_KEY);
     String headerValue = headerValues.get(0);
-    assertTrue(defautlHttpHeaderPattern.matcher(headerValue).matches());
+    assertTrue(GaxHttpJsonProperties.getDefaultApiClientHeaderPattern().matcher(headerValue).matches());
   }
 }


### PR DESCRIPTION
Use the common GaxHttpJsonProperties.getDefaultApiClientHeaderPattern(), instead of recreating regex exp.