### PR TITLE
ci: Add Downstream Protobuf-Java Source Compatibility Test

### DIFF
--- a/.github/workflows/downstream_protobuf_compatibility_check_nightly.yaml
+++ b/.github/workflows/downstream_protobuf_compatibility_check_nightly.yaml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          java-version: 21
+          java-version: 17
           distribution: temurin
       - name: Print Protobuf-Java testing version
         run: echo "Testing with Protobuf-Java v${{ matrix.protobuf-version }}"

--- a/.github/workflows/downstream_protobuf_compatibility_check_nightly.yaml
+++ b/.github/workflows/downstream_protobuf_compatibility_check_nightly.yaml
@@ -15,7 +15,7 @@ name: Downstream Protobuf Compatibility Check Nightly
 jobs:
   downstream-protobuf-test:
     # Checks if PR comes from Release-Please branch or '' if invoked from nightly job
-    if: github.head_ref == 'release-please--branches--main' || github.head_ref == ''
+    if: github.head_ref == 'release-please--branches--main' || github.event_name == 'schedule'
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false

--- a/.github/workflows/downstream_protobuf_compatibility_check_nightly.yaml
+++ b/.github/workflows/downstream_protobuf_compatibility_check_nightly.yaml
@@ -1,5 +1,4 @@
 on:
-  pull_request:
   workflow_dispatch:
     inputs:
       protobuf_versions:

--- a/.github/workflows/downstream_protobuf_compatibility_check_nightly.yaml
+++ b/.github/workflows/downstream_protobuf_compatibility_check_nightly.yaml
@@ -11,7 +11,7 @@ on:
   schedule:
     - cron: '0 1 * * *' # Nightly at 1am
 
-name: Downstream Compatibility Nightly
+name: Downstream Protobuf Compatibility Check Nightly
 jobs:
   downstream-protobuf-test:
     runs-on: ubuntu-22.04

--- a/.github/workflows/downstream_protobuf_compatibility_check_nightly.yaml
+++ b/.github/workflows/downstream_protobuf_compatibility_check_nightly.yaml
@@ -1,4 +1,5 @@
 on:
+  pull_request:
   workflow_dispatch:
     inputs:
       protobuf_versions:

--- a/.github/workflows/downstream_protobuf_compatibility_check_nightly.yaml
+++ b/.github/workflows/downstream_protobuf_compatibility_check_nightly.yaml
@@ -14,7 +14,7 @@ on:
 name: Downstream Protobuf Compatibility Check Nightly
 jobs:
   downstream-protobuf-test:
-    # Checks if PR comes from Release-Please branch or '' if invoked from nightly job
+    # Checks if PR comes from Release-Please branch or if invoked from nightly job
     if: github.head_ref == 'release-please--branches--main' || github.event_name == 'schedule'
     runs-on: ubuntu-22.04
     strategy:

--- a/.github/workflows/downstream_protobuf_compatibility_check_nightly.yaml
+++ b/.github/workflows/downstream_protobuf_compatibility_check_nightly.yaml
@@ -1,11 +1,11 @@
 on:
   pull_request:
-    # Updates on Release-Please PRs
+    # Runs on PRs targeting main, but will be filtered for Release PRs
     branches:
-      - 'release-please--branches--main'
+      - 'main'
   workflow_dispatch:
     inputs:
-      protobuf_versions:
+      protobuf_runtime_versions:
         description: 'Comma separated list of Protobuf-Java versions (i.e. "3.25.x","4.x.y")'
         required: true
   schedule:
@@ -14,6 +14,8 @@ on:
 name: Downstream Protobuf Compatibility Check Nightly
 jobs:
   downstream-protobuf-test:
+    # Checks if PR comes from Release-Please branch or '' if invoked from nightly job
+    if: github.head_ref == 'release-please--branches--main' || github.head_ref == ''
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -35,7 +37,7 @@ jobs:
           - java-storage-nio
         # Default Protobuf-Java versions to use are specified here. Without this, the nightly workflow won't know
         # which values to use and would resolve to ''.
-        protobuf-version: ${{ fromJSON(format('[{0}]', inputs.protobuf_versions || '"3.25.5","4.28.3"')) }}
+        protobuf-version: ${{ fromJSON(format('[{0}]', inputs.protobuf_runtime_versions || '"3.25.5","4.28.3"')) }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4

--- a/.github/workflows/downstream_protobuf_compatibility_check_nightly.yaml
+++ b/.github/workflows/downstream_protobuf_compatibility_check_nightly.yaml
@@ -1,5 +1,8 @@
 on:
   pull_request:
+    # Updates on Release-Please PRs
+    branches:
+      - 'release-please--branches--main'
   workflow_dispatch:
     inputs:
       protobuf_versions:

--- a/.github/workflows/downstream_protobuf_compatibility_check_nightly.yaml
+++ b/.github/workflows/downstream_protobuf_compatibility_check_nightly.yaml
@@ -41,4 +41,4 @@ jobs:
       - name: Print Protobuf-Java testing version
         run: echo "Testing with Protobuf-Java v${{ matrix.protobuf-version }}"
       - name: Perform downstream source compatibility testing
-        run: REPOS_UNDER_TEST="${{ matrix.repo }}" PROTOBUF_RUNTIME_VERSION="${{ matrix.protobuf-version}}" ./.kokoro/presubmit/downstream-protobuf-source-compatibility.sh
+        run: REPOS_UNDER_TEST="${{ matrix.repo }}" PROTOBUF_RUNTIME_VERSION="${{ matrix.protobuf-version}}" ./.kokoro/nightly/downstream-protobuf-source-compatibility.sh

--- a/.github/workflows/downstream_protobuf_compatibility_check_nightly.yaml
+++ b/.github/workflows/downstream_protobuf_compatibility_check_nightly.yaml
@@ -1,0 +1,45 @@
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      protobuf_versions:
+        description: 'Comma separated list of Protobuf-Java versions (i.e. "3.25.x","4.x.y")'
+        required: true
+  schedule:
+    - cron: '0 1 * * *' # Nightly at 1am
+
+name: Downstream Compatibility Nightly
+jobs:
+  downstream-protobuf-test:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        repo:
+          - google-cloud-java
+          - java-bigtable
+          - java-bigquery
+          - java-bigquerystorage
+          - java-datastore
+          - java-firestore
+          - java-logging
+          - java-logging-logback
+          - java-pubsub
+          - java-pubsublite
+          - java-spanner-jdbc
+          - java-spanner
+          - java-storage
+          - java-storage-nio
+        # Default Protobuf-Java versions to use are specified here. Without this, the nightly workflow won't know
+        # which values to use and would resolve to ''.
+        protobuf-version: ${{ fromJSON(format('[{0}]', inputs.protobuf_versions || '"3.25.5","4.28.3"')) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: temurin
+      - name: Print Protobuf-Java testing version
+        run: echo "Testing with Protobuf-Java v${{ matrix.protobuf-version }}"
+      - name: Perform downstream source compatibility testing
+        run: REPOS_UNDER_TEST="${{ matrix.repo }}" PROTOBUF_RUNTIME_VERSION="${{ matrix.protobuf-version}}" ./.kokoro/presubmit/downstream-protobuf-source-compatibility.sh

--- a/.kokoro/nightly/downstream-protobuf-source-compatibility.sh
+++ b/.kokoro/nightly/downstream-protobuf-source-compatibility.sh
@@ -30,7 +30,8 @@ fi
 # Get the directory of the build script
 scriptDir=$(realpath "$(dirname "${BASH_SOURCE[0]}")")
 cd "${scriptDir}/../.." # cd to the root of this repo
-source "$scriptDir/common.sh"
+# common.sh lives in the presubmit folder
+source "$scriptDir/../presubmit/common.sh"
 setup_maven_mirror
 
 for repo in ${REPOS_UNDER_TEST//,/ }; do # Split on comma

--- a/.kokoro/nightly/downstream-protobuf-source-compatibility.sh
+++ b/.kokoro/nightly/downstream-protobuf-source-compatibility.sh
@@ -29,13 +29,6 @@ if [ -z "${PROTOBUF_RUNTIME_VERSION}" ]; then
   exit 1
 fi
 
-# Get the directory of the build script
-scriptDir=$(realpath "$(dirname "${BASH_SOURCE[0]}")")
-cd "${scriptDir}/../.." # cd to the root of this repo
-# common.sh lives in the presubmit folder
-source "$scriptDir/../presubmit/common.sh"
-setup_maven_mirror
-
 for repo in ${REPOS_UNDER_TEST//,/ }; do # Split on comma
   # Perform source-compatibility testing on main (latest changes)
   git clone "https://github.com/googleapis/$repo.git" --depth=1

--- a/.kokoro/nightly/downstream-protobuf-source-compatibility.sh
+++ b/.kokoro/nightly/downstream-protobuf-source-compatibility.sh
@@ -18,12 +18,14 @@ set -eo pipefail
 # Comma-delimited list of repos to test with the local java-shared-dependencies
 if [ -z "${REPOS_UNDER_TEST}" ]; then
   echo "REPOS_UNDER_TEST must be set to run downstream-protobuf-source-compatibility.sh"
+  echo "Expects a comma-delimited list: i.e REPOS_UNDER_TEST=\"java-bigtable,java-bigquery\""
   exit 1
 fi
 
 # Version of Protobuf-Java runtime to compile with
 if [ -z "${PROTOBUF_RUNTIME_VERSION}" ]; then
   echo "PROTOBUF_RUNTIME_VERSION must be set to run downstream-protobuf-source-compatibility.sh"
+  echo "Expects a single Protobuf-Java runtime version i.e. PROTOBUF_RUNTIME_VERSION=\"4.28.3\""
   exit 1
 fi
 

--- a/.kokoro/presubmit/downstream-protobuf-source-compatibility.sh
+++ b/.kokoro/presubmit/downstream-protobuf-source-compatibility.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+# Comma-delimited list of repos to test with the local java-shared-dependencies
+if [ -z "${REPOS_UNDER_TEST}" ]; then
+  echo "REPOS_UNDER_TEST must be set to run downstream-protobuf-source-compatibility.sh"
+  exit 1
+fi
+
+# Version of Protobuf-Java runtime to compile with
+if [ -z "${PROTOBUF_RUNTIME_VERSION}" ]; then
+  echo "PROTOBUF_RUNTIME_VERSION must be set to run downstream-protobuf-source-compatibility.sh"
+  exit 1
+fi
+
+# Get the directory of the build script
+scriptDir=$(realpath "$(dirname "${BASH_SOURCE[0]}")")
+cd "${scriptDir}/../.." # cd to the root of this repo
+source "$scriptDir/common.sh"
+setup_maven_mirror
+
+for repo in ${REPOS_UNDER_TEST//,/ }; do # Split on comma
+  # Perform source-compatibility testing on main (latest changes)
+  git clone "https://github.com/googleapis/$repo.git" --depth=1
+  pushd "$repo"
+
+  # Compile the Handwritten Library with the Protobuf-Java version to test source compatibility
+  # Run unit tests to help check for any behavior differences (dependant on coverage)
+  mvn clean test -B -V -ntp \
+      -Dclirr.skip=true \
+      -Denforcer.skip=true \
+      -Dmaven.javadoc.skip=true \
+      -Dprotobuf.version=${PROTOBUF_RUNTIME_VERSION} \
+      -T 1C
+  popd
+done


### PR DESCRIPTION
Set up a nightly CI job that tests Protobuf compatibility with downstream libraries. This step of the CI job is to test source compatibility.

The nightly job will check the compatibility of these libraries with the latest in Protobuf-Java 3.x and and 4.x. This job can be manually invoked with the Protobuf-Java versions as a list.

Future steps may introduce testing for binary compatibility. 