### PR TITLE
fix: return all library names if repo-level parameter changes

### DIFF
--- a/hermetic_build/common/cli/get_changed_libraries.py
+++ b/hermetic_build/common/cli/get_changed_libraries.py
@@ -72,10 +72,6 @@ def create(
         baseline_config=from_yaml(baseline_generation_config_path),
         current_config=from_yaml(current_generation_config_path),
     )
-    changed_libraries = config_change.get_changed_libraries()
-    if changed_libraries is None:
-        print("No changed library.")
-        return
     click.echo(",".join(config_change.get_changed_libraries()))
 
 

--- a/hermetic_build/common/model/config_change.py
+++ b/hermetic_build/common/model/config_change.py
@@ -62,7 +62,6 @@ class QualifiedCommit:
 
 
 class ConfigChange:
-    ALL_LIBRARIES_CHANGED = "ALL_LIBRARIES"
 
     def __init__(
         self,
@@ -77,14 +76,13 @@ class ConfigChange:
     def get_changed_libraries(self) -> list[str]:
         """
         Returns a unique, sorted list of library name of changed libraries.
-        A special list [ALL_LIBRARIES], will be returned if there is a
-        repository level change, which means all libraries in the current_config
-        will be generated.
 
         :return: library names of change libraries.
         """
         if ChangeType.REPO_LEVEL_CHANGE in self.change_to_libraries:
-            return [ConfigChange.ALL_LIBRARIES_CHANGED]
+            return [
+                library.get_library_name() for library in self.current_config.libraries
+            ]
         library_names = set()
         for change_type, library_changes in self.change_to_libraries.items():
             if change_type == ChangeType.GOOGLEAPIS_COMMIT:

--- a/hermetic_build/common/model/config_change.py
+++ b/hermetic_build/common/model/config_change.py
@@ -62,7 +62,7 @@ class QualifiedCommit:
 
 
 class ConfigChange:
-    ALL_LIBRARIES_CHANGED = None
+    ALL_LIBRARIES_CHANGED = "ALL_LIBRARIES"
 
     def __init__(
         self,
@@ -74,16 +74,17 @@ class ConfigChange:
         self.baseline_config = baseline_config
         self.current_config = current_config
 
-    def get_changed_libraries(self) -> Optional[list[str]]:
+    def get_changed_libraries(self) -> list[str]:
         """
         Returns a unique, sorted list of library name of changed libraries.
-        None if there is a repository level change, which means all libraries
-        in the current_config will be generated.
+        A special list [ALL_LIBRARIES], will be returned if there is a
+        repository level change, which means all libraries in the current_config
+        will be generated.
 
         :return: library names of change libraries.
         """
         if ChangeType.REPO_LEVEL_CHANGE in self.change_to_libraries:
-            return ConfigChange.ALL_LIBRARIES_CHANGED
+            return [ConfigChange.ALL_LIBRARIES_CHANGED]
         library_names = set()
         for change_type, library_changes in self.change_to_libraries.items():
             if change_type == ChangeType.GOOGLEAPIS_COMMIT:

--- a/hermetic_build/common/tests/model/config_change_unit_tests.py
+++ b/hermetic_build/common/tests/model/config_change_unit_tests.py
@@ -39,10 +39,26 @@ class ConfigChangeTest(unittest.TestCase):
                 ],
             },
             baseline_config=ConfigChangeTest.__get_a_gen_config(),
-            current_config=ConfigChangeTest.__get_a_gen_config(),
+            current_config=ConfigChangeTest.__get_a_gen_config(
+                googleapis_commitish="",
+                libraries=[
+                    ConfigChangeTest.__get_a_library_config(
+                        library_name="gke-backup",
+                        gapic_configs=[
+                            GapicConfig(proto_path="google/cloud/gkebackup/v1")
+                        ],
+                    ),
+                    ConfigChangeTest.__get_a_library_config(
+                        library_name="test-library",
+                        gapic_configs=[
+                            GapicConfig(proto_path="google/cloud/gkebackup/v1")
+                        ],
+                    ),
+                ],
+            ),
         )
         self.assertEqual(
-            [ConfigChange.ALL_LIBRARIES_CHANGED],
+            ["gke-backup", "test-library"],
             config_change.get_changed_libraries(),
         )
 

--- a/hermetic_build/common/tests/model/config_change_unit_tests.py
+++ b/hermetic_build/common/tests/model/config_change_unit_tests.py
@@ -42,7 +42,7 @@ class ConfigChangeTest(unittest.TestCase):
             current_config=ConfigChangeTest.__get_a_gen_config(),
         )
         self.assertEqual(
-            ConfigChange.ALL_LIBRARIES_CHANGED,
+            [ConfigChange.ALL_LIBRARIES_CHANGED],
             config_change.get_changed_libraries(),
         )
 

--- a/hermetic_build/library_generation/cli/entry_point.py
+++ b/hermetic_build/library_generation/cli/entry_point.py
@@ -44,6 +44,7 @@ def main(ctx):
     show_default=True,
     help="""
     A list of library names that will be generated, separated by comma.
+    If set to `ALL_LIBRARIES`, all libraries will be generated.
     The library name of a library is the value of library_name or api_shortname,
     if library_name is not specified, in the generation configuration.
     """,
@@ -157,7 +158,11 @@ def _needs_full_repo_generation(generation_config: GenerationConfig) -> bool:
 def _parse_library_name_from(
     includes: Optional[str], generation_config: GenerationConfig
 ) -> Optional[list[str]]:
-    if includes is None or _needs_full_repo_generation(generation_config):
+    if (
+        includes is None
+        or includes == "ALL_LIBRARIES"
+        or _needs_full_repo_generation(generation_config)
+    ):
         return None
     return [library_name.strip() for library_name in includes.split(",")]
 

--- a/hermetic_build/library_generation/cli/entry_point.py
+++ b/hermetic_build/library_generation/cli/entry_point.py
@@ -44,7 +44,6 @@ def main(ctx):
     show_default=True,
     help="""
     A list of library names that will be generated, separated by comma.
-    If set to `ALL_LIBRARIES`, all libraries will be generated.
     The library name of a library is the value of library_name or api_shortname,
     if library_name is not specified, in the generation configuration.
     """,
@@ -158,11 +157,7 @@ def _needs_full_repo_generation(generation_config: GenerationConfig) -> bool:
 def _parse_library_name_from(
     includes: Optional[str], generation_config: GenerationConfig
 ) -> Optional[list[str]]:
-    if (
-        includes is None
-        or includes == "ALL_LIBRARIES"
-        or _needs_full_repo_generation(generation_config)
-    ):
+    if includes is None or _needs_full_repo_generation(generation_config):
         return None
     return [library_name.strip() for library_name in includes.split(",")]
 


### PR DESCRIPTION
In this PR:
- Return all library names as a comma-separated string if repo-level parameter changes.

Fix: #3381 