### PR TITLE
fix: instantiate GaxProperties at build time to ensure we get the protobuf version

### DIFF
--- a/gax-java/gax/src/main/resources/META-INF/native-image/com.google.api/gax/native-image.properties
+++ b/gax-java/gax/src/main/resources/META-INF/native-image/com.google.api/gax/native-image.properties
@@ -1,7 +1,9 @@
 Args = --enable-url-protocols=https,http \
 --initialize-at-build-time=org.conscrypt,\
   org.junit.platform.engine.TestTag,\
-  com.google.api.gax.core.GaxProperties \
+  com.google.api.gax.core.GaxProperties,\
+  com.google.common.base.Platform,\
+  com.google.common.base.Platform$JdkPatternCompiler \
   --features=com.google.api.gax.nativeimage.OpenCensusFeature,\
   com.google.api.gax.nativeimage.GoogleJsonClientFeature \
   --add-modules=jdk.httpserver

--- a/gax-java/gax/src/main/resources/META-INF/native-image/com.google.api/gax/native-image.properties
+++ b/gax-java/gax/src/main/resources/META-INF/native-image/com.google.api/gax/native-image.properties
@@ -1,6 +1,7 @@
 Args = --enable-url-protocols=https,http \
 --initialize-at-build-time=org.conscrypt,\
-  org.junit.platform.engine.TestTag \
+  org.junit.platform.engine.TestTag,\
+  com.google.api.gax.core.GaxProperties \
   --features=com.google.api.gax.nativeimage.OpenCensusFeature,\
   com.google.api.gax.nativeimage.GoogleJsonClientFeature \
   --add-modules=jdk.httpserver

--- a/gax-java/gax/src/main/resources/META-INF/native-image/com.google.api/gax/native-image.properties
+++ b/gax-java/gax/src/main/resources/META-INF/native-image/com.google.api/gax/native-image.properties
@@ -1,7 +1,8 @@
 Args = --enable-url-protocols=https,http \
 --initialize-at-build-time=org.conscrypt,\
   org.junit.platform.engine.TestTag,\
-  com.google.api.gax.core.GaxProperties \
+  com.google.api.gax.core.GaxProperties, \
+  com.google.common.base.Platform \
   --features=com.google.api.gax.nativeimage.OpenCensusFeature,\
   com.google.api.gax.nativeimage.GoogleJsonClientFeature \
   --add-modules=jdk.httpserver

--- a/gax-java/gax/src/main/resources/META-INF/native-image/com.google.api/gax/native-image.properties
+++ b/gax-java/gax/src/main/resources/META-INF/native-image/com.google.api/gax/native-image.properties
@@ -1,8 +1,7 @@
 Args = --enable-url-protocols=https,http \
 --initialize-at-build-time=org.conscrypt,\
   org.junit.platform.engine.TestTag,\
-  com.google.api.gax.core.GaxProperties, \
-  com.google.common.base.Platform \
+  com.google.api.gax.core.GaxProperties \
   --features=com.google.api.gax.nativeimage.OpenCensusFeature,\
   com.google.api.gax.nativeimage.GoogleJsonClientFeature \
   --add-modules=jdk.httpserver


### PR DESCRIPTION
This should not vary from the runtime version for graalvm builds.

Tested: ran ITVersion tests in graalvm and printed out the header to see full value exists