### PR TITLE
chore: restrict internet access when running docker container in integration test

### DIFF
--- a/hermetic_build/library_generation/tests/integration_tests.py
+++ b/hermetic_build/library_generation/tests/integration_tests.py
@@ -303,6 +303,8 @@ class IntegrationTest(unittest.TestCase):
                 f"{user_id}:{group_id}",
                 "--rm",
                 "--quiet",
+                "--network",
+                "none",
                 "-v",
                 f"{repo_location}:/workspace/repo",
                 "-v",


### PR DESCRIPTION
A verification step in go/offline-gen-design