### PR TITLE
chore: reverting Release Please anontations for dependencies.properties

### DIFF
--- a/gax-java/dependencies.properties
+++ b/gax-java/dependencies.properties
@@ -35,10 +35,8 @@ version.io_grpc=1.68.1
 # It should be constructed the following way:
 #   1) Take full artifact id (including the group and classifier (if any) portions) and remove version portion.
 #   2) Replace all characters which are neither alphabetic nor digits with the underscore ('_') character
-# {x-version-update-start:proto-google-common-protos:current}
 maven.com_google_api_grpc_proto_google_common_protos=com.google.api.grpc:proto-google-common-protos:2.46.0
 maven.com_google_api_grpc_grpc_google_common_protos=com.google.api.grpc:grpc-google-common-protos:2.46.0
-# {x-version-update-end}
 maven.com_google_auth_google_auth_library_oauth2_http=com.google.auth:google-auth-library-oauth2-http:1.30.0
 maven.com_google_auth_google_auth_library_credentials=com.google.auth:google-auth-library-credentials:1.30.0
 maven.io_opentelemetry_opentelemetry_api=io.opentelemetry:opentelemetry-api:1.42.1
@@ -69,14 +67,10 @@ maven.com_google_errorprone_error_prone_annotations=com.google.errorprone:error_
 maven.com_google_j2objc_j2objc_annotations=com.google.j2objc:j2objc-annotations:2.8
 maven.com_google_auto_value_auto_value=com.google.auto.value:auto-value:1.11.0
 maven.com_google_auto_value_auto_value_annotations=com.google.auto.value:auto-value-annotations:1.11.0
-# {x-version-update-start:api-common:current}
 maven.com_google_api_api_common=com.google.api:api-common:2.38.0
-# {x-version-update-end}
 maven.org_threeten_threetenbp=org.threeten:threetenbp:1.7.0
-# {x-version-update-start:proto-google-iam-v1:current}
 maven.com_google_api_grpc_grpc_google_iam_v1=com.google.api.grpc:grpc-google-iam-v1:1.41.0
 maven.com_google_api_grpc_proto_google_iam_v1=com.google.api.grpc:proto-google-iam-v1:1.41.0
-# {x-version-update-end}
 maven.com_google_http_client_google_http_client=com.google.http-client:google-http-client:1.45.0
 maven.com_google_http_client_google_http_client_gson=com.google.http-client:google-http-client-gson:1.45.0
 maven.org_codehaus_mojo_animal_sniffer_annotations=org.codehaus.mojo:animal-sniffer-annotations:1.24


### PR DESCRIPTION
Reverts googleapis/sdk-platform-java#3396

https://github.com/googleapis/sdk-platform-java/pull/3382#issuecomment-2499518297

> I think my pull request about Release Please annotation broke the CI checks for Release Please pull request.

The Bazel integration tests are not ready to use the locally installed artifacts in local Maven repository. GAX artifacts are fine because they are from Bazel package. I'll need to explore how to build them in https://github.com/googleapis/sdk-platform-java/commit/c8cb5ae1e4444d3f08dcc78e817e63d16f5e46d8#diff-8a0414289f48984fdac9f835e30a3c10f79ebef40088b9045c98665d2bddb6e3.