### PR TITLE
chore(deps): Downgrade dev.cel to 0.6.0

### DIFF
--- a/java-shared-dependencies/third-party-dependencies/pom.xml
+++ b/java-shared-dependencies/third-party-dependencies/pom.xml
@@ -41,7 +41,7 @@
     <opentelemetry-semconv.version>1.26.0-alpha</opentelemetry-semconv.version>
     <flogger.version>0.8</flogger.version>
     <arrow.version>15.0.2</arrow.version>
-    <dev.cel.version>0.8.0</dev.cel.version>
+    <dev.cel.version>0.6.0</dev.cel.version>
     <com.google.crypto.tink.version>1.15.0</com.google.crypto.tink.version>
   </properties>
 


### PR DESCRIPTION
`dev.cel` 0.6.0+ brings in `protobuf-java` 4.28.x, which violates the no-downgrade rule since we still have [3.25.5](https://github.com/googleapis/sdk-platform-java/blob/f0236cfc102cf7ce06e1f733a4f40a50133d6b24/gapic-generator-java-pom-parent/pom.xml#L34) in this repo. This is not a major issue now as this dependency is not used yet in any downstream libraries, but we should downgrade it in case someone start using it. 
Separately, we should prevent this from happening in the future. See b/382754689 for potential future enhancements.