### PR TITLE
chore: close repo after use

### DIFF
--- a/hermetic_build/common/model/config_change.py
+++ b/hermetic_build/common/model/config_change.py
@@ -121,6 +121,7 @@ class ConfigChange:
                 if len(commit_parents) == 0:
                     break
                 commit = commit_parents[0]
+            repo.close()
         return qualified_commits
 
     def __get_library_names_from_qualified_commits(self) -> list[str]:


### PR DESCRIPTION
In this PR:
- Close repo after retrieving qualified commits.

This is an attempt to fix the following error ([log](https://github.com/googleapis/sdk-platform-java/actions/runs/12297693455/job/34319408952)):
```
Traceback (most recent call last):
  File "/home/runner/work/sdk-platform-java/sdk-platform-java/hermetic_build/common/cli/get_changed_libraries.py", line 79, in <module>
    main()
  File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/sdk-platform-java/sdk-platform-java/hermetic_build/common/cli/get_changed_libraries.py", line 75, in create
    click.echo(",".join(config_change.get_changed_libraries()))
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/site-packages/common/model/config_change.py", line 89, in get_changed_libraries
    library_names.update(self.__get_library_names_from_qualified_commits())
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/site-packages/common/model/config_change.py", line 127, in __get_library_names_from_qualified_commits
    qualified_commits = self.get_qualified_commits()
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/site-packages/common/model/config_change.py", line 108, in get_qualified_commits
    with tempfile.TemporaryDirectory() as tmp_dir:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/tempfile.py", line 946, in __exit__
    self.cleanup()
  File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/tempfile.py", line 950, in cleanup
    self._rmtree(self.name, ignore_errors=self._ignore_cleanup_errors)
  File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/tempfile.py", line 930, in _rmtree
    _shutil.rmtree(name, onexc=onexc)
  File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/shutil.py", line 759, in rmtree
    _rmtree_safe_fd(stack, onexc)
  File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/shutil.py", line 703, in _rmtree_safe_fd
    onexc(func, path, err)
  File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/shutil.py", line 662, in _rmtree_safe_fd
    os.rmdir(name, dir_fd=dirfd)
OSError: [Errno 39] Directory not empty: '/tmp/tmpig4jo9hh'
```