### PR TITLE
docs: hermetic build README syntax fix

### DIFF
--- a/hermetic_build/README.md
+++ b/hermetic_build/README.md
@@ -222,7 +222,7 @@ libraries:
      --quiet \
      -u "$(id -u):$(id -g)" \
      -v "$(pwd):/workspace" \
-     -v /path/to/api_definition:/workspace \
+     -v /path/to/api_definition:/workspace/apis \
      gcr.io/cloud-devrel-public-resources/java-library-generation:image-tag
    ```
 
@@ -232,7 +232,7 @@ libraries:
    * `-v "$(pwd):/workspace"` maps the host machine's current working directory
      to the /workspace folder. 
      The image is configured to perform changes in this directory.
-   * `-v /path/to/api_definition:/workspace` maps the host machine's API 
+   * `-v /path/to/api_definition:/workspace/apis` maps the host machine's API 
      definitions folder to `/workspace/apis` folder.
  
 3. An advanced example:


### PR DESCRIPTION
Providing the same `/workspace` mount point for two volumes produces an error. Expected second mount point is `/workspace/apis`