### PR TITLE
fix: plumb mtlsEndpoint to gRPC Channel provider instead of setting it in EndpointContext.

### DIFF
--- a/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
+++ b/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
@@ -123,6 +123,7 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
   private final HeaderProvider headerProvider;
   private final boolean useS2A;
   private final String endpoint;
+  private final String mtlsEndpoint;
   // TODO: remove. envProvider currently provides DirectPath environment variable, and is only used
   // during initial rollout for DirectPath. This provider will be removed once the DirectPath
   // environment is not used.
@@ -152,6 +153,7 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
     this.executor = builder.executor;
     this.headerProvider = builder.headerProvider;
     this.endpoint = builder.endpoint;
+    this.mtlsEndpoint = builder.mtlsEndpoint;
     this.useS2A = builder.useS2A;
     this.mtlsProvider = builder.mtlsProvider;
     this.s2aConfigProvider = builder.s2aConfigProvider;
@@ -229,6 +231,11 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
     return endpoint == null;
   }
 
+  @Override
+  public boolean needsMtlsEndpoint() {
+    return mtlsEndpoint == null;
+  }
+
   /**
    * Specify the endpoint the channel should connect to.
    *
@@ -241,6 +248,21 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
   public TransportChannelProvider withEndpoint(String endpoint) {
     validateEndpoint(endpoint);
     return toBuilder().setEndpoint(endpoint).build();
+  }
+
+  /**
+   * Specify the mtlsEndpoint the channel should connect to.
+   *
+   * <p>The value of {@code mtlsEndpoint} must be of the form {@code host:port}.
+   *
+   * @param mtlsEndpoint The mtlsEndpoint to connect to
+   * @return A new {@link InstantiatingGrpcChannelProvider} with the specified mtlsEndpoint
+   *     configured
+   */
+  @Override
+  public TransportChannelProvider withMtlsEndpoint(String mtlsEndpoint) {
+    validateEndpoint(mtlsEndpoint);
+    return toBuilder().setMtlsEndpoint(mtlsEndpoint).build();
   }
 
   /**
@@ -590,8 +612,7 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
         }
         if (channelCredentials != null) {
           // Create the channel using S2A-secured channel credentials.
-          // {@code endpoint} is set to mtlsEndpoint in {@link EndpointContext} when useS2A is true.
-          builder = Grpc.newChannelBuilder(endpoint, channelCredentials);
+          builder = Grpc.newChannelBuilder(mtlsEndpoint, channelCredentials);
         } else {
           // Use default if we cannot initialize channel credentials via DCA or S2A.
           builder = ManagedChannelBuilder.forAddress(serviceAddress, port);
@@ -743,6 +764,7 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
     private Executor executor;
     private HeaderProvider headerProvider;
     private String endpoint;
+    private String mtlsEndpoint;
     private boolean useS2A;
     private EnvironmentProvider envProvider;
     private SecureSessionAgent s2aConfigProvider = SecureSessionAgent.create();
@@ -773,6 +795,7 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
       this.executor = provider.executor;
       this.headerProvider = provider.headerProvider;
       this.endpoint = provider.endpoint;
+      this.mtlsEndpoint = provider.mtlsEndpoint;
       this.useS2A = provider.useS2A;
       this.envProvider = provider.envProvider;
       this.interceptorProvider = provider.interceptorProvider;
@@ -843,6 +866,13 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
       return this;
     }
 
+    /** Sets the mtlsEndpoint used to reach the service, eg "localhost:8080". */
+    public Builder setMtlsEndpoint(String mtlsEndpoint) {
+      validateEndpoint(mtlsEndpoint);
+      this.mtlsEndpoint = mtlsEndpoint;
+      return this;
+    }
+
     Builder setUseS2A(boolean useS2A) {
       this.useS2A = useS2A;
       return this;
@@ -874,6 +904,10 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
 
     public String getEndpoint() {
       return endpoint;
+    }
+
+    public String getMtlsEndpoint() {
+      return mtlsEndpoint;
     }
 
     /** The maximum message size allowed to be received on the channel. */

--- a/gax-java/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcLongRunningTest.java
+++ b/gax-java/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcLongRunningTest.java
@@ -103,6 +103,8 @@ class GrpcLongRunningTest {
     when(operationsChannelProvider.getTransportChannel()).thenReturn(transportChannel);
     when(operationsChannelProvider.withUseS2A(Mockito.any(boolean.class)))
         .thenReturn(operationsChannelProvider);
+    when(operationsChannelProvider.withMtlsEndpoint(Mockito.any(String.class)))
+        .thenReturn(operationsChannelProvider);
 
     clock = new FakeApiClock(0L);
     executor = RecordingScheduler.create(clock);

--- a/gax-java/gax-grpc/src/test/java/com/google/api/gax/grpc/testing/LocalChannelProvider.java
+++ b/gax-java/gax-grpc/src/test/java/com/google/api/gax/grpc/testing/LocalChannelProvider.java
@@ -102,8 +102,18 @@ public class LocalChannelProvider implements TransportChannelProvider {
   }
 
   @Override
+  public boolean needsMtlsEndpoint() {
+    return false;
+  }
+
+  @Override
   public TransportChannelProvider withEndpoint(String endpoint) {
     throw new UnsupportedOperationException("LocalChannelProvider doesn't need an endpoint");
+  }
+
+  @Override
+  public TransportChannelProvider withMtlsEndpoint(String mtlsEndpoint) {
+    throw new UnsupportedOperationException("LocalChannelProvider doesn't need an mtlsEndpoint");
   }
 
   @Override

--- a/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/InstantiatingHttpJsonChannelProvider.java
+++ b/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/InstantiatingHttpJsonChannelProvider.java
@@ -120,8 +120,18 @@ public final class InstantiatingHttpJsonChannelProvider implements TransportChan
   }
 
   @Override
+  public boolean needsMtlsEndpoint() {
+    return false;
+  }
+
+  @Override
   public TransportChannelProvider withEndpoint(String endpoint) {
     return toBuilder().setEndpoint(endpoint).build();
+  }
+
+  @Override
+  public TransportChannelProvider withMtlsEndpoint(String mtlsEndpoint) {
+    return this;
   }
 
   @Override

--- a/gax-java/gax/clirr-ignored-differences.xml
+++ b/gax-java/gax/clirr-ignored-differences.xml
@@ -118,4 +118,14 @@
     <className>com/google/api/gax/rpc/TransportChannelProvider</className>
     <method>* withUseS2A(*)</method>
   </difference>
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/api/gax/rpc/TransportChannelProvider</className>
+    <method>* needsMtlsEndpoint()</method>
+  </difference>
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/api/gax/rpc/TransportChannelProvider</className>
+    <method>* withMtlsEndpoint(*)</method>
+  </difference>
 </differences>

--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
@@ -222,6 +222,10 @@ public abstract class ClientContext {
     if (transportChannelProvider.needsEndpoint()) {
       transportChannelProvider = transportChannelProvider.withEndpoint(endpoint);
     }
+    if (transportChannelProvider.needsMtlsEndpoint()) {
+      transportChannelProvider =
+          transportChannelProvider.withMtlsEndpoint(endpointContext.mtlsEndpoint());
+    }
     transportChannelProvider = transportChannelProvider.withUseS2A(endpointContext.useS2A());
     TransportChannel transportChannel = transportChannelProvider.getTransportChannel();
 

--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/EndpointContext.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/EndpointContext.java
@@ -272,10 +272,6 @@ public abstract class EndpointContext {
 
     /** Determines the fully resolved endpoint and universe domain values */
     private String determineEndpoint() throws IOException {
-      if (shouldUseS2A()) {
-        return mtlsEndpoint();
-      }
-
       MtlsProvider mtlsProvider = mtlsProvider() == null ? new MtlsProvider() : mtlsProvider();
       // TransportChannelProvider's endpoint will override the ClientSettings' endpoint
       String customEndpoint =

--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/FixedTransportChannelProvider.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/FixedTransportChannelProvider.java
@@ -84,9 +84,20 @@ public class FixedTransportChannelProvider implements TransportChannelProvider {
   }
 
   @Override
+  public boolean needsMtlsEndpoint() {
+    return false;
+  }
+
+  @Override
   public TransportChannelProvider withEndpoint(String endpoint) {
     throw new UnsupportedOperationException(
         "FixedTransportChannelProvider doesn't need an endpoint");
+  }
+
+  @Override
+  public TransportChannelProvider withMtlsEndpoint(String mtlsEndpoint) {
+    throw new UnsupportedOperationException(
+        "FixedTransportChannelProvider doesn't need an mtlsEndpoint");
   }
 
   @Override

--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/TransportChannelProvider.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/TransportChannelProvider.java
@@ -90,12 +90,22 @@ public interface TransportChannelProvider {
   /** True if the TransportProvider has no endpoint set. */
   boolean needsEndpoint();
 
+  /** True if the TransportProvider has no mtlsEndpoint set. */
+  boolean needsMtlsEndpoint();
+
   /**
    * Sets the endpoint to use when constructing a new {@link TransportChannel}.
    *
    * <p>This method should only be called if {@link #needsEndpoint()} returns true.
    */
   TransportChannelProvider withEndpoint(String endpoint);
+
+  /**
+   * Sets the mtlsEndpoint to use when constructing a new {@link TransportChannel}.
+   *
+   * <p>This method should only be called if {@link #needsMtlsEndpoint()} returns true.
+   */
+  TransportChannelProvider withMtlsEndpoint(String mtlsEndpoint);
 
   /** Sets whether to use S2A when constructing a new {@link TransportChannel}. */
   default TransportChannelProvider withUseS2A(boolean useS2A) {

--- a/gax-java/gax/src/test/java/com/google/api/gax/rpc/ClientContextTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/rpc/ClientContextTest.java
@@ -180,6 +180,11 @@ class ClientContextTest {
     }
 
     @Override
+    public boolean needsMtlsEndpoint() {
+      return false;
+    }
+
+    @Override
     public String getEndpoint() {
       return endpoint;
     }
@@ -193,6 +198,17 @@ class ClientContextTest {
           this.headers,
           this.credentials,
           endpoint);
+    }
+
+    @Override
+    public TransportChannelProvider withMtlsEndpoint(String mtlsEndpoint) {
+      return new FakeTransportProvider(
+          this.transport,
+          this.executor,
+          this.shouldAutoClose,
+          this.headers,
+          this.credentials,
+          this.endpoint);
     }
 
     @Override


### PR DESCRIPTION
Fix a problem where if DirectPath is to be used (`canUseDirectPath` is going to return true), but endpoint resolution determines conditions are met to use S2A, the endpoint incorrectly gets set to mtls endpoint. 

We only try S2A logic (e.g we only look at `useS2A`), if we have ruled out DirectPath as an option (`canUseDirectPathI()` returns false), but endpoint resolution logic doesn't know this, and will set endpoint to mtls endpoint if it determines S2A can be used, even if DirectPath can be used.