### PR TITLE
fix: graalvm missing build time class when using protobuf 4.x

### DIFF
--- a/gapic-generator-java-pom-parent/pom.xml
+++ b/gapic-generator-java-pom-parent/pom.xml
@@ -31,7 +31,7 @@
     <google.http-client.version>1.45.2</google.http-client.version>
     <gson.version>2.11.0</gson.version>
     <guava.version>33.3.1-jre</guava.version>
-    <protobuf.version>3.25.5</protobuf.version>
+    <protobuf.version>4.28.1</protobuf.version>
     <opentelemetry.version>1.44.1</opentelemetry.version>
     <maven.compiler.release>8</maven.compiler.release>
     <errorprone.version>2.36.0</errorprone.version>

--- a/gapic-generator-java-pom-parent/pom.xml
+++ b/gapic-generator-java-pom-parent/pom.xml
@@ -31,7 +31,7 @@
     <google.http-client.version>1.45.2</google.http-client.version>
     <gson.version>2.11.0</gson.version>
     <guava.version>33.3.1-jre</guava.version>
-    <protobuf.version>4.28.1</protobuf.version>
+    <protobuf.version>3.25.5</protobuf.version>
     <opentelemetry.version>1.44.1</opentelemetry.version>
     <maven.compiler.release>8</maven.compiler.release>
     <errorprone.version>2.36.0</errorprone.version>

--- a/gax-java/gax/src/main/resources/META-INF/native-image/com.google.api/gax/native-image.properties
+++ b/gax-java/gax/src/main/resources/META-INF/native-image/com.google.api/gax/native-image.properties
@@ -3,7 +3,7 @@ Args = --enable-url-protocols=https,http \
   org.junit.platform.engine.TestTag,\
   com.google.api.gax.core.GaxProperties,\
   com.google.common.base.Platform,\
-  com.google.common.base.Platform$JdkPatternCompiler, \
+  com.google.common.base.Platform$JdkPatternCompiler,\
   com.google.protobuf.RuntimeVersion \
   --features=com.google.api.gax.nativeimage.OpenCensusFeature,\
   com.google.api.gax.nativeimage.GoogleJsonClientFeature \

--- a/gax-java/gax/src/main/resources/META-INF/native-image/com.google.api/gax/native-image.properties
+++ b/gax-java/gax/src/main/resources/META-INF/native-image/com.google.api/gax/native-image.properties
@@ -3,7 +3,8 @@ Args = --enable-url-protocols=https,http \
   org.junit.platform.engine.TestTag,\
   com.google.api.gax.core.GaxProperties,\
   com.google.common.base.Platform,\
-  com.google.common.base.Platform$JdkPatternCompiler \
+  com.google.common.base.Platform$JdkPatternCompiler, \
+  com.google.protobuf.RuntimeVersion \
   --features=com.google.api.gax.nativeimage.OpenCensusFeature,\
   com.google.api.gax.nativeimage.GoogleJsonClientFeature \
   --add-modules=jdk.httpserver


### PR DESCRIPTION
In case of protobuf 4+ need to include protobuf.Runtime in classes initialized at build time as that is used to determine protobuf version for graalvm.

Tested, temporarily bumped protobuf dependency to 4.28.1 without including Runtime in build time class list.  Received error:

```
Error: Classes that should be initialized at run time got initialized during image building:
 com.google.protobuf.RuntimeVersion was unintentionally initialized at build time. To see why com.google.protobuf.RuntimeVersion got initialized use --trace-class-initialization=com.google.protobuf.RuntimeVersion
```

Updated to include Runtime and received passing [native showcase tests](https://github.com/googleapis/sdk-platform-java/actions/runs/12205342463/job/34052473211?pr=3438)



