### PR TITLE
chore: explicitly specify maven central location for renovate-bot version lookups

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -65,7 +65,10 @@
   "packageRules": [
     {
       "matchPackageNames": ["com.google.cloud:google-cloud-shared-config"],
-      "registryUrls": ["https://repo1.maven.org/maven2"]
+      "registryUrls": [
+        "https://repo.maven.apache.org/maven2/",
+        "https://repo1.maven.org/maven2"
+      ]
     },
     {
       "matchUpdateTypes": [

--- a/renovate.json
+++ b/renovate.json
@@ -64,6 +64,10 @@
   ],
   "packageRules": [
     {
+      "matchPackageNames": ["com.google.cloud:google-cloud-shared-config"],
+      "registryUrls": ["https://repo1.maven.org/maven2"]
+    },
+    {
       "matchUpdateTypes": [
         "major"
       ],


### PR DESCRIPTION
From https://github.com/googleapis/sdk-platform-java/pull/3372, the files `.cloudbuild/`directories aren't getting updated to use the latest java-shared-config version. From the [renovate logs](https://developer.mend.io/github/googleapis/sdk-platform-java/-/job/019327f8-a53b-767d-986c-4ddee5aacab7), there appears to be a difference in the registry urls used when looking up versions from maven central. 

Registry used when an update to the latest version is successfully made to `1.12.0`: 
```
     {
        "datasource": "maven",
        "deps": [
          {
            "currentValue": "1.11.3",
            "currentVersion": "1.11.3",
            "datasource": "maven",
            "depName": "com.google.cloud:google-cloud-shared-config",
            "depType": "parent-root",
            "fileReplacePosition": 702,
            "fixedVersion": "1.11.3",
            "isSingleVersion": true,
            "packageName": "com.google.cloud:google-cloud-shared-config",
            "packageScope": "com.google.cloud",
            "registryUrls": [
              "https://maven-central.storage-download.googleapis.com/maven2/",
              "https://repo.maven.apache.org/maven2"
            ],
            "sourceUrl": "https://github.com/googleapis/java-shared-config",
            "versioning": "maven",
            "warnings": [],
            "updates": [
              {
                "bucket": "non-major",
                "newVersion": "1.12.0",
                "newValue": "1.12.0",
                "releaseTimestamp": "2024-11-13T20:18:15.000Z",
                "newVersionAgeInDays": 0,
                "registryUrl": "https://maven-central.storage-download.googleapis.com/maven2",
                "newMajor": 1,
                "newMinor": 12,
                "newPatch": 0,
                "updateType": "minor",
                "branchName": "renovate/com.google.cloud-google-cloud-shared-config-1.x"
              }
            ]
          },
```

For `.cloudbuild/` files, the registryUrl defaults to `https://repo.maven.apache.org/maven2`:

```
      {
        "datasourceTemplate": "maven",
        "depNameTemplate": "com.google.cloud:google-cloud-shared-config",
        "deps": [
          {
            "currentValue": "1.11.3",
            "currentVersion": "1.11.3",
            "currentVersionAgeInDays": 43,
            "currentVersionTimestamp": "2024-10-01T21:54:00.000Z",
            "datasource": "maven",
            "depName": "com.google.cloud:google-cloud-shared-config",
            "fixedVersion": "1.11.3",
            "packageName": "com.google.cloud:google-cloud-shared-config",
            "packageScope": "com.google.cloud",
            "registryUrl": "https://repo.maven.apache.org/maven2",
            "replaceString": "  _JAVA_SHARED_CONFIG_VERSION: '1.11.3'",
            "sourceUrl": "https://github.com/googleapis/java-shared-config",
            "versioning": "maven",
            "warnings": [],
            "updates": []
          }
        ],
        "matchStrings": [
          "  _JAVA_SHARED_CONFIG_VERSION: '(?<currentValue>.+?)'"
        ],
        "packageFile": ".cloudbuild/graalvm/cloudbuild-test-b-downstream-kmsinventory.yaml"
      },
```

Explicitly specifying registryUrl to `https://repo1.maven.org/maven2` worked in https://github.com/mpeddada1/forking-renovate-repro