### PR TITLE
chore: make library generation IT non-required

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -21,7 +21,6 @@ branchProtectionRules:
   - graalvm-presubmit-sdk-platform-java-a-downstream-kmsinventory (java-graalvm-ci-prod)
   - graalvm-presubmit-sdk-platform-java-b-downstream-kmsinventory (java-graalvm-ci-prod)
   - library_generation
-  - library-generation-integration-tests
   - library-generation-lint-python
   - library-generation-lint-shell
   - library-generation-unit-tests


### PR DESCRIPTION
In this PR:
- Make the library generation integration test non-required.

This integration test will be removed in #3476 because we will use cloud build to run integration tests.