### PR TITLE
chore(hermetic-build): add hint for old commit hash error message

### DIFF
--- a/hermetic_build/release_note_generation/generate_pr_description.py
+++ b/hermetic_build/release_note_generation/generate_pr_description.py
@@ -115,7 +115,8 @@ def get_repo_level_commit_messages(
             f"current_commit ({current_commit_sha[:7]}, committed on "
             f"{current_commit_time}) should be newer than or equal to "
             f"baseline_commit ({baseline_commit_sha[:7]}, committed on "
-            f"{baseline_commit_time})."
+            f"{baseline_commit_time}) (is this branch up to date with "
+            f"the base branch?)."
         )
     qualified_commits = {}
     commit = current_commit


### PR DESCRIPTION
This adds a small hint on why it's likely that the release note generation workflow has failed due to the current branch having an older commit than the base branch. Rationale: requires understanding on why "hermetic code library generation" needs an "newer commit".
