### PR TITLE
chore: update owlbot cli sha using renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -60,6 +60,19 @@
       ],
       "depNameTemplate": "com.google.cloud:google-cloud-shared-config",
       "datasourceTemplate": "maven"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^.cloudbuild/library_generation/library_generation.Dockerfile$"
+      ],
+      "matchStrings": [
+        "OWLBOT_CLI_COMMITTISH=(?<currentDigest>.*?)\\n"
+      ],
+      "currentValueTemplate": "main",
+      "depNameTemplate": "repo-automation-bots",
+      "packageNameTemplate": "https://github.com/googleapis/repo-automation-bots",
+      "datasourceTemplate": "git-refs"
     }
   ],
   "packageRules": [

--- a/renovate.json
+++ b/renovate.json
@@ -195,6 +195,19 @@
         "^io.netty"
       ],
       "groupName": "Netty dependencies"
+    },
+    {
+      "groupName": "Library generation image updates",
+      "matchDatasources": [
+        "git-refs",
+        "docker"
+      ],
+      "matchPackagePatterns": [
+        "https://github.com/googleapis/repo-automation-bots",
+        "docker.io/library/maven",
+        "docker.io/library/alpine",
+        "docker.io/library/python"
+      ]
     }
   ]
 }


### PR DESCRIPTION
In this PR:
- Update owlbot-cli sha using renovate Bot ([doc](https://docs.renovatebot.com/modules/datasource/git-refs/)).
- Group image dependency updates to a single PR.

Debug output of renovate:
```
{
   "deps": [
     {
       "depName": "repo-automation-bots",
       "packageName": "https://github.com/googleapis/repo-automation-bots",
       "currentValue": "main",
       "currentDigest": "ab222d9a20bb27586433caedc70f049b7853db7e",
       "datasource": "git-refs",
       "replaceString": "OWLBOT_CLI_COMMITTISH=ab222d9a20bb27586433caedc70f049b7853db7e\n",
       "updates": [
         {
           "updateType": "digest",
           "newValue": "main",
           "newDigest": "f66cf627d08d80cba67521e4db491c8e4e4ad315",
           "branchName": "renovate/library-generation-image-updates"
         }
       ],
       "versioning": "semver-coerced",
       "warnings": []
     }
   ],
   "matchStrings": ["OWLBOT_CLI_COMMITTISH=(?<currentDigest>.*?)\\n"],
   "depNameTemplate": "repo-automation-bots",
   "packageNameTemplate": "https://github.com/googleapis/repo-automation-bots",
   "currentValueTemplate": "main",
   "datasourceTemplate": "git-refs",
   "packageFile": ".cloudbuild/library_generation/library_generation.Dockerfile"
 }
```