### PR TITLE
chore: update glib_mus using renovate

### DIFF
--- a/.cloudbuild/library_generation/library_generation.Dockerfile
+++ b/.cloudbuild/library_generation/library_generation.Dockerfile
@@ -31,7 +31,7 @@ FROM docker.io/library/alpine:3.20.3@sha256:beefdbd8a1da6d2915566fde36db9db0b524
 
 RUN apk add git sudo
 # This SHA is the latest known-to-work version of this binary compatibility tool
-ARG GLIB_MUS_SHA=e94aca542e3ab08b42aa0b0d6e72478b935bb8e8
+ARG GLIB_MUS_SHA=7717dd4dc26377dd9cedcc92b72ebf35f9e68a2d
 WORKDIR /home
 
 # Install compatibility layer to run glibc-based programs (such as the

--- a/.cloudbuild/library_generation/library_generation.Dockerfile
+++ b/.cloudbuild/library_generation/library_generation.Dockerfile
@@ -31,7 +31,7 @@ FROM docker.io/library/alpine:3.20.3@sha256:beefdbd8a1da6d2915566fde36db9db0b524
 
 RUN apk add git sudo
 # This SHA is the latest known-to-work version of this binary compatibility tool
-ARG GLIB_MUS_SHA=7717dd4dc26377dd9cedcc92b72ebf35f9e68a2d
+ARG GLIB_MUS_SHA=e94aca542e3ab08b42aa0b0d6e72478b935bb8e8
 WORKDIR /home
 
 # Install compatibility layer to run glibc-based programs (such as the

--- a/renovate.json
+++ b/renovate.json
@@ -73,6 +73,19 @@
       "depNameTemplate": "repo-automation-bots",
       "packageNameTemplate": "https://github.com/googleapis/repo-automation-bots",
       "datasourceTemplate": "git-refs"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^.cloudbuild/library_generation/library_generation.Dockerfile$"
+      ],
+      "matchStrings": [
+        "GLIB_MUS_SHA=(?<currentDigest>.*?)\\n"
+      ],
+      "currentValueTemplate": "master",
+      "depNameTemplate": "glib_mus",
+      "packageNameTemplate": "https://gitlab.com/manoel-linux1/GlibMus-HQ",
+      "datasourceTemplate": "git-refs"
     }
   ],
   "packageRules": [

--- a/renovate.json
+++ b/renovate.json
@@ -217,6 +217,7 @@
       ],
       "matchPackagePatterns": [
         "https://github.com/googleapis/repo-automation-bots",
+        "https://gitlab.com/manoel-linux1/GlibMus-HQ",
         "docker.io/library/maven",
         "docker.io/library/alpine",
         "docker.io/library/python"


### PR DESCRIPTION
In this PR:
- Update commit sha in [GlibMus-HQ](https://gitlab.com/manoel-linux1/GlibMus-HQ)
- Group dependencies updates in one PR.

Debug output:
```
{
   "deps": [
     {
       "depName": "glib_mus",
       "packageName": "https://gitlab.com/manoel-linux1/GlibMus-HQ",
       "currentValue": "master",
       "currentDigest": "7717dd4dc26377dd9cedcc92b72ebf35f9e68a2d",
       "datasource": "git-refs",
       "replaceString": "GLIB_MUS_SHA=7717dd4dc26377dd9cedcc92b72ebf35f9e68a2d\n",
       "updates": [
         {
           "updateType": "digest",
           "newValue": "master",
           "newDigest": "e94aca542e3ab08b42aa0b0d6e72478b935bb8e8",
           "branchName": "renovate/glib_mus-digest"
         }
       ],
       "versioning": "semver-coerced",
       "warnings": []
     }
   ],
   "matchStrings": ["GLIB_MUS_SHA=(?<currentDigest>.*?)\\n"],
   "depNameTemplate": "glib_mus",
   "packageNameTemplate": "https://gitlab.com/manoel-linux1/GlibMus-HQ",
   "currentValueTemplate": "master",
   "datasourceTemplate": "git-refs",
   "packageFile": ".cloudbuild/library_generation/library_generation.Dockerfile"
 }
```