### PR TITLE
tests: Update the golden files' copyright to 2025

### DIFF
--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/ComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/ComposerTest.java
@@ -61,6 +61,7 @@ class ComposerTest {
     assertTrue(context.containsServices());
   }
 
+  @Disabled
   @Test
   public void gapicClass_addApacheLicense_validInput_succeeds() {
     ClassDefinition classDef =

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/ComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/ComposerTest.java
@@ -62,7 +62,6 @@ class ComposerTest {
     assertTrue(context.containsServices());
   }
 
-  @Disabled
   @Test
   public void gapicClass_addApacheLicense_validInput_succeeds() {
     ClassDefinition classDef =

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/ComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/ComposerTest.java
@@ -39,6 +39,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Disabled;
 
 class ComposerTest {
   private final GapicContext context = GrpcTestProtoLoader.instance().parseShowcaseEcho();

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/ComposerTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/ComposerTest.java
@@ -39,7 +39,6 @@ import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Disabled;
 
 class ComposerTest {
   private final GapicContext context = GrpcTestProtoLoader.instance().parseShowcaseEcho();

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/goldens/ComposerPostProcOnFooBar.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/goldens/ComposerPostProcOnFooBar.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/grpc-google-common-protos/src/main/java/com/google/cloud/location/LocationsGrpc.java
+++ b/java-common-protos/grpc-google-common-protos/src/main/java/com/google/cloud/location/LocationsGrpc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/grpc-google-common-protos/src/main/java/com/google/longrunning/OperationsGrpc.java
+++ b/java-common-protos/grpc-google-common-protos/src/main/java/com/google/longrunning/OperationsGrpc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Advice.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Advice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/AdviceOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/AdviceOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/AnnotationsProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/AnnotationsProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/AuthProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/AuthProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/AuthProvider.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/AuthProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/AuthProviderOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/AuthProviderOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/AuthRequirement.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/AuthRequirement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/AuthRequirementOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/AuthRequirementOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Authentication.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Authentication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/AuthenticationOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/AuthenticationOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/AuthenticationRule.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/AuthenticationRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/AuthenticationRuleOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/AuthenticationRuleOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Backend.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Backend.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/BackendOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/BackendOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/BackendProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/BackendProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/BackendRule.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/BackendRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/BackendRuleOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/BackendRuleOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Billing.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Billing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/BillingOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/BillingOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/BillingProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/BillingProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ChangeType.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ChangeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ClientLibraryDestination.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ClientLibraryDestination.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ClientLibraryOrganization.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ClientLibraryOrganization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ClientLibrarySettings.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ClientLibrarySettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ClientLibrarySettingsOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ClientLibrarySettingsOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ClientProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ClientProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/CommonLanguageSettings.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/CommonLanguageSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/CommonLanguageSettingsOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/CommonLanguageSettingsOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ConfigChange.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ConfigChange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ConfigChangeOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ConfigChangeOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ConfigChangeProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ConfigChangeProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ConsumerProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ConsumerProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Context.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Context.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ContextOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ContextOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ContextProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ContextProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ContextRule.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ContextRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ContextRuleOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ContextRuleOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Control.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Control.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ControlOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ControlOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ControlProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ControlProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/CppSettings.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/CppSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/CppSettingsOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/CppSettingsOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/CustomHttpPattern.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/CustomHttpPattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/CustomHttpPatternOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/CustomHttpPatternOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Distribution.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Distribution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/DistributionOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/DistributionOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/DistributionProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/DistributionProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Documentation.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Documentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/DocumentationOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/DocumentationOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/DocumentationProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/DocumentationProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/DocumentationRule.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/DocumentationRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/DocumentationRuleOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/DocumentationRuleOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/DotnetSettings.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/DotnetSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/DotnetSettingsOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/DotnetSettingsOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Endpoint.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Endpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/EndpointOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/EndpointOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/EndpointProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/EndpointProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ErrorReason.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ErrorReason.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ErrorReasonProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ErrorReasonProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/FieldBehavior.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/FieldBehavior.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/FieldBehaviorProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/FieldBehaviorProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/FieldInfo.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/FieldInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/FieldInfoOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/FieldInfoOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/FieldInfoProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/FieldInfoProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/FieldPolicy.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/FieldPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/FieldPolicyOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/FieldPolicyOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/GoSettings.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/GoSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/GoSettingsOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/GoSettingsOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Http.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Http.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/HttpBody.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/HttpBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/HttpBodyOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/HttpBodyOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/HttpBodyProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/HttpBodyProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/HttpOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/HttpOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/HttpProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/HttpProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/HttpRule.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/HttpRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/HttpRuleOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/HttpRuleOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/JavaSettings.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/JavaSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/JavaSettingsOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/JavaSettingsOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/JwtLocation.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/JwtLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/JwtLocationOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/JwtLocationOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/LabelDescriptor.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/LabelDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/LabelDescriptorOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/LabelDescriptorOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/LabelProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/LabelProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/LaunchStage.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/LaunchStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/LaunchStageProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/LaunchStageProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/LogDescriptor.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/LogDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/LogDescriptorOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/LogDescriptorOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/LogProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/LogProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Logging.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Logging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/LoggingOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/LoggingOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/LoggingProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/LoggingProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MethodPolicy.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MethodPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MethodPolicyOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MethodPolicyOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MethodSettings.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MethodSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MethodSettingsOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MethodSettingsOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Metric.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Metric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MetricDescriptor.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MetricDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MetricDescriptorOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MetricDescriptorOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MetricOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MetricOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MetricProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MetricProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MetricRule.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MetricRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MetricRuleOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MetricRuleOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MonitoredResource.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MonitoredResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MonitoredResourceDescriptor.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MonitoredResourceDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MonitoredResourceDescriptorOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MonitoredResourceDescriptorOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MonitoredResourceMetadata.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MonitoredResourceMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MonitoredResourceMetadataOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MonitoredResourceMetadataOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MonitoredResourceOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MonitoredResourceOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MonitoredResourceProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MonitoredResourceProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Monitoring.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Monitoring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MonitoringOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MonitoringOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MonitoringProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/MonitoringProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/NodeSettings.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/NodeSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/NodeSettingsOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/NodeSettingsOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/OAuthRequirements.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/OAuthRequirements.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/OAuthRequirementsOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/OAuthRequirementsOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Page.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Page.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/PageOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/PageOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/PhpSettings.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/PhpSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/PhpSettingsOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/PhpSettingsOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/PolicyProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/PolicyProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ProjectProperties.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ProjectProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ProjectPropertiesOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ProjectPropertiesOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Property.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Property.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/PropertyOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/PropertyOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Publishing.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Publishing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/PublishingOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/PublishingOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/PythonSettings.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/PythonSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/PythonSettingsOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/PythonSettingsOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Quota.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Quota.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/QuotaLimit.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/QuotaLimit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/QuotaLimitOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/QuotaLimitOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/QuotaOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/QuotaOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/QuotaProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/QuotaProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ResourceDescriptor.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ResourceDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ResourceDescriptorOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ResourceDescriptorOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ResourceProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ResourceProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ResourceReference.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ResourceReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ResourceReferenceOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ResourceReferenceOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/RoutingParameter.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/RoutingParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/RoutingParameterOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/RoutingParameterOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/RoutingProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/RoutingProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/RoutingRule.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/RoutingRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/RoutingRuleOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/RoutingRuleOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/RubySettings.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/RubySettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/RubySettingsOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/RubySettingsOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/SelectiveGapicGeneration.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/SelectiveGapicGeneration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/SelectiveGapicGenerationOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/SelectiveGapicGenerationOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Service.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Service.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ServiceOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ServiceOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ServiceProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/ServiceProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/SourceInfo.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/SourceInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/SourceInfoOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/SourceInfoOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/SourceInfoProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/SourceInfoProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/SystemParameter.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/SystemParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/SystemParameterOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/SystemParameterOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/SystemParameterProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/SystemParameterProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/SystemParameterRule.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/SystemParameterRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/SystemParameterRuleOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/SystemParameterRuleOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/SystemParameters.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/SystemParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/SystemParametersOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/SystemParametersOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/TypeReference.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/TypeReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/TypeReferenceOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/TypeReferenceOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Usage.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Usage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/UsageOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/UsageOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/UsageProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/UsageProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/UsageRule.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/UsageRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/UsageRuleOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/UsageRuleOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Visibility.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/Visibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/VisibilityOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/VisibilityOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/VisibilityProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/VisibilityProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/VisibilityRule.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/VisibilityRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/VisibilityRuleOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/api/VisibilityRuleOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/Action.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/Action.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/ActionOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/ActionOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/BorderStyle.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/BorderStyle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/BorderStyleOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/BorderStyleOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/Button.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/Button.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/ButtonList.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/ButtonList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/ButtonListOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/ButtonListOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/ButtonOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/ButtonOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/Card.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/Card.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/CardOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/CardOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/CardProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/CardProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/Columns.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/Columns.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/ColumnsOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/ColumnsOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/DateTimePicker.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/DateTimePicker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/DateTimePickerOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/DateTimePickerOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/DecoratedText.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/DecoratedText.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/DecoratedTextOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/DecoratedTextOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/Divider.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/Divider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/DividerOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/DividerOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/Grid.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/Grid.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/GridOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/GridOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/Icon.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/Icon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/IconOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/IconOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/Image.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/Image.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/ImageComponent.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/ImageComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/ImageComponentOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/ImageComponentOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/ImageCropStyle.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/ImageCropStyle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/ImageCropStyleOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/ImageCropStyleOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/ImageOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/ImageOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/MaterialIcon.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/MaterialIcon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/MaterialIconOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/MaterialIconOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/OnClick.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/OnClick.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/OnClickOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/OnClickOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/OpenLink.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/OpenLink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/OpenLinkOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/OpenLinkOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/SelectionInput.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/SelectionInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/SelectionInputOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/SelectionInputOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/Suggestions.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/Suggestions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/SuggestionsOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/SuggestionsOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/TextInput.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/TextInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/TextInputOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/TextInputOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/TextParagraph.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/TextParagraph.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/TextParagraphOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/TextParagraphOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/Widget.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/Widget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/WidgetOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/apps/card/v1/WidgetOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/ExtendedOperationsProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/ExtendedOperationsProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/OperationResponseMapping.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/OperationResponseMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/AuditLog.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/AuditLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/AuditLogOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/AuditLogOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/AuditLogProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/AuditLogProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/AuthenticationInfo.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/AuthenticationInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/AuthenticationInfoOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/AuthenticationInfoOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/AuthorizationInfo.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/AuthorizationInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/AuthorizationInfoOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/AuthorizationInfoOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/OrgPolicyViolationInfo.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/OrgPolicyViolationInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/OrgPolicyViolationInfoOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/OrgPolicyViolationInfoOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/PolicyViolationInfo.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/PolicyViolationInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/PolicyViolationInfoOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/PolicyViolationInfoOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/RequestMetadata.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/RequestMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/RequestMetadataOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/RequestMetadataOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/ResourceLocation.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/ResourceLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/ResourceLocationOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/ResourceLocationOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/ServiceAccountDelegationInfo.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/ServiceAccountDelegationInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/ServiceAccountDelegationInfoOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/ServiceAccountDelegationInfoOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/ViolationInfo.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/ViolationInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/ViolationInfoOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/audit/ViolationInfoOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/location/GetLocationRequest.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/location/GetLocationRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/location/GetLocationRequestOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/location/GetLocationRequestOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/location/ListLocationsRequest.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/location/ListLocationsRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/location/ListLocationsRequestOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/location/ListLocationsRequestOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/location/ListLocationsResponse.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/location/ListLocationsResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/location/ListLocationsResponseOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/location/ListLocationsResponseOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/location/Location.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/location/Location.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/location/LocationOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/location/LocationOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/location/LocationsProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/cloud/location/LocationsProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/geo/type/Viewport.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/geo/type/Viewport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/geo/type/ViewportOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/geo/type/ViewportOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/geo/type/ViewportProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/geo/type/ViewportProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/logging/type/HttpRequest.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/logging/type/HttpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/logging/type/HttpRequestOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/logging/type/HttpRequestOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/logging/type/HttpRequestProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/logging/type/HttpRequestProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/logging/type/LogSeverity.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/logging/type/LogSeverity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/logging/type/LogSeverityProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/logging/type/LogSeverityProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/longrunning/CancelOperationRequest.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/longrunning/CancelOperationRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/longrunning/CancelOperationRequestOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/longrunning/CancelOperationRequestOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/longrunning/DeleteOperationRequest.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/longrunning/DeleteOperationRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/longrunning/DeleteOperationRequestOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/longrunning/DeleteOperationRequestOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/longrunning/GetOperationRequest.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/longrunning/GetOperationRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/longrunning/GetOperationRequestOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/longrunning/GetOperationRequestOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/longrunning/ListOperationsRequest.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/longrunning/ListOperationsRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/longrunning/ListOperationsRequestOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/longrunning/ListOperationsRequestOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/longrunning/ListOperationsResponse.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/longrunning/ListOperationsResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/longrunning/ListOperationsResponseOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/longrunning/ListOperationsResponseOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/longrunning/Operation.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/longrunning/Operation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/longrunning/OperationInfo.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/longrunning/OperationInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/longrunning/OperationInfoOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/longrunning/OperationInfoOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/longrunning/OperationOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/longrunning/OperationOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/longrunning/OperationsProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/longrunning/OperationsProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/longrunning/WaitOperationRequest.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/longrunning/WaitOperationRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/longrunning/WaitOperationRequestOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/longrunning/WaitOperationRequestOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/BadRequest.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/BadRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/BadRequestOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/BadRequestOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/Code.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/CodeProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/CodeProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/DebugInfo.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/DebugInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/DebugInfoOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/DebugInfoOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/ErrorDetailsProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/ErrorDetailsProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/ErrorInfo.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/ErrorInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/ErrorInfoOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/ErrorInfoOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/Help.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/Help.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/HelpOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/HelpOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/LocalizedMessage.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/LocalizedMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/LocalizedMessageOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/LocalizedMessageOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/PreconditionFailure.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/PreconditionFailure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/PreconditionFailureOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/PreconditionFailureOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/QuotaFailure.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/QuotaFailure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/QuotaFailureOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/QuotaFailureOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/RequestInfo.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/RequestInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/RequestInfoOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/RequestInfoOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/ResourceInfo.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/ResourceInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/ResourceInfoOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/ResourceInfoOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/RetryInfo.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/RetryInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/RetryInfoOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/RetryInfoOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/Status.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/Status.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/StatusOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/StatusOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/StatusProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/StatusProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/context/AttributeContext.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/context/AttributeContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/context/AttributeContextOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/context/AttributeContextOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/context/AttributeContextProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/context/AttributeContextProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/context/AuditContext.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/context/AuditContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/context/AuditContextOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/context/AuditContextOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/context/AuditContextProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/rpc/context/AuditContextProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/shopping/type/Channel.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/shopping/type/Channel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/shopping/type/ChannelOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/shopping/type/ChannelOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/shopping/type/CustomAttribute.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/shopping/type/CustomAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/shopping/type/CustomAttributeOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/shopping/type/CustomAttributeOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/shopping/type/Destination.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/shopping/type/Destination.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/shopping/type/DestinationOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/shopping/type/DestinationOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/shopping/type/Price.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/shopping/type/Price.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/shopping/type/PriceOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/shopping/type/PriceOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/shopping/type/ReportingContext.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/shopping/type/ReportingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/shopping/type/ReportingContextOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/shopping/type/ReportingContextOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/shopping/type/TypesProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/shopping/type/TypesProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/shopping/type/Weight.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/shopping/type/Weight.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/shopping/type/WeightOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/shopping/type/WeightOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/CalendarPeriod.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/CalendarPeriod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/CalendarPeriodProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/CalendarPeriodProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/Color.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/Color.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/ColorOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/ColorOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/ColorProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/ColorProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/Date.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/Date.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/DateOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/DateOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/DateProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/DateProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/DateTime.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/DateTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/DateTimeOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/DateTimeOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/DateTimeProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/DateTimeProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/DayOfWeek.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/DayOfWeek.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/DayOfWeekProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/DayOfWeekProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/Decimal.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/Decimal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/DecimalOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/DecimalOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/DecimalProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/DecimalProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/Expr.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/Expr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/ExprOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/ExprOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/ExprProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/ExprProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/Fraction.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/Fraction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/FractionOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/FractionOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/FractionProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/FractionProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/Interval.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/Interval.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/IntervalOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/IntervalOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/IntervalProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/IntervalProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/LatLng.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/LatLng.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/LatLngOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/LatLngOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/LatLngProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/LatLngProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/LocalizedText.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/LocalizedText.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/LocalizedTextOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/LocalizedTextOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/LocalizedTextProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/LocalizedTextProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/Money.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/Money.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/MoneyOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/MoneyOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/MoneyProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/MoneyProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/Month.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/Month.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/MonthProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/MonthProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/PhoneNumber.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/PhoneNumber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/PhoneNumberOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/PhoneNumberOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/PhoneNumberProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/PhoneNumberProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/PostalAddress.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/PostalAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/PostalAddressOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/PostalAddressOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/PostalAddressProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/PostalAddressProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/Quaternion.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/Quaternion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/QuaternionOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/QuaternionOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/QuaternionProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/QuaternionProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/TimeOfDay.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/TimeOfDay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/TimeOfDayOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/TimeOfDayOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/TimeOfDayProto.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/TimeOfDayProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/TimeZone.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/TimeZone.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/TimeZoneOrBuilder.java
+++ b/java-common-protos/proto-google-common-protos/src/main/java/com/google/type/TimeZoneOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/grpc-google-iam-v1/src/main/java/com/google/iam/v1/IAMPolicyGrpc.java
+++ b/java-iam/grpc-google-iam-v1/src/main/java/com/google/iam/v1/IAMPolicyGrpc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/grpc-google-iam-v2/src/main/java/com/google/iam/v2/PoliciesGrpc.java
+++ b/java-iam/grpc-google-iam-v2/src/main/java/com/google/iam/v2/PoliciesGrpc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/grpc-google-iam-v2beta/src/main/java/com/google/iam/v2beta/PoliciesGrpc.java
+++ b/java-iam/grpc-google-iam-v2beta/src/main/java/com/google/iam/v2beta/PoliciesGrpc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/AuditConfig.java
+++ b/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/AuditConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/AuditConfigDelta.java
+++ b/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/AuditConfigDelta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/AuditConfigDeltaOrBuilder.java
+++ b/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/AuditConfigDeltaOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/AuditConfigOrBuilder.java
+++ b/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/AuditConfigOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/AuditLogConfig.java
+++ b/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/AuditLogConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/AuditLogConfigOrBuilder.java
+++ b/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/AuditLogConfigOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/Binding.java
+++ b/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/Binding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/BindingDelta.java
+++ b/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/BindingDelta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/BindingDeltaOrBuilder.java
+++ b/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/BindingDeltaOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/BindingOrBuilder.java
+++ b/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/BindingOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/GetIamPolicyRequest.java
+++ b/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/GetIamPolicyRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/GetIamPolicyRequestOrBuilder.java
+++ b/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/GetIamPolicyRequestOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/GetPolicyOptions.java
+++ b/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/GetPolicyOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/GetPolicyOptionsOrBuilder.java
+++ b/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/GetPolicyOptionsOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/IamPolicyProto.java
+++ b/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/IamPolicyProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/OptionsProto.java
+++ b/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/OptionsProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/Policy.java
+++ b/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/Policy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/PolicyDelta.java
+++ b/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/PolicyDelta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/PolicyDeltaOrBuilder.java
+++ b/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/PolicyDeltaOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/PolicyOrBuilder.java
+++ b/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/PolicyOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/PolicyProto.java
+++ b/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/PolicyProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/ResourcePolicyMember.java
+++ b/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/ResourcePolicyMember.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/ResourcePolicyMemberOrBuilder.java
+++ b/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/ResourcePolicyMemberOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/ResourcePolicyMemberProto.java
+++ b/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/ResourcePolicyMemberProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/SetIamPolicyRequest.java
+++ b/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/SetIamPolicyRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/SetIamPolicyRequestOrBuilder.java
+++ b/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/SetIamPolicyRequestOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/TestIamPermissionsRequest.java
+++ b/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/TestIamPermissionsRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/TestIamPermissionsRequestOrBuilder.java
+++ b/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/TestIamPermissionsRequestOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/TestIamPermissionsResponse.java
+++ b/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/TestIamPermissionsResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/TestIamPermissionsResponseOrBuilder.java
+++ b/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/TestIamPermissionsResponseOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/logging/AuditData.java
+++ b/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/logging/AuditData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/logging/AuditDataOrBuilder.java
+++ b/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/logging/AuditDataOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/logging/AuditDataProto.java
+++ b/java-iam/proto-google-iam-v1/src/main/java/com/google/iam/v1/logging/AuditDataProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/CreatePolicyRequest.java
+++ b/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/CreatePolicyRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/CreatePolicyRequestOrBuilder.java
+++ b/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/CreatePolicyRequestOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/DeletePolicyRequest.java
+++ b/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/DeletePolicyRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/DeletePolicyRequestOrBuilder.java
+++ b/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/DeletePolicyRequestOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/DenyRule.java
+++ b/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/DenyRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/DenyRuleOrBuilder.java
+++ b/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/DenyRuleOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/DenyRuleProto.java
+++ b/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/DenyRuleProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/GetPolicyRequest.java
+++ b/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/GetPolicyRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/GetPolicyRequestOrBuilder.java
+++ b/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/GetPolicyRequestOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/ListPoliciesRequest.java
+++ b/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/ListPoliciesRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/ListPoliciesRequestOrBuilder.java
+++ b/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/ListPoliciesRequestOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/ListPoliciesResponse.java
+++ b/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/ListPoliciesResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/ListPoliciesResponseOrBuilder.java
+++ b/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/ListPoliciesResponseOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/Policy.java
+++ b/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/Policy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/PolicyOperationMetadata.java
+++ b/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/PolicyOperationMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/PolicyOperationMetadataOrBuilder.java
+++ b/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/PolicyOperationMetadataOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/PolicyOrBuilder.java
+++ b/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/PolicyOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/PolicyProto.java
+++ b/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/PolicyProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/PolicyRule.java
+++ b/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/PolicyRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/PolicyRuleOrBuilder.java
+++ b/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/PolicyRuleOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/UpdatePolicyRequest.java
+++ b/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/UpdatePolicyRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/UpdatePolicyRequestOrBuilder.java
+++ b/java-iam/proto-google-iam-v2/src/main/java/com/google/iam/v2/UpdatePolicyRequestOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/CreatePolicyRequest.java
+++ b/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/CreatePolicyRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/CreatePolicyRequestOrBuilder.java
+++ b/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/CreatePolicyRequestOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/DeletePolicyRequest.java
+++ b/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/DeletePolicyRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/DeletePolicyRequestOrBuilder.java
+++ b/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/DeletePolicyRequestOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/DenyRule.java
+++ b/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/DenyRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/DenyRuleOrBuilder.java
+++ b/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/DenyRuleOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/DenyRuleProto.java
+++ b/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/DenyRuleProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/GetPolicyRequest.java
+++ b/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/GetPolicyRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/GetPolicyRequestOrBuilder.java
+++ b/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/GetPolicyRequestOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/ListPoliciesRequest.java
+++ b/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/ListPoliciesRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/ListPoliciesRequestOrBuilder.java
+++ b/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/ListPoliciesRequestOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/ListPoliciesResponse.java
+++ b/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/ListPoliciesResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/ListPoliciesResponseOrBuilder.java
+++ b/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/ListPoliciesResponseOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/Policy.java
+++ b/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/Policy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/PolicyOperationMetadata.java
+++ b/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/PolicyOperationMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/PolicyOperationMetadataOrBuilder.java
+++ b/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/PolicyOperationMetadataOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/PolicyOrBuilder.java
+++ b/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/PolicyOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/PolicyProto.java
+++ b/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/PolicyProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/PolicyRule.java
+++ b/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/PolicyRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/PolicyRuleOrBuilder.java
+++ b/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/PolicyRuleOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/UpdatePolicyRequest.java
+++ b/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/UpdatePolicyRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/UpdatePolicyRequestOrBuilder.java
+++ b/java-iam/proto-google-iam-v2beta/src/main/java/com/google/iam/v2beta/UpdatePolicyRequestOrBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/ComplianceClient.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/ComplianceClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/ComplianceSettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/ComplianceSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/EchoClient.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/EchoClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/EchoSettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/EchoSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/IdentityClient.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/IdentityClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/IdentitySettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/IdentitySettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/MessagingClient.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/MessagingClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/MessagingSettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/MessagingSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/SequenceServiceClient.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/SequenceServiceClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/SequenceServiceSettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/SequenceServiceSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/TestingClient.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/TestingClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/TestingSettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/TestingSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/package-info.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/ComplianceStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/ComplianceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/ComplianceStubSettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/ComplianceStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/EchoStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/EchoStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/EchoStubSettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/EchoStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcComplianceCallableFactory.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcComplianceCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcComplianceStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcComplianceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcEchoCallableFactory.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcEchoCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcEchoStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcEchoStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcIdentityCallableFactory.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcIdentityCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcIdentityStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcIdentityStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcMessagingCallableFactory.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcMessagingCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcMessagingStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcMessagingStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcSequenceServiceCallableFactory.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcSequenceServiceCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcSequenceServiceStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcSequenceServiceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcTestingCallableFactory.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcTestingCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcTestingStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcTestingStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonComplianceCallableFactory.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonComplianceCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonComplianceStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonComplianceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonEchoCallableFactory.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonEchoCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonEchoStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonEchoStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonIdentityCallableFactory.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonIdentityCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonIdentityStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonIdentityStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonMessagingCallableFactory.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonMessagingCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonMessagingStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonMessagingStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonSequenceServiceCallableFactory.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonSequenceServiceCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonSequenceServiceStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonSequenceServiceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonTestingCallableFactory.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonTestingCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonTestingStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonTestingStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/IdentityStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/IdentityStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/IdentityStubSettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/IdentityStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/MessagingStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/MessagingStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/MessagingStubSettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/MessagingStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/SequenceServiceStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/SequenceServiceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/SequenceServiceStubSettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/SequenceServiceStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/TestingStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/TestingStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/TestingStubSettings.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/TestingStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/BlurbName.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/BlurbName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ProfileName.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ProfileName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/RoomName.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/RoomName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/SequenceName.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/SequenceName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/SequenceReportName.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/SequenceReportName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/SessionName.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/SessionName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/StreamingSequenceName.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/StreamingSequenceName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/StreamingSequenceReportName.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/StreamingSequenceReportName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/TestName.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/TestName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/UserName.java
+++ b/showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/UserName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservice/create/SyncCreateSetCredentialsProvider.java
+++ b/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservice/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservice/create/SyncCreateSetEndpoint.java
+++ b/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservice/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservice/create/SyncCreateUseHttpJsonTransport.java
+++ b/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservice/create/SyncCreateUseHttpJsonTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservice/listconnections/AsyncListConnections.java
+++ b/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservice/listconnections/AsyncListConnections.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservice/listconnections/AsyncListConnectionsPaged.java
+++ b/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservice/listconnections/AsyncListConnectionsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservice/listconnections/SyncListConnections.java
+++ b/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservice/listconnections/SyncListConnections.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservice/listconnections/SyncListConnectionsEndpointname.java
+++ b/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservice/listconnections/SyncListConnectionsEndpointname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservice/listconnections/SyncListConnectionsString.java
+++ b/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservice/listconnections/SyncListConnectionsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservicesettings/listconnections/SyncListConnections.java
+++ b/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/connectionservicesettings/listconnections/SyncListConnections.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/stub/connectionservicestubsettings/listconnections/SyncListConnections.java
+++ b/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/stub/connectionservicestubsettings/listconnections/SyncListConnections.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/stub/tetherstubsettings/egress/SyncEgress.java
+++ b/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/stub/tetherstubsettings/egress/SyncEgress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/tether/create/SyncCreateSetCredentialsProvider.java
+++ b/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/tether/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/tether/create/SyncCreateSetEndpoint.java
+++ b/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/tether/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/tether/egress/AsyncEgress.java
+++ b/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/tether/egress/AsyncEgress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/tethersettings/egress/SyncEgress.java
+++ b/test/integration/goldens/apigeeconnect/samples/snippets/generated/main/java/com/google/cloud/apigeeconnect/v1/tethersettings/egress/SyncEgress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/ConnectionServiceClient.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/ConnectionServiceClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/ConnectionServiceClientHttpJsonTest.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/ConnectionServiceClientHttpJsonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/ConnectionServiceClientTest.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/ConnectionServiceClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/ConnectionServiceSettings.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/ConnectionServiceSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/EndpointName.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/EndpointName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/MockConnectionService.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/MockConnectionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/MockConnectionServiceImpl.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/MockConnectionServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/MockTether.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/MockTether.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/MockTetherImpl.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/MockTetherImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/TetherClient.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/TetherClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/TetherClientTest.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/TetherClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/TetherSettings.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/TetherSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/package-info.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/ConnectionServiceStub.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/ConnectionServiceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/ConnectionServiceStubSettings.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/ConnectionServiceStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/GrpcConnectionServiceCallableFactory.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/GrpcConnectionServiceCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/GrpcConnectionServiceStub.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/GrpcConnectionServiceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/GrpcTetherCallableFactory.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/GrpcTetherCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/GrpcTetherStub.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/GrpcTetherStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/HttpJsonConnectionServiceCallableFactory.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/HttpJsonConnectionServiceCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/HttpJsonConnectionServiceStub.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/HttpJsonConnectionServiceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/TetherStub.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/TetherStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/TetherStubSettings.java
+++ b/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/TetherStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/analyzeiampolicy/AsyncAnalyzeIamPolicy.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/analyzeiampolicy/AsyncAnalyzeIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/analyzeiampolicy/SyncAnalyzeIamPolicy.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/analyzeiampolicy/SyncAnalyzeIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/analyzeiampolicylongrunning/AsyncAnalyzeIamPolicyLongrunning.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/analyzeiampolicylongrunning/AsyncAnalyzeIamPolicyLongrunning.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/analyzeiampolicylongrunning/AsyncAnalyzeIamPolicyLongrunningLRO.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/analyzeiampolicylongrunning/AsyncAnalyzeIamPolicyLongrunningLRO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/analyzeiampolicylongrunning/SyncAnalyzeIamPolicyLongrunning.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/analyzeiampolicylongrunning/SyncAnalyzeIamPolicyLongrunning.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/analyzemove/AsyncAnalyzeMove.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/analyzemove/AsyncAnalyzeMove.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/analyzemove/SyncAnalyzeMove.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/analyzemove/SyncAnalyzeMove.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/batchgetassetshistory/AsyncBatchGetAssetsHistory.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/batchgetassetshistory/AsyncBatchGetAssetsHistory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/batchgetassetshistory/SyncBatchGetAssetsHistory.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/batchgetassetshistory/SyncBatchGetAssetsHistory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/batchgeteffectiveiampolicies/AsyncBatchGetEffectiveIamPolicies.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/batchgeteffectiveiampolicies/AsyncBatchGetEffectiveIamPolicies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/batchgeteffectiveiampolicies/SyncBatchGetEffectiveIamPolicies.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/batchgeteffectiveiampolicies/SyncBatchGetEffectiveIamPolicies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/create/SyncCreateSetCredentialsProvider.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/create/SyncCreateSetEndpoint.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/create/SyncCreateUseHttpJsonTransport.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/create/SyncCreateUseHttpJsonTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/createfeed/AsyncCreateFeed.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/createfeed/AsyncCreateFeed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/createfeed/SyncCreateFeed.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/createfeed/SyncCreateFeed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/createfeed/SyncCreateFeedString.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/createfeed/SyncCreateFeedString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/createsavedquery/AsyncCreateSavedQuery.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/createsavedquery/AsyncCreateSavedQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/createsavedquery/SyncCreateSavedQuery.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/createsavedquery/SyncCreateSavedQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/createsavedquery/SyncCreateSavedQueryFoldernameSavedqueryString.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/createsavedquery/SyncCreateSavedQueryFoldernameSavedqueryString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/createsavedquery/SyncCreateSavedQueryOrganizationnameSavedqueryString.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/createsavedquery/SyncCreateSavedQueryOrganizationnameSavedqueryString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/createsavedquery/SyncCreateSavedQueryProjectnameSavedqueryString.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/createsavedquery/SyncCreateSavedQueryProjectnameSavedqueryString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/createsavedquery/SyncCreateSavedQueryStringSavedqueryString.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/createsavedquery/SyncCreateSavedQueryStringSavedqueryString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/deletefeed/AsyncDeleteFeed.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/deletefeed/AsyncDeleteFeed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/deletefeed/SyncDeleteFeed.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/deletefeed/SyncDeleteFeed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/deletefeed/SyncDeleteFeedFeedname.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/deletefeed/SyncDeleteFeedFeedname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/deletefeed/SyncDeleteFeedString.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/deletefeed/SyncDeleteFeedString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/deletesavedquery/AsyncDeleteSavedQuery.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/deletesavedquery/AsyncDeleteSavedQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/deletesavedquery/SyncDeleteSavedQuery.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/deletesavedquery/SyncDeleteSavedQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/deletesavedquery/SyncDeleteSavedQuerySavedqueryname.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/deletesavedquery/SyncDeleteSavedQuerySavedqueryname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/deletesavedquery/SyncDeleteSavedQueryString.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/deletesavedquery/SyncDeleteSavedQueryString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/exportassets/AsyncExportAssets.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/exportassets/AsyncExportAssets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/exportassets/AsyncExportAssetsLRO.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/exportassets/AsyncExportAssetsLRO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/exportassets/SyncExportAssets.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/exportassets/SyncExportAssets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/getfeed/AsyncGetFeed.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/getfeed/AsyncGetFeed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/getfeed/SyncGetFeed.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/getfeed/SyncGetFeed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/getfeed/SyncGetFeedFeedname.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/getfeed/SyncGetFeedFeedname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/getfeed/SyncGetFeedString.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/getfeed/SyncGetFeedString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/getsavedquery/AsyncGetSavedQuery.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/getsavedquery/AsyncGetSavedQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/getsavedquery/SyncGetSavedQuery.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/getsavedquery/SyncGetSavedQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/getsavedquery/SyncGetSavedQuerySavedqueryname.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/getsavedquery/SyncGetSavedQuerySavedqueryname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/getsavedquery/SyncGetSavedQueryString.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/getsavedquery/SyncGetSavedQueryString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listassets/AsyncListAssets.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listassets/AsyncListAssets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listassets/AsyncListAssetsPaged.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listassets/AsyncListAssetsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listassets/SyncListAssets.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listassets/SyncListAssets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listassets/SyncListAssetsResourcename.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listassets/SyncListAssetsResourcename.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listassets/SyncListAssetsString.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listassets/SyncListAssetsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listfeeds/AsyncListFeeds.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listfeeds/AsyncListFeeds.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listfeeds/SyncListFeeds.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listfeeds/SyncListFeeds.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listfeeds/SyncListFeedsString.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listfeeds/SyncListFeedsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listsavedqueries/AsyncListSavedQueries.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listsavedqueries/AsyncListSavedQueries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listsavedqueries/AsyncListSavedQueriesPaged.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listsavedqueries/AsyncListSavedQueriesPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listsavedqueries/SyncListSavedQueries.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listsavedqueries/SyncListSavedQueries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listsavedqueries/SyncListSavedQueriesFoldername.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listsavedqueries/SyncListSavedQueriesFoldername.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listsavedqueries/SyncListSavedQueriesOrganizationname.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listsavedqueries/SyncListSavedQueriesOrganizationname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listsavedqueries/SyncListSavedQueriesProjectname.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listsavedqueries/SyncListSavedQueriesProjectname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listsavedqueries/SyncListSavedQueriesString.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/listsavedqueries/SyncListSavedQueriesString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/queryassets/AsyncQueryAssets.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/queryassets/AsyncQueryAssets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/queryassets/SyncQueryAssets.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/queryassets/SyncQueryAssets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/searchalliampolicies/AsyncSearchAllIamPolicies.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/searchalliampolicies/AsyncSearchAllIamPolicies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/searchalliampolicies/AsyncSearchAllIamPoliciesPaged.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/searchalliampolicies/AsyncSearchAllIamPoliciesPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/searchalliampolicies/SyncSearchAllIamPolicies.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/searchalliampolicies/SyncSearchAllIamPolicies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/searchalliampolicies/SyncSearchAllIamPoliciesStringString.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/searchalliampolicies/SyncSearchAllIamPoliciesStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/searchallresources/AsyncSearchAllResources.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/searchallresources/AsyncSearchAllResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/searchallresources/AsyncSearchAllResourcesPaged.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/searchallresources/AsyncSearchAllResourcesPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/searchallresources/SyncSearchAllResources.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/searchallresources/SyncSearchAllResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/searchallresources/SyncSearchAllResourcesStringStringListstring.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/searchallresources/SyncSearchAllResourcesStringStringListstring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/updatefeed/AsyncUpdateFeed.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/updatefeed/AsyncUpdateFeed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/updatefeed/SyncUpdateFeed.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/updatefeed/SyncUpdateFeed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/updatefeed/SyncUpdateFeedFeed.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/updatefeed/SyncUpdateFeedFeed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/updatesavedquery/AsyncUpdateSavedQuery.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/updatesavedquery/AsyncUpdateSavedQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/updatesavedquery/SyncUpdateSavedQuery.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/updatesavedquery/SyncUpdateSavedQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/updatesavedquery/SyncUpdateSavedQuerySavedqueryFieldmask.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservice/updatesavedquery/SyncUpdateSavedQuerySavedqueryFieldmask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservicesettings/batchgetassetshistory/SyncBatchGetAssetsHistory.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservicesettings/batchgetassetshistory/SyncBatchGetAssetsHistory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservicesettings/exportassets/SyncExportAssets.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetservicesettings/exportassets/SyncExportAssets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/stub/assetservicestubsettings/batchgetassetshistory/SyncBatchGetAssetsHistory.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/stub/assetservicestubsettings/batchgetassetshistory/SyncBatchGetAssetsHistory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/stub/assetservicestubsettings/exportassets/SyncExportAssets.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/stub/assetservicestubsettings/exportassets/SyncExportAssets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/AssetServiceClient.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/AssetServiceClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/AssetServiceClientHttpJsonTest.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/AssetServiceClientHttpJsonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/AssetServiceClientTest.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/AssetServiceClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/AssetServiceSettings.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/AssetServiceSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/FeedName.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/FeedName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/FolderName.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/FolderName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/MockAssetService.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/MockAssetService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/MockAssetServiceImpl.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/MockAssetServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/OrganizationName.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/OrganizationName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/ProjectName.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/ProjectName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/SavedQueryName.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/SavedQueryName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/package-info.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/AssetServiceStub.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/AssetServiceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/AssetServiceStubSettings.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/AssetServiceStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/GrpcAssetServiceCallableFactory.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/GrpcAssetServiceCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/GrpcAssetServiceStub.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/GrpcAssetServiceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/HttpJsonAssetServiceCallableFactory.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/HttpJsonAssetServiceCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/HttpJsonAssetServiceStub.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/HttpJsonAssetServiceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/basebigtabledatasettings/mutaterow/SyncMutateRow.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/basebigtabledatasettings/mutaterow/SyncMutateRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/checkandmutaterow/AsyncCheckAndMutateRow.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/checkandmutaterow/AsyncCheckAndMutateRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/checkandmutaterow/SyncCheckAndMutateRow.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/checkandmutaterow/SyncCheckAndMutateRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/checkandmutaterow/SyncCheckAndMutateRowStringBytestringRowfilterListmutationListmutation.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/checkandmutaterow/SyncCheckAndMutateRowStringBytestringRowfilterListmutationListmutation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/checkandmutaterow/SyncCheckAndMutateRowStringBytestringRowfilterListmutationListmutationString.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/checkandmutaterow/SyncCheckAndMutateRowStringBytestringRowfilterListmutationListmutationString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/checkandmutaterow/SyncCheckAndMutateRowTablenameBytestringRowfilterListmutationListmutation.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/checkandmutaterow/SyncCheckAndMutateRowTablenameBytestringRowfilterListmutationListmutation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/checkandmutaterow/SyncCheckAndMutateRowTablenameBytestringRowfilterListmutationListmutationString.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/checkandmutaterow/SyncCheckAndMutateRowTablenameBytestringRowfilterListmutationListmutationString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/create/SyncCreateSetCredentialsProvider.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/create/SyncCreateSetEndpoint.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/mutaterow/AsyncMutateRow.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/mutaterow/AsyncMutateRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/mutaterow/SyncMutateRow.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/mutaterow/SyncMutateRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/mutaterow/SyncMutateRowStringBytestringListmutation.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/mutaterow/SyncMutateRowStringBytestringListmutation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/mutaterow/SyncMutateRowStringBytestringListmutationString.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/mutaterow/SyncMutateRowStringBytestringListmutationString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/mutaterow/SyncMutateRowTablenameBytestringListmutation.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/mutaterow/SyncMutateRowTablenameBytestringListmutation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/mutaterow/SyncMutateRowTablenameBytestringListmutationString.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/mutaterow/SyncMutateRowTablenameBytestringListmutationString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/mutaterows/AsyncMutateRows.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/mutaterows/AsyncMutateRows.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/pingandwarm/AsyncPingAndWarm.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/pingandwarm/AsyncPingAndWarm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/pingandwarm/SyncPingAndWarm.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/pingandwarm/SyncPingAndWarm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/pingandwarm/SyncPingAndWarmInstancename.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/pingandwarm/SyncPingAndWarmInstancename.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/pingandwarm/SyncPingAndWarmInstancenameString.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/pingandwarm/SyncPingAndWarmInstancenameString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/pingandwarm/SyncPingAndWarmString.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/pingandwarm/SyncPingAndWarmString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/pingandwarm/SyncPingAndWarmStringString.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/pingandwarm/SyncPingAndWarmStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/readmodifywriterow/AsyncReadModifyWriteRow.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/readmodifywriterow/AsyncReadModifyWriteRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/readmodifywriterow/SyncReadModifyWriteRow.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/readmodifywriterow/SyncReadModifyWriteRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/readmodifywriterow/SyncReadModifyWriteRowStringBytestringListreadmodifywriterule.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/readmodifywriterow/SyncReadModifyWriteRowStringBytestringListreadmodifywriterule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/readmodifywriterow/SyncReadModifyWriteRowStringBytestringListreadmodifywriteruleString.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/readmodifywriterow/SyncReadModifyWriteRowStringBytestringListreadmodifywriteruleString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/readmodifywriterow/SyncReadModifyWriteRowTablenameBytestringListreadmodifywriterule.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/readmodifywriterow/SyncReadModifyWriteRowTablenameBytestringListreadmodifywriterule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/readmodifywriterow/SyncReadModifyWriteRowTablenameBytestringListreadmodifywriteruleString.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/readmodifywriterow/SyncReadModifyWriteRowTablenameBytestringListreadmodifywriteruleString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/readrows/AsyncReadRows.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/readrows/AsyncReadRows.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/samplerowkeys/AsyncSampleRowKeys.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/bigtable/samplerowkeys/AsyncSampleRowKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/stub/bigtablestubsettings/mutaterow/SyncMutateRow.java
+++ b/test/integration/goldens/bigtable/samples/snippets/generated/main/java/com/google/cloud/bigtable/data/v2/stub/bigtablestubsettings/mutaterow/SyncMutateRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/src/com/google/bigtable/v2/InstanceName.java
+++ b/test/integration/goldens/bigtable/src/com/google/bigtable/v2/InstanceName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/src/com/google/bigtable/v2/TableName.java
+++ b/test/integration/goldens/bigtable/src/com/google/bigtable/v2/TableName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/BaseBigtableDataClient.java
+++ b/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/BaseBigtableDataClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/BaseBigtableDataClientTest.java
+++ b/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/BaseBigtableDataClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/BaseBigtableDataSettings.java
+++ b/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/BaseBigtableDataSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/MockBigtable.java
+++ b/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/MockBigtable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/MockBigtableImpl.java
+++ b/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/MockBigtableImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/package-info.java
+++ b/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/stub/BigtableStub.java
+++ b/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/stub/BigtableStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/stub/BigtableStubSettings.java
+++ b/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/stub/BigtableStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/stub/GrpcBigtableCallableFactory.java
+++ b/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/stub/GrpcBigtableCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/stub/GrpcBigtableStub.java
+++ b/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/stub/GrpcBigtableStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/aggregatedlist/AsyncAggregatedList.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/aggregatedlist/AsyncAggregatedList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/aggregatedlist/AsyncAggregatedListPaged.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/aggregatedlist/AsyncAggregatedListPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/aggregatedlist/SyncAggregatedList.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/aggregatedlist/SyncAggregatedList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/aggregatedlist/SyncAggregatedListString.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/aggregatedlist/SyncAggregatedListString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/create/SyncCreateSetCredentialsProvider.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/create/SyncCreateSetEndpoint.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/delete/AsyncDelete.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/delete/AsyncDelete.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/delete/AsyncDeleteLRO.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/delete/AsyncDeleteLRO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/delete/SyncDelete.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/delete/SyncDelete.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/delete/SyncDeleteStringStringString.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/delete/SyncDeleteStringStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/insert/AsyncInsert.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/insert/AsyncInsert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/insert/AsyncInsertLRO.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/insert/AsyncInsertLRO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/insert/SyncInsert.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/insert/SyncInsert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/insert/SyncInsertStringStringAddress.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/insert/SyncInsertStringStringAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/list/AsyncList.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/list/AsyncList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/list/AsyncListPaged.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/list/AsyncListPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/list/SyncList.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/list/SyncList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/list/SyncListStringStringString.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addresses/list/SyncListStringStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addressessettings/aggregatedlist/SyncAggregatedList.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addressessettings/aggregatedlist/SyncAggregatedList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addressessettings/delete/SyncDelete.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addressessettings/delete/SyncDelete.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/regionoperations/create/SyncCreateSetCredentialsProvider.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/regionoperations/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/regionoperations/create/SyncCreateSetEndpoint.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/regionoperations/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/regionoperations/get/AsyncGet.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/regionoperations/get/AsyncGet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/regionoperations/get/SyncGet.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/regionoperations/get/SyncGet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/regionoperations/get/SyncGetStringStringString.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/regionoperations/get/SyncGetStringStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/regionoperations/wait/AsyncWait.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/regionoperations/wait/AsyncWait.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/regionoperations/wait/SyncWait.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/regionoperations/wait/SyncWait.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/regionoperations/wait/SyncWaitStringStringString.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/regionoperations/wait/SyncWaitStringStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/regionoperationssettings/get/SyncGet.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/regionoperationssettings/get/SyncGet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/stub/addressesstubsettings/aggregatedlist/SyncAggregatedList.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/stub/addressesstubsettings/aggregatedlist/SyncAggregatedList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/stub/addressesstubsettings/delete/SyncDelete.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/stub/addressesstubsettings/delete/SyncDelete.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/stub/regionoperationsstubsettings/get/SyncGet.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/stub/regionoperationsstubsettings/get/SyncGet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/AddressesClient.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/AddressesClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/AddressesClientTest.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/AddressesClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/AddressesSettings.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/AddressesSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/RegionOperationsClient.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/RegionOperationsClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/RegionOperationsClientTest.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/RegionOperationsClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/RegionOperationsSettings.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/RegionOperationsSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/package-info.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/AddressesStub.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/AddressesStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/AddressesStubSettings.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/AddressesStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/HttpJsonAddressesCallableFactory.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/HttpJsonAddressesCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/HttpJsonAddressesStub.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/HttpJsonAddressesStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/HttpJsonRegionOperationsCallableFactory.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/HttpJsonRegionOperationsCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/HttpJsonRegionOperationsStub.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/HttpJsonRegionOperationsStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/RegionOperationsStub.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/RegionOperationsStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/RegionOperationsStubSettings.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/RegionOperationsStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/create/SyncCreateSetCredentialsProvider.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/create/SyncCreateSetEndpoint.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/create/SyncCreateUseHttpJsonTransport.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/create/SyncCreateUseHttpJsonTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/generateaccesstoken/AsyncGenerateAccessToken.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/generateaccesstoken/AsyncGenerateAccessToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/generateaccesstoken/SyncGenerateAccessToken.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/generateaccesstoken/SyncGenerateAccessToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/generateaccesstoken/SyncGenerateAccessTokenServiceaccountnameListstringListstringDuration.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/generateaccesstoken/SyncGenerateAccessTokenServiceaccountnameListstringListstringDuration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/generateaccesstoken/SyncGenerateAccessTokenStringListstringListstringDuration.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/generateaccesstoken/SyncGenerateAccessTokenStringListstringListstringDuration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/generateidtoken/AsyncGenerateIdToken.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/generateidtoken/AsyncGenerateIdToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/generateidtoken/SyncGenerateIdToken.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/generateidtoken/SyncGenerateIdToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/generateidtoken/SyncGenerateIdTokenServiceaccountnameListstringStringBoolean.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/generateidtoken/SyncGenerateIdTokenServiceaccountnameListstringStringBoolean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/generateidtoken/SyncGenerateIdTokenStringListstringStringBoolean.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/generateidtoken/SyncGenerateIdTokenStringListstringStringBoolean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/signblob/AsyncSignBlob.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/signblob/AsyncSignBlob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/signblob/SyncSignBlob.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/signblob/SyncSignBlob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/signblob/SyncSignBlobServiceaccountnameListstringBytestring.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/signblob/SyncSignBlobServiceaccountnameListstringBytestring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/signblob/SyncSignBlobStringListstringBytestring.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/signblob/SyncSignBlobStringListstringBytestring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/signjwt/AsyncSignJwt.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/signjwt/AsyncSignJwt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/signjwt/SyncSignJwt.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/signjwt/SyncSignJwt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/signjwt/SyncSignJwtServiceaccountnameListstringString.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/signjwt/SyncSignJwtServiceaccountnameListstringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/signjwt/SyncSignJwtStringListstringString.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentials/signjwt/SyncSignJwtStringListstringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentialssettings/generateaccesstoken/SyncGenerateAccessToken.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/iamcredentialssettings/generateaccesstoken/SyncGenerateAccessToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/stub/iamcredentialsstubsettings/generateaccesstoken/SyncGenerateAccessToken.java
+++ b/test/integration/goldens/credentials/samples/snippets/generated/main/java/com/google/cloud/iam/credentials/v1/stub/iamcredentialsstubsettings/generateaccesstoken/SyncGenerateAccessToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/IAMCredentialsClientHttpJsonTest.java
+++ b/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/IAMCredentialsClientHttpJsonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/IAMCredentialsClientTest.java
+++ b/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/IAMCredentialsClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/IamCredentialsClient.java
+++ b/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/IamCredentialsClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/IamCredentialsSettings.java
+++ b/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/IamCredentialsSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/MockIAMCredentials.java
+++ b/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/MockIAMCredentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/MockIAMCredentialsImpl.java
+++ b/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/MockIAMCredentialsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/ServiceAccountName.java
+++ b/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/ServiceAccountName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/package-info.java
+++ b/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/GrpcIamCredentialsCallableFactory.java
+++ b/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/GrpcIamCredentialsCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/GrpcIamCredentialsStub.java
+++ b/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/GrpcIamCredentialsStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/HttpJsonIamCredentialsCallableFactory.java
+++ b/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/HttpJsonIamCredentialsCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/HttpJsonIamCredentialsStub.java
+++ b/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/HttpJsonIamCredentialsStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/IamCredentialsStub.java
+++ b/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/IamCredentialsStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/IamCredentialsStubSettings.java
+++ b/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/IamCredentialsStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/iampolicy/create/SyncCreateSetCredentialsProvider.java
+++ b/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/iampolicy/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/iampolicy/create/SyncCreateSetEndpoint.java
+++ b/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/iampolicy/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/iampolicy/getiampolicy/AsyncGetIamPolicy.java
+++ b/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/iampolicy/getiampolicy/AsyncGetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/iampolicy/getiampolicy/SyncGetIamPolicy.java
+++ b/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/iampolicy/getiampolicy/SyncGetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/iampolicy/setiampolicy/AsyncSetIamPolicy.java
+++ b/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/iampolicy/setiampolicy/AsyncSetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/iampolicy/setiampolicy/SyncSetIamPolicy.java
+++ b/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/iampolicy/setiampolicy/SyncSetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/iampolicy/testiampermissions/AsyncTestIamPermissions.java
+++ b/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/iampolicy/testiampermissions/AsyncTestIamPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/iampolicy/testiampermissions/SyncTestIamPermissions.java
+++ b/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/iampolicy/testiampermissions/SyncTestIamPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/iampolicysettings/setiampolicy/SyncSetIamPolicy.java
+++ b/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/iampolicysettings/setiampolicy/SyncSetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/stub/iampolicystubsettings/setiampolicy/SyncSetIamPolicy.java
+++ b/test/integration/goldens/iam/samples/snippets/generated/main/java/com/google/iam/v1/stub/iampolicystubsettings/setiampolicy/SyncSetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/src/com/google/iam/v1/IAMPolicyClient.java
+++ b/test/integration/goldens/iam/src/com/google/iam/v1/IAMPolicyClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/src/com/google/iam/v1/IAMPolicyClientTest.java
+++ b/test/integration/goldens/iam/src/com/google/iam/v1/IAMPolicyClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/src/com/google/iam/v1/IAMPolicySettings.java
+++ b/test/integration/goldens/iam/src/com/google/iam/v1/IAMPolicySettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/src/com/google/iam/v1/MockIAMPolicy.java
+++ b/test/integration/goldens/iam/src/com/google/iam/v1/MockIAMPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/src/com/google/iam/v1/MockIAMPolicyImpl.java
+++ b/test/integration/goldens/iam/src/com/google/iam/v1/MockIAMPolicyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/src/com/google/iam/v1/package-info.java
+++ b/test/integration/goldens/iam/src/com/google/iam/v1/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/src/com/google/iam/v1/stub/GrpcIAMPolicyCallableFactory.java
+++ b/test/integration/goldens/iam/src/com/google/iam/v1/stub/GrpcIAMPolicyCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/src/com/google/iam/v1/stub/GrpcIAMPolicyStub.java
+++ b/test/integration/goldens/iam/src/com/google/iam/v1/stub/GrpcIAMPolicyStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/src/com/google/iam/v1/stub/IAMPolicyStub.java
+++ b/test/integration/goldens/iam/src/com/google/iam/v1/stub/IAMPolicyStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/iam/src/com/google/iam/v1/stub/IAMPolicyStubSettings.java
+++ b/test/integration/goldens/iam/src/com/google/iam/v1/stub/IAMPolicyStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/asymmetricdecrypt/AsyncAsymmetricDecrypt.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/asymmetricdecrypt/AsyncAsymmetricDecrypt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/asymmetricdecrypt/SyncAsymmetricDecrypt.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/asymmetricdecrypt/SyncAsymmetricDecrypt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/asymmetricdecrypt/SyncAsymmetricDecryptCryptokeyversionnameBytestring.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/asymmetricdecrypt/SyncAsymmetricDecryptCryptokeyversionnameBytestring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/asymmetricdecrypt/SyncAsymmetricDecryptStringBytestring.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/asymmetricdecrypt/SyncAsymmetricDecryptStringBytestring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/asymmetricsign/AsyncAsymmetricSign.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/asymmetricsign/AsyncAsymmetricSign.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/asymmetricsign/SyncAsymmetricSign.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/asymmetricsign/SyncAsymmetricSign.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/asymmetricsign/SyncAsymmetricSignCryptokeyversionnameDigest.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/asymmetricsign/SyncAsymmetricSignCryptokeyversionnameDigest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/asymmetricsign/SyncAsymmetricSignStringDigest.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/asymmetricsign/SyncAsymmetricSignStringDigest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/create/SyncCreateSetCredentialsProvider.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/create/SyncCreateSetEndpoint.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createcryptokey/AsyncCreateCryptoKey.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createcryptokey/AsyncCreateCryptoKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createcryptokey/SyncCreateCryptoKey.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createcryptokey/SyncCreateCryptoKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createcryptokey/SyncCreateCryptoKeyKeyringnameStringCryptokey.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createcryptokey/SyncCreateCryptoKeyKeyringnameStringCryptokey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createcryptokey/SyncCreateCryptoKeyStringStringCryptokey.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createcryptokey/SyncCreateCryptoKeyStringStringCryptokey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createcryptokeyversion/AsyncCreateCryptoKeyVersion.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createcryptokeyversion/AsyncCreateCryptoKeyVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createcryptokeyversion/SyncCreateCryptoKeyVersion.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createcryptokeyversion/SyncCreateCryptoKeyVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createcryptokeyversion/SyncCreateCryptoKeyVersionCryptokeynameCryptokeyversion.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createcryptokeyversion/SyncCreateCryptoKeyVersionCryptokeynameCryptokeyversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createcryptokeyversion/SyncCreateCryptoKeyVersionStringCryptokeyversion.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createcryptokeyversion/SyncCreateCryptoKeyVersionStringCryptokeyversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createimportjob/AsyncCreateImportJob.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createimportjob/AsyncCreateImportJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createimportjob/SyncCreateImportJob.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createimportjob/SyncCreateImportJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createimportjob/SyncCreateImportJobKeyringnameStringImportjob.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createimportjob/SyncCreateImportJobKeyringnameStringImportjob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createimportjob/SyncCreateImportJobStringStringImportjob.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createimportjob/SyncCreateImportJobStringStringImportjob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createkeyring/AsyncCreateKeyRing.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createkeyring/AsyncCreateKeyRing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createkeyring/SyncCreateKeyRing.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createkeyring/SyncCreateKeyRing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createkeyring/SyncCreateKeyRingLocationnameStringKeyring.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createkeyring/SyncCreateKeyRingLocationnameStringKeyring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createkeyring/SyncCreateKeyRingStringStringKeyring.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/createkeyring/SyncCreateKeyRingStringStringKeyring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/decrypt/AsyncDecrypt.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/decrypt/AsyncDecrypt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/decrypt/SyncDecrypt.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/decrypt/SyncDecrypt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/decrypt/SyncDecryptCryptokeynameBytestring.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/decrypt/SyncDecryptCryptokeynameBytestring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/decrypt/SyncDecryptStringBytestring.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/decrypt/SyncDecryptStringBytestring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/destroycryptokeyversion/AsyncDestroyCryptoKeyVersion.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/destroycryptokeyversion/AsyncDestroyCryptoKeyVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/destroycryptokeyversion/SyncDestroyCryptoKeyVersion.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/destroycryptokeyversion/SyncDestroyCryptoKeyVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/destroycryptokeyversion/SyncDestroyCryptoKeyVersionCryptokeyversionname.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/destroycryptokeyversion/SyncDestroyCryptoKeyVersionCryptokeyversionname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/destroycryptokeyversion/SyncDestroyCryptoKeyVersionString.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/destroycryptokeyversion/SyncDestroyCryptoKeyVersionString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/encrypt/AsyncEncrypt.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/encrypt/AsyncEncrypt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/encrypt/SyncEncrypt.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/encrypt/SyncEncrypt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/encrypt/SyncEncryptResourcenameBytestring.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/encrypt/SyncEncryptResourcenameBytestring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/encrypt/SyncEncryptStringBytestring.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/encrypt/SyncEncryptStringBytestring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getcryptokey/AsyncGetCryptoKey.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getcryptokey/AsyncGetCryptoKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getcryptokey/SyncGetCryptoKey.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getcryptokey/SyncGetCryptoKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getcryptokey/SyncGetCryptoKeyCryptokeyname.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getcryptokey/SyncGetCryptoKeyCryptokeyname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getcryptokey/SyncGetCryptoKeyString.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getcryptokey/SyncGetCryptoKeyString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getcryptokeyversion/AsyncGetCryptoKeyVersion.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getcryptokeyversion/AsyncGetCryptoKeyVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getcryptokeyversion/SyncGetCryptoKeyVersion.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getcryptokeyversion/SyncGetCryptoKeyVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getcryptokeyversion/SyncGetCryptoKeyVersionCryptokeyversionname.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getcryptokeyversion/SyncGetCryptoKeyVersionCryptokeyversionname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getcryptokeyversion/SyncGetCryptoKeyVersionString.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getcryptokeyversion/SyncGetCryptoKeyVersionString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getiampolicy/AsyncGetIamPolicy.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getiampolicy/AsyncGetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getiampolicy/SyncGetIamPolicy.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getiampolicy/SyncGetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getimportjob/AsyncGetImportJob.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getimportjob/AsyncGetImportJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getimportjob/SyncGetImportJob.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getimportjob/SyncGetImportJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getimportjob/SyncGetImportJobImportjobname.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getimportjob/SyncGetImportJobImportjobname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getimportjob/SyncGetImportJobString.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getimportjob/SyncGetImportJobString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getkeyring/AsyncGetKeyRing.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getkeyring/AsyncGetKeyRing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getkeyring/SyncGetKeyRing.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getkeyring/SyncGetKeyRing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getkeyring/SyncGetKeyRingKeyringname.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getkeyring/SyncGetKeyRingKeyringname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getkeyring/SyncGetKeyRingString.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getkeyring/SyncGetKeyRingString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getlocation/AsyncGetLocation.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getlocation/AsyncGetLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getlocation/SyncGetLocation.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getlocation/SyncGetLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getpublickey/AsyncGetPublicKey.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getpublickey/AsyncGetPublicKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getpublickey/SyncGetPublicKey.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getpublickey/SyncGetPublicKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getpublickey/SyncGetPublicKeyCryptokeyversionname.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getpublickey/SyncGetPublicKeyCryptokeyversionname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getpublickey/SyncGetPublicKeyString.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/getpublickey/SyncGetPublicKeyString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/importcryptokeyversion/AsyncImportCryptoKeyVersion.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/importcryptokeyversion/AsyncImportCryptoKeyVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/importcryptokeyversion/SyncImportCryptoKeyVersion.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/importcryptokeyversion/SyncImportCryptoKeyVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeys/AsyncListCryptoKeys.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeys/AsyncListCryptoKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeys/AsyncListCryptoKeysPaged.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeys/AsyncListCryptoKeysPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeys/SyncListCryptoKeys.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeys/SyncListCryptoKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeys/SyncListCryptoKeysKeyringname.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeys/SyncListCryptoKeysKeyringname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeys/SyncListCryptoKeysString.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeys/SyncListCryptoKeysString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeyversions/AsyncListCryptoKeyVersions.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeyversions/AsyncListCryptoKeyVersions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeyversions/AsyncListCryptoKeyVersionsPaged.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeyversions/AsyncListCryptoKeyVersionsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeyversions/SyncListCryptoKeyVersions.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeyversions/SyncListCryptoKeyVersions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeyversions/SyncListCryptoKeyVersionsCryptokeyname.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeyversions/SyncListCryptoKeyVersionsCryptokeyname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeyversions/SyncListCryptoKeyVersionsString.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listcryptokeyversions/SyncListCryptoKeyVersionsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listimportjobs/AsyncListImportJobs.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listimportjobs/AsyncListImportJobs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listimportjobs/AsyncListImportJobsPaged.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listimportjobs/AsyncListImportJobsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listimportjobs/SyncListImportJobs.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listimportjobs/SyncListImportJobs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listimportjobs/SyncListImportJobsKeyringname.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listimportjobs/SyncListImportJobsKeyringname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listimportjobs/SyncListImportJobsString.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listimportjobs/SyncListImportJobsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listkeyrings/AsyncListKeyRings.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listkeyrings/AsyncListKeyRings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listkeyrings/AsyncListKeyRingsPaged.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listkeyrings/AsyncListKeyRingsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listkeyrings/SyncListKeyRings.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listkeyrings/SyncListKeyRings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listkeyrings/SyncListKeyRingsLocationname.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listkeyrings/SyncListKeyRingsLocationname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listkeyrings/SyncListKeyRingsString.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listkeyrings/SyncListKeyRingsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listlocations/AsyncListLocations.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listlocations/AsyncListLocations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listlocations/AsyncListLocationsPaged.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listlocations/AsyncListLocationsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listlocations/SyncListLocations.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/listlocations/SyncListLocations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/restorecryptokeyversion/AsyncRestoreCryptoKeyVersion.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/restorecryptokeyversion/AsyncRestoreCryptoKeyVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/restorecryptokeyversion/SyncRestoreCryptoKeyVersion.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/restorecryptokeyversion/SyncRestoreCryptoKeyVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/restorecryptokeyversion/SyncRestoreCryptoKeyVersionCryptokeyversionname.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/restorecryptokeyversion/SyncRestoreCryptoKeyVersionCryptokeyversionname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/restorecryptokeyversion/SyncRestoreCryptoKeyVersionString.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/restorecryptokeyversion/SyncRestoreCryptoKeyVersionString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/testiampermissions/AsyncTestIamPermissions.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/testiampermissions/AsyncTestIamPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/testiampermissions/SyncTestIamPermissions.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/testiampermissions/SyncTestIamPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokey/AsyncUpdateCryptoKey.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokey/AsyncUpdateCryptoKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokey/SyncUpdateCryptoKey.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokey/SyncUpdateCryptoKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokey/SyncUpdateCryptoKeyCryptokeyFieldmask.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokey/SyncUpdateCryptoKeyCryptokeyFieldmask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokeyprimaryversion/AsyncUpdateCryptoKeyPrimaryVersion.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokeyprimaryversion/AsyncUpdateCryptoKeyPrimaryVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokeyprimaryversion/SyncUpdateCryptoKeyPrimaryVersion.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokeyprimaryversion/SyncUpdateCryptoKeyPrimaryVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokeyprimaryversion/SyncUpdateCryptoKeyPrimaryVersionCryptokeynameString.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokeyprimaryversion/SyncUpdateCryptoKeyPrimaryVersionCryptokeynameString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokeyprimaryversion/SyncUpdateCryptoKeyPrimaryVersionStringString.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokeyprimaryversion/SyncUpdateCryptoKeyPrimaryVersionStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokeyversion/AsyncUpdateCryptoKeyVersion.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokeyversion/AsyncUpdateCryptoKeyVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokeyversion/SyncUpdateCryptoKeyVersion.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokeyversion/SyncUpdateCryptoKeyVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokeyversion/SyncUpdateCryptoKeyVersionCryptokeyversionFieldmask.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservice/updatecryptokeyversion/SyncUpdateCryptoKeyVersionCryptokeyversionFieldmask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservicesettings/getkeyring/SyncGetKeyRing.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementservicesettings/getkeyring/SyncGetKeyRing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/stub/keymanagementservicestubsettings/getkeyring/SyncGetKeyRing.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/stub/keymanagementservicestubsettings/getkeyring/SyncGetKeyRing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/CryptoKeyName.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/CryptoKeyName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/CryptoKeyVersionName.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/CryptoKeyVersionName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/ImportJobName.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/ImportJobName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/KeyManagementServiceClient.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/KeyManagementServiceClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/KeyManagementServiceClientTest.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/KeyManagementServiceClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/KeyManagementServiceSettings.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/KeyManagementServiceSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/KeyRingName.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/KeyRingName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/LocationName.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/LocationName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/MockIAMPolicy.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/MockIAMPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/MockIAMPolicyImpl.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/MockIAMPolicyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/MockKeyManagementService.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/MockKeyManagementService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/MockKeyManagementServiceImpl.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/MockKeyManagementServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/MockLocations.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/MockLocations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/MockLocationsImpl.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/MockLocationsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/package-info.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/stub/GrpcKeyManagementServiceCallableFactory.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/stub/GrpcKeyManagementServiceCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/stub/GrpcKeyManagementServiceStub.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/stub/GrpcKeyManagementServiceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/stub/KeyManagementServiceStub.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/stub/KeyManagementServiceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/stub/KeyManagementServiceStubSettings.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/stub/KeyManagementServiceStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/create/SyncCreateSetCredentialsProvider.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/create/SyncCreateSetEndpoint.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/create/SyncCreateUseHttpJsonTransport.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/create/SyncCreateUseHttpJsonTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/createbook/AsyncCreateBook.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/createbook/AsyncCreateBook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/createbook/SyncCreateBook.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/createbook/SyncCreateBook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/createbook/SyncCreateBookShelfnameBook.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/createbook/SyncCreateBookShelfnameBook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/createbook/SyncCreateBookStringBook.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/createbook/SyncCreateBookStringBook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/createshelf/AsyncCreateShelf.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/createshelf/AsyncCreateShelf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/createshelf/SyncCreateShelf.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/createshelf/SyncCreateShelf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/createshelf/SyncCreateShelfShelf.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/createshelf/SyncCreateShelfShelf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/deletebook/AsyncDeleteBook.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/deletebook/AsyncDeleteBook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/deletebook/SyncDeleteBook.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/deletebook/SyncDeleteBook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/deletebook/SyncDeleteBookBookname.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/deletebook/SyncDeleteBookBookname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/deletebook/SyncDeleteBookString.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/deletebook/SyncDeleteBookString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/deleteshelf/AsyncDeleteShelf.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/deleteshelf/AsyncDeleteShelf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/deleteshelf/SyncDeleteShelf.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/deleteshelf/SyncDeleteShelf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/deleteshelf/SyncDeleteShelfShelfname.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/deleteshelf/SyncDeleteShelfShelfname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/deleteshelf/SyncDeleteShelfString.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/deleteshelf/SyncDeleteShelfString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/getbook/AsyncGetBook.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/getbook/AsyncGetBook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/getbook/SyncGetBook.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/getbook/SyncGetBook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/getbook/SyncGetBookBookname.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/getbook/SyncGetBookBookname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/getbook/SyncGetBookString.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/getbook/SyncGetBookString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/getshelf/AsyncGetShelf.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/getshelf/AsyncGetShelf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/getshelf/SyncGetShelf.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/getshelf/SyncGetShelf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/getshelf/SyncGetShelfShelfname.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/getshelf/SyncGetShelfShelfname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/getshelf/SyncGetShelfString.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/getshelf/SyncGetShelfString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/listbooks/AsyncListBooks.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/listbooks/AsyncListBooks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/listbooks/AsyncListBooksPaged.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/listbooks/AsyncListBooksPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/listbooks/SyncListBooks.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/listbooks/SyncListBooks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/listbooks/SyncListBooksShelfname.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/listbooks/SyncListBooksShelfname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/listbooks/SyncListBooksString.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/listbooks/SyncListBooksString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/listshelves/AsyncListShelves.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/listshelves/AsyncListShelves.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/listshelves/AsyncListShelvesPaged.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/listshelves/AsyncListShelvesPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/listshelves/SyncListShelves.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/listshelves/SyncListShelves.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/mergeshelves/AsyncMergeShelves.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/mergeshelves/AsyncMergeShelves.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/mergeshelves/SyncMergeShelves.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/mergeshelves/SyncMergeShelves.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/mergeshelves/SyncMergeShelvesShelfnameShelfname.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/mergeshelves/SyncMergeShelvesShelfnameShelfname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/mergeshelves/SyncMergeShelvesShelfnameString.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/mergeshelves/SyncMergeShelvesShelfnameString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/mergeshelves/SyncMergeShelvesStringShelfname.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/mergeshelves/SyncMergeShelvesStringShelfname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/mergeshelves/SyncMergeShelvesStringString.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/mergeshelves/SyncMergeShelvesStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/movebook/AsyncMoveBook.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/movebook/AsyncMoveBook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/movebook/SyncMoveBook.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/movebook/SyncMoveBook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/movebook/SyncMoveBookBooknameShelfname.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/movebook/SyncMoveBookBooknameShelfname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/movebook/SyncMoveBookBooknameString.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/movebook/SyncMoveBookBooknameString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/movebook/SyncMoveBookStringShelfname.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/movebook/SyncMoveBookStringShelfname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/movebook/SyncMoveBookStringString.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/movebook/SyncMoveBookStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/updatebook/AsyncUpdateBook.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/updatebook/AsyncUpdateBook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/updatebook/SyncUpdateBook.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/updatebook/SyncUpdateBook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/updatebook/SyncUpdateBookBookFieldmask.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservice/updatebook/SyncUpdateBookBookFieldmask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservicesettings/createshelf/SyncCreateShelf.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryservicesettings/createshelf/SyncCreateShelf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/stub/libraryservicestubsettings/createshelf/SyncCreateShelf.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/stub/libraryservicestubsettings/createshelf/SyncCreateShelf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/src/com/google/cloud/example/library/v1/LibraryServiceClient.java
+++ b/test/integration/goldens/library/src/com/google/cloud/example/library/v1/LibraryServiceClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/src/com/google/cloud/example/library/v1/LibraryServiceClientHttpJsonTest.java
+++ b/test/integration/goldens/library/src/com/google/cloud/example/library/v1/LibraryServiceClientHttpJsonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/src/com/google/cloud/example/library/v1/LibraryServiceClientTest.java
+++ b/test/integration/goldens/library/src/com/google/cloud/example/library/v1/LibraryServiceClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/src/com/google/cloud/example/library/v1/LibraryServiceSettings.java
+++ b/test/integration/goldens/library/src/com/google/cloud/example/library/v1/LibraryServiceSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/src/com/google/cloud/example/library/v1/MockLibraryService.java
+++ b/test/integration/goldens/library/src/com/google/cloud/example/library/v1/MockLibraryService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/src/com/google/cloud/example/library/v1/MockLibraryServiceImpl.java
+++ b/test/integration/goldens/library/src/com/google/cloud/example/library/v1/MockLibraryServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/src/com/google/cloud/example/library/v1/package-info.java
+++ b/test/integration/goldens/library/src/com/google/cloud/example/library/v1/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/GrpcLibraryServiceCallableFactory.java
+++ b/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/GrpcLibraryServiceCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/GrpcLibraryServiceStub.java
+++ b/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/GrpcLibraryServiceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/HttpJsonLibraryServiceCallableFactory.java
+++ b/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/HttpJsonLibraryServiceCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/HttpJsonLibraryServiceStub.java
+++ b/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/HttpJsonLibraryServiceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/LibraryServiceStub.java
+++ b/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/LibraryServiceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/LibraryServiceStubSettings.java
+++ b/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/LibraryServiceStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/src/com/google/example/library/v1/BookName.java
+++ b/test/integration/goldens/library/src/com/google/example/library/v1/BookName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/library/src/com/google/example/library/v1/ShelfName.java
+++ b/test/integration/goldens/library/src/com/google/example/library/v1/ShelfName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/copylogentries/AsyncCopyLogEntries.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/copylogentries/AsyncCopyLogEntries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/copylogentries/AsyncCopyLogEntriesLRO.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/copylogentries/AsyncCopyLogEntriesLRO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/copylogentries/SyncCopyLogEntries.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/copylogentries/SyncCopyLogEntries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/create/SyncCreateSetCredentialsProvider.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/create/SyncCreateSetEndpoint.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createbucket/AsyncCreateBucket.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createbucket/AsyncCreateBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createbucket/SyncCreateBucket.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createbucket/SyncCreateBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createexclusion/AsyncCreateExclusion.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createexclusion/AsyncCreateExclusion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createexclusion/SyncCreateExclusion.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createexclusion/SyncCreateExclusion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createexclusion/SyncCreateExclusionBillingaccountnameLogexclusion.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createexclusion/SyncCreateExclusionBillingaccountnameLogexclusion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createexclusion/SyncCreateExclusionFoldernameLogexclusion.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createexclusion/SyncCreateExclusionFoldernameLogexclusion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createexclusion/SyncCreateExclusionOrganizationnameLogexclusion.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createexclusion/SyncCreateExclusionOrganizationnameLogexclusion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createexclusion/SyncCreateExclusionProjectnameLogexclusion.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createexclusion/SyncCreateExclusionProjectnameLogexclusion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createexclusion/SyncCreateExclusionStringLogexclusion.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createexclusion/SyncCreateExclusionStringLogexclusion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createsink/AsyncCreateSink.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createsink/AsyncCreateSink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createsink/SyncCreateSink.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createsink/SyncCreateSink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createsink/SyncCreateSinkBillingaccountnameLogsink.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createsink/SyncCreateSinkBillingaccountnameLogsink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createsink/SyncCreateSinkFoldernameLogsink.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createsink/SyncCreateSinkFoldernameLogsink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createsink/SyncCreateSinkOrganizationnameLogsink.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createsink/SyncCreateSinkOrganizationnameLogsink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createsink/SyncCreateSinkProjectnameLogsink.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createsink/SyncCreateSinkProjectnameLogsink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createsink/SyncCreateSinkStringLogsink.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createsink/SyncCreateSinkStringLogsink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createview/AsyncCreateView.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createview/AsyncCreateView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createview/SyncCreateView.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/createview/SyncCreateView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deletebucket/AsyncDeleteBucket.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deletebucket/AsyncDeleteBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deletebucket/SyncDeleteBucket.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deletebucket/SyncDeleteBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deleteexclusion/AsyncDeleteExclusion.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deleteexclusion/AsyncDeleteExclusion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deleteexclusion/SyncDeleteExclusion.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deleteexclusion/SyncDeleteExclusion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deleteexclusion/SyncDeleteExclusionLogexclusionname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deleteexclusion/SyncDeleteExclusionLogexclusionname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deleteexclusion/SyncDeleteExclusionString.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deleteexclusion/SyncDeleteExclusionString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deletesink/AsyncDeleteSink.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deletesink/AsyncDeleteSink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deletesink/SyncDeleteSink.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deletesink/SyncDeleteSink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deletesink/SyncDeleteSinkLogsinkname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deletesink/SyncDeleteSinkLogsinkname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deletesink/SyncDeleteSinkString.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deletesink/SyncDeleteSinkString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deleteview/AsyncDeleteView.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deleteview/AsyncDeleteView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deleteview/SyncDeleteView.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/deleteview/SyncDeleteView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getbucket/AsyncGetBucket.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getbucket/AsyncGetBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getbucket/SyncGetBucket.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getbucket/SyncGetBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getcmeksettings/AsyncGetCmekSettings.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getcmeksettings/AsyncGetCmekSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getcmeksettings/SyncGetCmekSettings.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getcmeksettings/SyncGetCmekSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getexclusion/AsyncGetExclusion.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getexclusion/AsyncGetExclusion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getexclusion/SyncGetExclusion.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getexclusion/SyncGetExclusion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getexclusion/SyncGetExclusionLogexclusionname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getexclusion/SyncGetExclusionLogexclusionname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getexclusion/SyncGetExclusionString.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getexclusion/SyncGetExclusionString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getsettings/AsyncGetSettings.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getsettings/AsyncGetSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getsettings/SyncGetSettings.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getsettings/SyncGetSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getsettings/SyncGetSettingsSettingsname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getsettings/SyncGetSettingsSettingsname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getsettings/SyncGetSettingsString.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getsettings/SyncGetSettingsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getsink/AsyncGetSink.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getsink/AsyncGetSink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getsink/SyncGetSink.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getsink/SyncGetSink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getsink/SyncGetSinkLogsinkname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getsink/SyncGetSinkLogsinkname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getsink/SyncGetSinkString.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getsink/SyncGetSinkString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getview/AsyncGetView.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getview/AsyncGetView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getview/SyncGetView.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/getview/SyncGetView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listbuckets/AsyncListBuckets.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listbuckets/AsyncListBuckets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listbuckets/AsyncListBucketsPaged.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listbuckets/AsyncListBucketsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listbuckets/SyncListBuckets.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listbuckets/SyncListBuckets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listbuckets/SyncListBucketsBillingaccountlocationname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listbuckets/SyncListBucketsBillingaccountlocationname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listbuckets/SyncListBucketsFolderlocationname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listbuckets/SyncListBucketsFolderlocationname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listbuckets/SyncListBucketsLocationname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listbuckets/SyncListBucketsLocationname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listbuckets/SyncListBucketsOrganizationlocationname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listbuckets/SyncListBucketsOrganizationlocationname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listbuckets/SyncListBucketsString.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listbuckets/SyncListBucketsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listexclusions/AsyncListExclusions.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listexclusions/AsyncListExclusions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listexclusions/AsyncListExclusionsPaged.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listexclusions/AsyncListExclusionsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listexclusions/SyncListExclusions.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listexclusions/SyncListExclusions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listexclusions/SyncListExclusionsBillingaccountname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listexclusions/SyncListExclusionsBillingaccountname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listexclusions/SyncListExclusionsFoldername.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listexclusions/SyncListExclusionsFoldername.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listexclusions/SyncListExclusionsOrganizationname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listexclusions/SyncListExclusionsOrganizationname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listexclusions/SyncListExclusionsProjectname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listexclusions/SyncListExclusionsProjectname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listexclusions/SyncListExclusionsString.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listexclusions/SyncListExclusionsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listsinks/AsyncListSinks.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listsinks/AsyncListSinks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listsinks/AsyncListSinksPaged.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listsinks/AsyncListSinksPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listsinks/SyncListSinks.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listsinks/SyncListSinks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listsinks/SyncListSinksBillingaccountname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listsinks/SyncListSinksBillingaccountname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listsinks/SyncListSinksFoldername.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listsinks/SyncListSinksFoldername.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listsinks/SyncListSinksOrganizationname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listsinks/SyncListSinksOrganizationname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listsinks/SyncListSinksProjectname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listsinks/SyncListSinksProjectname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listsinks/SyncListSinksString.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listsinks/SyncListSinksString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listviews/AsyncListViews.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listviews/AsyncListViews.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listviews/AsyncListViewsPaged.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listviews/AsyncListViewsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listviews/SyncListViews.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listviews/SyncListViews.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listviews/SyncListViewsString.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/listviews/SyncListViewsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/undeletebucket/AsyncUndeleteBucket.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/undeletebucket/AsyncUndeleteBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/undeletebucket/SyncUndeleteBucket.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/undeletebucket/SyncUndeleteBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatebucket/AsyncUpdateBucket.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatebucket/AsyncUpdateBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatebucket/SyncUpdateBucket.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatebucket/SyncUpdateBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatecmeksettings/AsyncUpdateCmekSettings.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatecmeksettings/AsyncUpdateCmekSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatecmeksettings/SyncUpdateCmekSettings.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatecmeksettings/SyncUpdateCmekSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updateexclusion/AsyncUpdateExclusion.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updateexclusion/AsyncUpdateExclusion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updateexclusion/SyncUpdateExclusion.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updateexclusion/SyncUpdateExclusion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updateexclusion/SyncUpdateExclusionLogexclusionnameLogexclusionFieldmask.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updateexclusion/SyncUpdateExclusionLogexclusionnameLogexclusionFieldmask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updateexclusion/SyncUpdateExclusionStringLogexclusionFieldmask.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updateexclusion/SyncUpdateExclusionStringLogexclusionFieldmask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatesettings/AsyncUpdateSettings.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatesettings/AsyncUpdateSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatesettings/SyncUpdateSettings.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatesettings/SyncUpdateSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatesettings/SyncUpdateSettingsSettingsFieldmask.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatesettings/SyncUpdateSettingsSettingsFieldmask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatesink/AsyncUpdateSink.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatesink/AsyncUpdateSink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatesink/SyncUpdateSink.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatesink/SyncUpdateSink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatesink/SyncUpdateSinkLogsinknameLogsink.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatesink/SyncUpdateSinkLogsinknameLogsink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatesink/SyncUpdateSinkLogsinknameLogsinkFieldmask.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatesink/SyncUpdateSinkLogsinknameLogsinkFieldmask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatesink/SyncUpdateSinkStringLogsink.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatesink/SyncUpdateSinkStringLogsink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatesink/SyncUpdateSinkStringLogsinkFieldmask.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updatesink/SyncUpdateSinkStringLogsinkFieldmask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updateview/AsyncUpdateView.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updateview/AsyncUpdateView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updateview/SyncUpdateView.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configservicev2/updateview/SyncUpdateView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configsettings/copylogentries/SyncCopyLogEntries.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configsettings/copylogentries/SyncCopyLogEntries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configsettings/getbucket/SyncGetBucket.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configsettings/getbucket/SyncGetBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/create/SyncCreateSetCredentialsProvider.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/create/SyncCreateSetEndpoint.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/deletelog/AsyncDeleteLog.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/deletelog/AsyncDeleteLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/deletelog/SyncDeleteLog.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/deletelog/SyncDeleteLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/deletelog/SyncDeleteLogLogname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/deletelog/SyncDeleteLogLogname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/deletelog/SyncDeleteLogString.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/deletelog/SyncDeleteLogString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogentries/AsyncListLogEntries.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogentries/AsyncListLogEntries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogentries/AsyncListLogEntriesPaged.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogentries/AsyncListLogEntriesPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogentries/SyncListLogEntries.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogentries/SyncListLogEntries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogentries/SyncListLogEntriesListstringStringString.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogentries/SyncListLogEntriesListstringStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogs/AsyncListLogs.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogs/AsyncListLogs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogs/AsyncListLogsPaged.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogs/AsyncListLogsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogs/SyncListLogs.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogs/SyncListLogs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogs/SyncListLogsBillingaccountname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogs/SyncListLogsBillingaccountname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogs/SyncListLogsFoldername.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogs/SyncListLogsFoldername.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogs/SyncListLogsOrganizationname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogs/SyncListLogsOrganizationname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogs/SyncListLogsProjectname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogs/SyncListLogsProjectname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogs/SyncListLogsString.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listlogs/SyncListLogsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listmonitoredresourcedescriptors/AsyncListMonitoredResourceDescriptors.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listmonitoredresourcedescriptors/AsyncListMonitoredResourceDescriptors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listmonitoredresourcedescriptors/AsyncListMonitoredResourceDescriptorsPaged.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listmonitoredresourcedescriptors/AsyncListMonitoredResourceDescriptorsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listmonitoredresourcedescriptors/SyncListMonitoredResourceDescriptors.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/listmonitoredresourcedescriptors/SyncListMonitoredResourceDescriptors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/taillogentries/AsyncTailLogEntries.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/taillogentries/AsyncTailLogEntries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/writelogentries/AsyncWriteLogEntries.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/writelogentries/AsyncWriteLogEntries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/writelogentries/SyncWriteLogEntries.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/writelogentries/SyncWriteLogEntries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/writelogentries/SyncWriteLogEntriesLognameMonitoredresourceMapstringstringListlogentry.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/writelogentries/SyncWriteLogEntriesLognameMonitoredresourceMapstringstringListlogentry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/writelogentries/SyncWriteLogEntriesStringMonitoredresourceMapstringstringListlogentry.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingservicev2/writelogentries/SyncWriteLogEntriesStringMonitoredresourceMapstringstringListlogentry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingsettings/deletelog/SyncDeleteLog.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingsettings/deletelog/SyncDeleteLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/create/SyncCreateSetCredentialsProvider.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/create/SyncCreateSetEndpoint.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/createlogmetric/AsyncCreateLogMetric.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/createlogmetric/AsyncCreateLogMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/createlogmetric/SyncCreateLogMetric.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/createlogmetric/SyncCreateLogMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/createlogmetric/SyncCreateLogMetricProjectnameLogmetric.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/createlogmetric/SyncCreateLogMetricProjectnameLogmetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/createlogmetric/SyncCreateLogMetricStringLogmetric.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/createlogmetric/SyncCreateLogMetricStringLogmetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/deletelogmetric/AsyncDeleteLogMetric.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/deletelogmetric/AsyncDeleteLogMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/deletelogmetric/SyncDeleteLogMetric.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/deletelogmetric/SyncDeleteLogMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/deletelogmetric/SyncDeleteLogMetricLogmetricname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/deletelogmetric/SyncDeleteLogMetricLogmetricname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/deletelogmetric/SyncDeleteLogMetricString.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/deletelogmetric/SyncDeleteLogMetricString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/getlogmetric/AsyncGetLogMetric.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/getlogmetric/AsyncGetLogMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/getlogmetric/SyncGetLogMetric.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/getlogmetric/SyncGetLogMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/getlogmetric/SyncGetLogMetricLogmetricname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/getlogmetric/SyncGetLogMetricLogmetricname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/getlogmetric/SyncGetLogMetricString.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/getlogmetric/SyncGetLogMetricString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/listlogmetrics/AsyncListLogMetrics.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/listlogmetrics/AsyncListLogMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/listlogmetrics/AsyncListLogMetricsPaged.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/listlogmetrics/AsyncListLogMetricsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/listlogmetrics/SyncListLogMetrics.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/listlogmetrics/SyncListLogMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/listlogmetrics/SyncListLogMetricsProjectname.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/listlogmetrics/SyncListLogMetricsProjectname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/listlogmetrics/SyncListLogMetricsString.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/listlogmetrics/SyncListLogMetricsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/updatelogmetric/AsyncUpdateLogMetric.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/updatelogmetric/AsyncUpdateLogMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/updatelogmetric/SyncUpdateLogMetric.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/updatelogmetric/SyncUpdateLogMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/updatelogmetric/SyncUpdateLogMetricLogmetricnameLogmetric.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/updatelogmetric/SyncUpdateLogMetricLogmetricnameLogmetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/updatelogmetric/SyncUpdateLogMetricStringLogmetric.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsservicev2/updatelogmetric/SyncUpdateLogMetricStringLogmetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricssettings/getlogmetric/SyncGetLogMetric.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricssettings/getlogmetric/SyncGetLogMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/stub/configservicev2stubsettings/copylogentries/SyncCopyLogEntries.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/stub/configservicev2stubsettings/copylogentries/SyncCopyLogEntries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/stub/configservicev2stubsettings/getbucket/SyncGetBucket.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/stub/configservicev2stubsettings/getbucket/SyncGetBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/stub/loggingservicev2stubsettings/deletelog/SyncDeleteLog.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/stub/loggingservicev2stubsettings/deletelog/SyncDeleteLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/stub/metricsservicev2stubsettings/getlogmetric/SyncGetLogMetric.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/stub/metricsservicev2stubsettings/getlogmetric/SyncGetLogMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/ConfigClient.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/ConfigClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/ConfigClientTest.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/ConfigClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/ConfigSettings.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/ConfigSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/LoggingClient.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/LoggingClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/LoggingClientTest.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/LoggingClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/LoggingSettings.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/LoggingSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MetricsClient.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MetricsClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MetricsClientTest.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MetricsClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MetricsSettings.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MetricsSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MockConfigServiceV2.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MockConfigServiceV2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MockConfigServiceV2Impl.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MockConfigServiceV2Impl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MockLoggingServiceV2.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MockLoggingServiceV2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MockLoggingServiceV2Impl.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MockLoggingServiceV2Impl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MockMetricsServiceV2.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MockMetricsServiceV2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MockMetricsServiceV2Impl.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MockMetricsServiceV2Impl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/package-info.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/ConfigServiceV2Stub.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/ConfigServiceV2Stub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/ConfigServiceV2StubSettings.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/ConfigServiceV2StubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/GrpcConfigServiceV2CallableFactory.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/GrpcConfigServiceV2CallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/GrpcConfigServiceV2Stub.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/GrpcConfigServiceV2Stub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/GrpcLoggingServiceV2CallableFactory.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/GrpcLoggingServiceV2CallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/GrpcLoggingServiceV2Stub.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/GrpcLoggingServiceV2Stub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/GrpcMetricsServiceV2CallableFactory.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/GrpcMetricsServiceV2CallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/GrpcMetricsServiceV2Stub.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/GrpcMetricsServiceV2Stub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/LoggingServiceV2Stub.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/LoggingServiceV2Stub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/LoggingServiceV2StubSettings.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/LoggingServiceV2StubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/MetricsServiceV2Stub.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/MetricsServiceV2Stub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/MetricsServiceV2StubSettings.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/MetricsServiceV2StubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/logging/v2/BillingAccountLocationName.java
+++ b/test/integration/goldens/logging/src/com/google/logging/v2/BillingAccountLocationName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/logging/v2/BillingAccountName.java
+++ b/test/integration/goldens/logging/src/com/google/logging/v2/BillingAccountName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/logging/v2/CmekSettingsName.java
+++ b/test/integration/goldens/logging/src/com/google/logging/v2/CmekSettingsName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/logging/v2/FolderLocationName.java
+++ b/test/integration/goldens/logging/src/com/google/logging/v2/FolderLocationName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/logging/v2/FolderName.java
+++ b/test/integration/goldens/logging/src/com/google/logging/v2/FolderName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/logging/v2/LocationName.java
+++ b/test/integration/goldens/logging/src/com/google/logging/v2/LocationName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/logging/v2/LogBucketName.java
+++ b/test/integration/goldens/logging/src/com/google/logging/v2/LogBucketName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/logging/v2/LogExclusionName.java
+++ b/test/integration/goldens/logging/src/com/google/logging/v2/LogExclusionName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/logging/v2/LogMetricName.java
+++ b/test/integration/goldens/logging/src/com/google/logging/v2/LogMetricName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/logging/v2/LogName.java
+++ b/test/integration/goldens/logging/src/com/google/logging/v2/LogName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/logging/v2/LogSinkName.java
+++ b/test/integration/goldens/logging/src/com/google/logging/v2/LogSinkName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/logging/v2/LogViewName.java
+++ b/test/integration/goldens/logging/src/com/google/logging/v2/LogViewName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/logging/v2/OrganizationLocationName.java
+++ b/test/integration/goldens/logging/src/com/google/logging/v2/OrganizationLocationName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/logging/v2/OrganizationName.java
+++ b/test/integration/goldens/logging/src/com/google/logging/v2/OrganizationName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/logging/v2/ProjectName.java
+++ b/test/integration/goldens/logging/src/com/google/logging/v2/ProjectName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/logging/src/com/google/logging/v2/SettingsName.java
+++ b/test/integration/goldens/logging/src/com/google/logging/v2/SettingsName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/create/SyncCreateSetCredentialsProvider.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/create/SyncCreateSetEndpoint.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/createtopic/AsyncCreateTopic.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/createtopic/AsyncCreateTopic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/createtopic/SyncCreateTopic.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/createtopic/SyncCreateTopic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/createtopic/SyncCreateTopicString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/createtopic/SyncCreateTopicString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/createtopic/SyncCreateTopicTopicname.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/createtopic/SyncCreateTopicTopicname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/deletetopic/AsyncDeleteTopic.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/deletetopic/AsyncDeleteTopic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/deletetopic/SyncDeleteTopic.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/deletetopic/SyncDeleteTopic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/deletetopic/SyncDeleteTopicString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/deletetopic/SyncDeleteTopicString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/deletetopic/SyncDeleteTopicTopicname.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/deletetopic/SyncDeleteTopicTopicname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/detachsubscription/AsyncDetachSubscription.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/detachsubscription/AsyncDetachSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/detachsubscription/SyncDetachSubscription.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/detachsubscription/SyncDetachSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/getiampolicy/AsyncGetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/getiampolicy/AsyncGetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/getiampolicy/SyncGetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/getiampolicy/SyncGetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/gettopic/AsyncGetTopic.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/gettopic/AsyncGetTopic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/gettopic/SyncGetTopic.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/gettopic/SyncGetTopic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/gettopic/SyncGetTopicString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/gettopic/SyncGetTopicString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/gettopic/SyncGetTopicTopicname.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/gettopic/SyncGetTopicTopicname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopics/AsyncListTopics.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopics/AsyncListTopics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopics/AsyncListTopicsPaged.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopics/AsyncListTopicsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopics/SyncListTopics.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopics/SyncListTopics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopics/SyncListTopicsProjectname.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopics/SyncListTopicsProjectname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopics/SyncListTopicsString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopics/SyncListTopicsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsnapshots/AsyncListTopicSnapshots.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsnapshots/AsyncListTopicSnapshots.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsnapshots/AsyncListTopicSnapshotsPaged.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsnapshots/AsyncListTopicSnapshotsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsnapshots/SyncListTopicSnapshots.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsnapshots/SyncListTopicSnapshots.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsnapshots/SyncListTopicSnapshotsString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsnapshots/SyncListTopicSnapshotsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsnapshots/SyncListTopicSnapshotsTopicname.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsnapshots/SyncListTopicSnapshotsTopicname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsubscriptions/AsyncListTopicSubscriptions.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsubscriptions/AsyncListTopicSubscriptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsubscriptions/AsyncListTopicSubscriptionsPaged.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsubscriptions/AsyncListTopicSubscriptionsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsubscriptions/SyncListTopicSubscriptions.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsubscriptions/SyncListTopicSubscriptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsubscriptions/SyncListTopicSubscriptionsString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsubscriptions/SyncListTopicSubscriptionsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsubscriptions/SyncListTopicSubscriptionsTopicname.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/listtopicsubscriptions/SyncListTopicSubscriptionsTopicname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/publish/AsyncPublish.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/publish/AsyncPublish.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/publish/SyncPublish.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/publish/SyncPublish.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/publish/SyncPublishStringListpubsubmessage.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/publish/SyncPublishStringListpubsubmessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/publish/SyncPublishTopicnameListpubsubmessage.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/publish/SyncPublishTopicnameListpubsubmessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/setiampolicy/AsyncSetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/setiampolicy/AsyncSetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/setiampolicy/SyncSetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/setiampolicy/SyncSetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/testiampermissions/AsyncTestIamPermissions.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/testiampermissions/AsyncTestIamPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/testiampermissions/SyncTestIamPermissions.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/testiampermissions/SyncTestIamPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/updatetopic/AsyncUpdateTopic.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/updatetopic/AsyncUpdateTopic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/updatetopic/SyncUpdateTopic.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/publisher/updatetopic/SyncUpdateTopic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/commitschema/AsyncCommitSchema.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/commitschema/AsyncCommitSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/commitschema/SyncCommitSchema.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/commitschema/SyncCommitSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/commitschema/SyncCommitSchemaSchemanameSchema.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/commitschema/SyncCommitSchemaSchemanameSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/commitschema/SyncCommitSchemaStringSchema.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/commitschema/SyncCommitSchemaStringSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/create/SyncCreateSetCredentialsProvider.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/create/SyncCreateSetEndpoint.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/createschema/AsyncCreateSchema.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/createschema/AsyncCreateSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/createschema/SyncCreateSchema.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/createschema/SyncCreateSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/createschema/SyncCreateSchemaProjectnameSchemaString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/createschema/SyncCreateSchemaProjectnameSchemaString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/createschema/SyncCreateSchemaStringSchemaString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/createschema/SyncCreateSchemaStringSchemaString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/deleteschema/AsyncDeleteSchema.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/deleteschema/AsyncDeleteSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/deleteschema/SyncDeleteSchema.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/deleteschema/SyncDeleteSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/deleteschema/SyncDeleteSchemaSchemaname.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/deleteschema/SyncDeleteSchemaSchemaname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/deleteschema/SyncDeleteSchemaString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/deleteschema/SyncDeleteSchemaString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/deleteschemarevision/AsyncDeleteSchemaRevision.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/deleteschemarevision/AsyncDeleteSchemaRevision.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/deleteschemarevision/SyncDeleteSchemaRevision.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/deleteschemarevision/SyncDeleteSchemaRevision.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/deleteschemarevision/SyncDeleteSchemaRevisionSchemanameString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/deleteschemarevision/SyncDeleteSchemaRevisionSchemanameString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/deleteschemarevision/SyncDeleteSchemaRevisionStringString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/deleteschemarevision/SyncDeleteSchemaRevisionStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/getiampolicy/AsyncGetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/getiampolicy/AsyncGetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/getiampolicy/SyncGetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/getiampolicy/SyncGetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/getschema/AsyncGetSchema.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/getschema/AsyncGetSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/getschema/SyncGetSchema.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/getschema/SyncGetSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/getschema/SyncGetSchemaSchemaname.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/getschema/SyncGetSchemaSchemaname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/getschema/SyncGetSchemaString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/getschema/SyncGetSchemaString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemarevisions/AsyncListSchemaRevisions.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemarevisions/AsyncListSchemaRevisions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemarevisions/AsyncListSchemaRevisionsPaged.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemarevisions/AsyncListSchemaRevisionsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemarevisions/SyncListSchemaRevisions.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemarevisions/SyncListSchemaRevisions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemarevisions/SyncListSchemaRevisionsSchemaname.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemarevisions/SyncListSchemaRevisionsSchemaname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemarevisions/SyncListSchemaRevisionsString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemarevisions/SyncListSchemaRevisionsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemas/AsyncListSchemas.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemas/AsyncListSchemas.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemas/AsyncListSchemasPaged.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemas/AsyncListSchemasPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemas/SyncListSchemas.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemas/SyncListSchemas.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemas/SyncListSchemasProjectname.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemas/SyncListSchemasProjectname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemas/SyncListSchemasString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/listschemas/SyncListSchemasString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/rollbackschema/AsyncRollbackSchema.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/rollbackschema/AsyncRollbackSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/rollbackschema/SyncRollbackSchema.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/rollbackschema/SyncRollbackSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/rollbackschema/SyncRollbackSchemaSchemanameString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/rollbackschema/SyncRollbackSchemaSchemanameString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/rollbackschema/SyncRollbackSchemaStringString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/rollbackschema/SyncRollbackSchemaStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/setiampolicy/AsyncSetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/setiampolicy/AsyncSetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/setiampolicy/SyncSetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/setiampolicy/SyncSetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/testiampermissions/AsyncTestIamPermissions.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/testiampermissions/AsyncTestIamPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/testiampermissions/SyncTestIamPermissions.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/testiampermissions/SyncTestIamPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/validatemessage/AsyncValidateMessage.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/validatemessage/AsyncValidateMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/validatemessage/SyncValidateMessage.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/validatemessage/SyncValidateMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/validateschema/AsyncValidateSchema.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/validateschema/AsyncValidateSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/validateschema/SyncValidateSchema.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/validateschema/SyncValidateSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/validateschema/SyncValidateSchemaProjectnameSchema.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/validateschema/SyncValidateSchemaProjectnameSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/validateschema/SyncValidateSchemaStringSchema.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservice/validateschema/SyncValidateSchemaStringSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservicesettings/createschema/SyncCreateSchema.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaservicesettings/createschema/SyncCreateSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/stub/publisherstubsettings/createtopic/SyncCreateTopic.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/stub/publisherstubsettings/createtopic/SyncCreateTopic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/stub/schemaservicestubsettings/createschema/SyncCreateSchema.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/stub/schemaservicestubsettings/createschema/SyncCreateSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/stub/subscriberstubsettings/createsubscription/SyncCreateSubscription.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/stub/subscriberstubsettings/createsubscription/SyncCreateSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/acknowledge/AsyncAcknowledge.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/acknowledge/AsyncAcknowledge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/acknowledge/SyncAcknowledge.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/acknowledge/SyncAcknowledge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/acknowledge/SyncAcknowledgeStringListstring.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/acknowledge/SyncAcknowledgeStringListstring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/acknowledge/SyncAcknowledgeSubscriptionnameListstring.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/acknowledge/SyncAcknowledgeSubscriptionnameListstring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/create/SyncCreateSetCredentialsProvider.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/create/SyncCreateSetEndpoint.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsnapshot/AsyncCreateSnapshot.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsnapshot/AsyncCreateSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsnapshot/SyncCreateSnapshot.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsnapshot/SyncCreateSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsnapshot/SyncCreateSnapshotSnapshotnameString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsnapshot/SyncCreateSnapshotSnapshotnameString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsnapshot/SyncCreateSnapshotSnapshotnameSubscriptionname.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsnapshot/SyncCreateSnapshotSnapshotnameSubscriptionname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsnapshot/SyncCreateSnapshotStringString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsnapshot/SyncCreateSnapshotStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsnapshot/SyncCreateSnapshotStringSubscriptionname.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsnapshot/SyncCreateSnapshotStringSubscriptionname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsubscription/AsyncCreateSubscription.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsubscription/AsyncCreateSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsubscription/SyncCreateSubscription.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsubscription/SyncCreateSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsubscription/SyncCreateSubscriptionStringStringPushconfigInt.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsubscription/SyncCreateSubscriptionStringStringPushconfigInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsubscription/SyncCreateSubscriptionStringTopicnamePushconfigInt.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsubscription/SyncCreateSubscriptionStringTopicnamePushconfigInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsubscription/SyncCreateSubscriptionSubscriptionnameStringPushconfigInt.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsubscription/SyncCreateSubscriptionSubscriptionnameStringPushconfigInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsubscription/SyncCreateSubscriptionSubscriptionnameTopicnamePushconfigInt.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/createsubscription/SyncCreateSubscriptionSubscriptionnameTopicnamePushconfigInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/deletesnapshot/AsyncDeleteSnapshot.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/deletesnapshot/AsyncDeleteSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/deletesnapshot/SyncDeleteSnapshot.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/deletesnapshot/SyncDeleteSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/deletesnapshot/SyncDeleteSnapshotSnapshotname.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/deletesnapshot/SyncDeleteSnapshotSnapshotname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/deletesnapshot/SyncDeleteSnapshotString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/deletesnapshot/SyncDeleteSnapshotString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/deletesubscription/AsyncDeleteSubscription.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/deletesubscription/AsyncDeleteSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/deletesubscription/SyncDeleteSubscription.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/deletesubscription/SyncDeleteSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/deletesubscription/SyncDeleteSubscriptionString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/deletesubscription/SyncDeleteSubscriptionString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/deletesubscription/SyncDeleteSubscriptionSubscriptionname.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/deletesubscription/SyncDeleteSubscriptionSubscriptionname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getiampolicy/AsyncGetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getiampolicy/AsyncGetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getiampolicy/SyncGetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getiampolicy/SyncGetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getsnapshot/AsyncGetSnapshot.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getsnapshot/AsyncGetSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getsnapshot/SyncGetSnapshot.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getsnapshot/SyncGetSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getsnapshot/SyncGetSnapshotSnapshotname.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getsnapshot/SyncGetSnapshotSnapshotname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getsnapshot/SyncGetSnapshotString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getsnapshot/SyncGetSnapshotString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getsubscription/AsyncGetSubscription.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getsubscription/AsyncGetSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getsubscription/SyncGetSubscription.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getsubscription/SyncGetSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getsubscription/SyncGetSubscriptionString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getsubscription/SyncGetSubscriptionString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getsubscription/SyncGetSubscriptionSubscriptionname.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/getsubscription/SyncGetSubscriptionSubscriptionname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsnapshots/AsyncListSnapshots.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsnapshots/AsyncListSnapshots.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsnapshots/AsyncListSnapshotsPaged.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsnapshots/AsyncListSnapshotsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsnapshots/SyncListSnapshots.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsnapshots/SyncListSnapshots.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsnapshots/SyncListSnapshotsProjectname.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsnapshots/SyncListSnapshotsProjectname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsnapshots/SyncListSnapshotsString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsnapshots/SyncListSnapshotsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsubscriptions/AsyncListSubscriptions.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsubscriptions/AsyncListSubscriptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsubscriptions/AsyncListSubscriptionsPaged.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsubscriptions/AsyncListSubscriptionsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsubscriptions/SyncListSubscriptions.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsubscriptions/SyncListSubscriptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsubscriptions/SyncListSubscriptionsProjectname.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsubscriptions/SyncListSubscriptionsProjectname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsubscriptions/SyncListSubscriptionsString.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/listsubscriptions/SyncListSubscriptionsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/modifyackdeadline/AsyncModifyAckDeadline.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/modifyackdeadline/AsyncModifyAckDeadline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/modifyackdeadline/SyncModifyAckDeadline.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/modifyackdeadline/SyncModifyAckDeadline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/modifyackdeadline/SyncModifyAckDeadlineStringListstringInt.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/modifyackdeadline/SyncModifyAckDeadlineStringListstringInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/modifyackdeadline/SyncModifyAckDeadlineSubscriptionnameListstringInt.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/modifyackdeadline/SyncModifyAckDeadlineSubscriptionnameListstringInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/modifypushconfig/AsyncModifyPushConfig.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/modifypushconfig/AsyncModifyPushConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/modifypushconfig/SyncModifyPushConfig.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/modifypushconfig/SyncModifyPushConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/modifypushconfig/SyncModifyPushConfigStringPushconfig.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/modifypushconfig/SyncModifyPushConfigStringPushconfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/modifypushconfig/SyncModifyPushConfigSubscriptionnamePushconfig.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/modifypushconfig/SyncModifyPushConfigSubscriptionnamePushconfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/pull/AsyncPull.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/pull/AsyncPull.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/pull/SyncPull.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/pull/SyncPull.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/pull/SyncPullStringBooleanInt.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/pull/SyncPullStringBooleanInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/pull/SyncPullStringInt.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/pull/SyncPullStringInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/pull/SyncPullSubscriptionnameBooleanInt.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/pull/SyncPullSubscriptionnameBooleanInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/pull/SyncPullSubscriptionnameInt.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/pull/SyncPullSubscriptionnameInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/seek/AsyncSeek.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/seek/AsyncSeek.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/seek/SyncSeek.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/seek/SyncSeek.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/setiampolicy/AsyncSetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/setiampolicy/AsyncSetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/setiampolicy/SyncSetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/setiampolicy/SyncSetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/streamingpull/AsyncStreamingPull.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/streamingpull/AsyncStreamingPull.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/testiampermissions/AsyncTestIamPermissions.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/testiampermissions/AsyncTestIamPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/testiampermissions/SyncTestIamPermissions.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/testiampermissions/SyncTestIamPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/updatesnapshot/AsyncUpdateSnapshot.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/updatesnapshot/AsyncUpdateSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/updatesnapshot/SyncUpdateSnapshot.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/updatesnapshot/SyncUpdateSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/updatesubscription/AsyncUpdateSubscription.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/updatesubscription/AsyncUpdateSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/updatesubscription/SyncUpdateSubscription.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriber/updatesubscription/SyncUpdateSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriptionadminsettings/createsubscription/SyncCreateSubscription.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriptionadminsettings/createsubscription/SyncCreateSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/topicadminsettings/createtopic/SyncCreateTopic.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/topicadminsettings/createtopic/SyncCreateTopic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/MockIAMPolicy.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/MockIAMPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/MockIAMPolicyImpl.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/MockIAMPolicyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/MockPublisher.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/MockPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/MockPublisherImpl.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/MockPublisherImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/MockSchemaService.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/MockSchemaService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/MockSchemaServiceImpl.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/MockSchemaServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/MockSubscriber.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/MockSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/MockSubscriberImpl.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/MockSubscriberImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SchemaServiceClient.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SchemaServiceClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SchemaServiceClientTest.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SchemaServiceClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SchemaServiceSettings.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SchemaServiceSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SubscriptionAdminClient.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SubscriptionAdminClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SubscriptionAdminClientTest.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SubscriptionAdminClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SubscriptionAdminSettings.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SubscriptionAdminSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/TopicAdminClient.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/TopicAdminClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/TopicAdminClientTest.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/TopicAdminClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/TopicAdminSettings.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/TopicAdminSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/package-info.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/GrpcPublisherCallableFactory.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/GrpcPublisherCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/GrpcPublisherStub.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/GrpcPublisherStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/GrpcSchemaServiceCallableFactory.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/GrpcSchemaServiceCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/GrpcSchemaServiceStub.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/GrpcSchemaServiceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/GrpcSubscriberCallableFactory.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/GrpcSubscriberCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/GrpcSubscriberStub.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/GrpcSubscriberStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/PublisherStub.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/PublisherStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/PublisherStubSettings.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/PublisherStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/SchemaServiceStub.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/SchemaServiceStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/SchemaServiceStubSettings.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/SchemaServiceStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/SubscriberStub.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/SubscriberStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/SubscriberStubSettings.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/SubscriberStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/pubsub/v1/ProjectName.java
+++ b/test/integration/goldens/pubsub/src/com/google/pubsub/v1/ProjectName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/pubsub/v1/SchemaName.java
+++ b/test/integration/goldens/pubsub/src/com/google/pubsub/v1/SchemaName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/pubsub/v1/SnapshotName.java
+++ b/test/integration/goldens/pubsub/src/com/google/pubsub/v1/SnapshotName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/pubsub/v1/SubscriptionName.java
+++ b/test/integration/goldens/pubsub/src/com/google/pubsub/v1/SubscriptionName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/pubsub/src/com/google/pubsub/v1/TopicName.java
+++ b/test/integration/goldens/pubsub/src/com/google/pubsub/v1/TopicName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/create/SyncCreateSetCredentialsProvider.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/create/SyncCreateSetEndpoint.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/create/SyncCreateUseHttpJsonTransport.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/create/SyncCreateUseHttpJsonTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/createinstance/AsyncCreateInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/createinstance/AsyncCreateInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/createinstance/AsyncCreateInstanceLRO.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/createinstance/AsyncCreateInstanceLRO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/createinstance/SyncCreateInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/createinstance/SyncCreateInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/createinstance/SyncCreateInstanceLocationnameStringInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/createinstance/SyncCreateInstanceLocationnameStringInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/createinstance/SyncCreateInstanceStringStringInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/createinstance/SyncCreateInstanceStringStringInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/deleteinstance/AsyncDeleteInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/deleteinstance/AsyncDeleteInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/deleteinstance/AsyncDeleteInstanceLRO.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/deleteinstance/AsyncDeleteInstanceLRO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/deleteinstance/SyncDeleteInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/deleteinstance/SyncDeleteInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/deleteinstance/SyncDeleteInstanceInstancename.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/deleteinstance/SyncDeleteInstanceInstancename.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/deleteinstance/SyncDeleteInstanceString.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/deleteinstance/SyncDeleteInstanceString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/exportinstance/AsyncExportInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/exportinstance/AsyncExportInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/exportinstance/AsyncExportInstanceLRO.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/exportinstance/AsyncExportInstanceLRO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/exportinstance/SyncExportInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/exportinstance/SyncExportInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/exportinstance/SyncExportInstanceStringOutputconfig.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/exportinstance/SyncExportInstanceStringOutputconfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/failoverinstance/AsyncFailoverInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/failoverinstance/AsyncFailoverInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/failoverinstance/AsyncFailoverInstanceLRO.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/failoverinstance/AsyncFailoverInstanceLRO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/failoverinstance/SyncFailoverInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/failoverinstance/SyncFailoverInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/failoverinstance/SyncFailoverInstanceInstancenameFailoverinstancerequestdataprotectionmode.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/failoverinstance/SyncFailoverInstanceInstancenameFailoverinstancerequestdataprotectionmode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/failoverinstance/SyncFailoverInstanceStringFailoverinstancerequestdataprotectionmode.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/failoverinstance/SyncFailoverInstanceStringFailoverinstancerequestdataprotectionmode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/getinstance/AsyncGetInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/getinstance/AsyncGetInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/getinstance/SyncGetInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/getinstance/SyncGetInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/getinstance/SyncGetInstanceInstancename.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/getinstance/SyncGetInstanceInstancename.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/getinstance/SyncGetInstanceString.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/getinstance/SyncGetInstanceString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/getinstanceauthstring/AsyncGetInstanceAuthString.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/getinstanceauthstring/AsyncGetInstanceAuthString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/getinstanceauthstring/SyncGetInstanceAuthString.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/getinstanceauthstring/SyncGetInstanceAuthString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/getinstanceauthstring/SyncGetInstanceAuthStringInstancename.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/getinstanceauthstring/SyncGetInstanceAuthStringInstancename.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/getinstanceauthstring/SyncGetInstanceAuthStringString.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/getinstanceauthstring/SyncGetInstanceAuthStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/importinstance/AsyncImportInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/importinstance/AsyncImportInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/importinstance/AsyncImportInstanceLRO.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/importinstance/AsyncImportInstanceLRO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/importinstance/SyncImportInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/importinstance/SyncImportInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/importinstance/SyncImportInstanceStringInputconfig.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/importinstance/SyncImportInstanceStringInputconfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/listinstances/AsyncListInstances.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/listinstances/AsyncListInstances.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/listinstances/AsyncListInstancesPaged.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/listinstances/AsyncListInstancesPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/listinstances/SyncListInstances.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/listinstances/SyncListInstances.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/listinstances/SyncListInstancesLocationname.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/listinstances/SyncListInstancesLocationname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/listinstances/SyncListInstancesString.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/listinstances/SyncListInstancesString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/reschedulemaintenance/AsyncRescheduleMaintenance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/reschedulemaintenance/AsyncRescheduleMaintenance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/reschedulemaintenance/AsyncRescheduleMaintenanceLRO.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/reschedulemaintenance/AsyncRescheduleMaintenanceLRO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/reschedulemaintenance/SyncRescheduleMaintenance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/reschedulemaintenance/SyncRescheduleMaintenance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/reschedulemaintenance/SyncRescheduleMaintenanceInstancenameReschedulemaintenancerequestrescheduletypeTimestamp.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/reschedulemaintenance/SyncRescheduleMaintenanceInstancenameReschedulemaintenancerequestrescheduletypeTimestamp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/reschedulemaintenance/SyncRescheduleMaintenanceStringReschedulemaintenancerequestrescheduletypeTimestamp.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/reschedulemaintenance/SyncRescheduleMaintenanceStringReschedulemaintenancerequestrescheduletypeTimestamp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/updateinstance/AsyncUpdateInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/updateinstance/AsyncUpdateInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/updateinstance/AsyncUpdateInstanceLRO.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/updateinstance/AsyncUpdateInstanceLRO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/updateinstance/SyncUpdateInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/updateinstance/SyncUpdateInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/updateinstance/SyncUpdateInstanceFieldmaskInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/updateinstance/SyncUpdateInstanceFieldmaskInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/upgradeinstance/AsyncUpgradeInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/upgradeinstance/AsyncUpgradeInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/upgradeinstance/AsyncUpgradeInstanceLRO.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/upgradeinstance/AsyncUpgradeInstanceLRO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/upgradeinstance/SyncUpgradeInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/upgradeinstance/SyncUpgradeInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/upgradeinstance/SyncUpgradeInstanceInstancenameString.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/upgradeinstance/SyncUpgradeInstanceInstancenameString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/upgradeinstance/SyncUpgradeInstanceStringString.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredis/upgradeinstance/SyncUpgradeInstanceStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredissettings/createinstance/SyncCreateInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredissettings/createinstance/SyncCreateInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredissettings/getinstance/SyncGetInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredissettings/getinstance/SyncGetInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/stub/cloudredisstubsettings/createinstance/SyncCreateInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/stub/cloudredisstubsettings/createinstance/SyncCreateInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/stub/cloudredisstubsettings/getinstance/SyncGetInstance.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/stub/cloudredisstubsettings/getinstance/SyncGetInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/CloudRedisClient.java
+++ b/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/CloudRedisClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/CloudRedisClientHttpJsonTest.java
+++ b/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/CloudRedisClientHttpJsonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/CloudRedisClientTest.java
+++ b/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/CloudRedisClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/CloudRedisSettings.java
+++ b/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/CloudRedisSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/InstanceName.java
+++ b/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/InstanceName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/LocationName.java
+++ b/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/LocationName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/MockCloudRedis.java
+++ b/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/MockCloudRedis.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/MockCloudRedisImpl.java
+++ b/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/MockCloudRedisImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/package-info.java
+++ b/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/CloudRedisStub.java
+++ b/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/CloudRedisStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/CloudRedisStubSettings.java
+++ b/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/CloudRedisStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/GrpcCloudRedisCallableFactory.java
+++ b/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/GrpcCloudRedisCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/GrpcCloudRedisStub.java
+++ b/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/GrpcCloudRedisStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/HttpJsonCloudRedisCallableFactory.java
+++ b/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/HttpJsonCloudRedisCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/HttpJsonCloudRedisStub.java
+++ b/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/HttpJsonCloudRedisStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/cancelresumablewrite/AsyncCancelResumableWrite.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/cancelresumablewrite/AsyncCancelResumableWrite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/cancelresumablewrite/SyncCancelResumableWrite.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/cancelresumablewrite/SyncCancelResumableWrite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/cancelresumablewrite/SyncCancelResumableWriteString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/cancelresumablewrite/SyncCancelResumableWriteString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/composeobject/AsyncComposeObject.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/composeobject/AsyncComposeObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/composeobject/SyncComposeObject.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/composeobject/SyncComposeObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/create/SyncCreateSetCredentialsProvider.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/create/SyncCreateSetCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/create/SyncCreateSetEndpoint.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/create/SyncCreateSetEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createbucket/AsyncCreateBucket.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createbucket/AsyncCreateBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createbucket/SyncCreateBucket.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createbucket/SyncCreateBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createbucket/SyncCreateBucketProjectnameBucketString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createbucket/SyncCreateBucketProjectnameBucketString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createbucket/SyncCreateBucketStringBucketString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createbucket/SyncCreateBucketStringBucketString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createhmackey/AsyncCreateHmacKey.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createhmackey/AsyncCreateHmacKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createhmackey/SyncCreateHmacKey.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createhmackey/SyncCreateHmacKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createhmackey/SyncCreateHmacKeyProjectnameString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createhmackey/SyncCreateHmacKeyProjectnameString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createhmackey/SyncCreateHmacKeyStringString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createhmackey/SyncCreateHmacKeyStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createnotification/AsyncCreateNotification.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createnotification/AsyncCreateNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createnotification/SyncCreateNotification.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createnotification/SyncCreateNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createnotification/SyncCreateNotificationProjectnameNotification.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createnotification/SyncCreateNotificationProjectnameNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createnotification/SyncCreateNotificationStringNotification.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/createnotification/SyncCreateNotificationStringNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletebucket/AsyncDeleteBucket.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletebucket/AsyncDeleteBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletebucket/SyncDeleteBucket.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletebucket/SyncDeleteBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletebucket/SyncDeleteBucketBucketname.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletebucket/SyncDeleteBucketBucketname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletebucket/SyncDeleteBucketString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletebucket/SyncDeleteBucketString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletehmackey/AsyncDeleteHmacKey.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletehmackey/AsyncDeleteHmacKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletehmackey/SyncDeleteHmacKey.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletehmackey/SyncDeleteHmacKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletehmackey/SyncDeleteHmacKeyStringProjectname.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletehmackey/SyncDeleteHmacKeyStringProjectname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletehmackey/SyncDeleteHmacKeyStringString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletehmackey/SyncDeleteHmacKeyStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletenotification/AsyncDeleteNotification.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletenotification/AsyncDeleteNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletenotification/SyncDeleteNotification.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletenotification/SyncDeleteNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletenotification/SyncDeleteNotificationNotificationname.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletenotification/SyncDeleteNotificationNotificationname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletenotification/SyncDeleteNotificationString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deletenotification/SyncDeleteNotificationString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deleteobject/AsyncDeleteObject.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deleteobject/AsyncDeleteObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deleteobject/SyncDeleteObject.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deleteobject/SyncDeleteObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deleteobject/SyncDeleteObjectStringString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deleteobject/SyncDeleteObjectStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deleteobject/SyncDeleteObjectStringStringLong.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/deleteobject/SyncDeleteObjectStringStringLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getbucket/AsyncGetBucket.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getbucket/AsyncGetBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getbucket/SyncGetBucket.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getbucket/SyncGetBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getbucket/SyncGetBucketBucketname.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getbucket/SyncGetBucketBucketname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getbucket/SyncGetBucketString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getbucket/SyncGetBucketString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/gethmackey/AsyncGetHmacKey.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/gethmackey/AsyncGetHmacKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/gethmackey/SyncGetHmacKey.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/gethmackey/SyncGetHmacKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/gethmackey/SyncGetHmacKeyStringProjectname.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/gethmackey/SyncGetHmacKeyStringProjectname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/gethmackey/SyncGetHmacKeyStringString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/gethmackey/SyncGetHmacKeyStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getiampolicy/AsyncGetIamPolicy.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getiampolicy/AsyncGetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getiampolicy/SyncGetIamPolicy.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getiampolicy/SyncGetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getiampolicy/SyncGetIamPolicyResourcename.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getiampolicy/SyncGetIamPolicyResourcename.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getiampolicy/SyncGetIamPolicyString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getiampolicy/SyncGetIamPolicyString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getnotification/AsyncGetNotification.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getnotification/AsyncGetNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getnotification/SyncGetNotification.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getnotification/SyncGetNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getnotification/SyncGetNotificationBucketname.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getnotification/SyncGetNotificationBucketname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getnotification/SyncGetNotificationString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getnotification/SyncGetNotificationString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getobject/AsyncGetObject.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getobject/AsyncGetObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getobject/SyncGetObject.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getobject/SyncGetObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getobject/SyncGetObjectStringString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getobject/SyncGetObjectStringString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getobject/SyncGetObjectStringStringLong.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getobject/SyncGetObjectStringStringLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getserviceaccount/AsyncGetServiceAccount.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getserviceaccount/AsyncGetServiceAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getserviceaccount/SyncGetServiceAccount.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getserviceaccount/SyncGetServiceAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getserviceaccount/SyncGetServiceAccountProjectname.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getserviceaccount/SyncGetServiceAccountProjectname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getserviceaccount/SyncGetServiceAccountString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/getserviceaccount/SyncGetServiceAccountString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listbuckets/AsyncListBuckets.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listbuckets/AsyncListBuckets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listbuckets/AsyncListBucketsPaged.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listbuckets/AsyncListBucketsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listbuckets/SyncListBuckets.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listbuckets/SyncListBuckets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listbuckets/SyncListBucketsProjectname.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listbuckets/SyncListBucketsProjectname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listbuckets/SyncListBucketsString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listbuckets/SyncListBucketsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listhmackeys/AsyncListHmacKeys.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listhmackeys/AsyncListHmacKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listhmackeys/AsyncListHmacKeysPaged.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listhmackeys/AsyncListHmacKeysPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listhmackeys/SyncListHmacKeys.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listhmackeys/SyncListHmacKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listhmackeys/SyncListHmacKeysProjectname.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listhmackeys/SyncListHmacKeysProjectname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listhmackeys/SyncListHmacKeysString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listhmackeys/SyncListHmacKeysString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listnotifications/AsyncListNotifications.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listnotifications/AsyncListNotifications.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listnotifications/AsyncListNotificationsPaged.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listnotifications/AsyncListNotificationsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listnotifications/SyncListNotifications.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listnotifications/SyncListNotifications.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listnotifications/SyncListNotificationsProjectname.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listnotifications/SyncListNotificationsProjectname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listnotifications/SyncListNotificationsString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listnotifications/SyncListNotificationsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listobjects/AsyncListObjects.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listobjects/AsyncListObjects.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listobjects/AsyncListObjectsPaged.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listobjects/AsyncListObjectsPaged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listobjects/SyncListObjects.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listobjects/SyncListObjects.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listobjects/SyncListObjectsProjectname.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listobjects/SyncListObjectsProjectname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listobjects/SyncListObjectsString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/listobjects/SyncListObjectsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/lockbucketretentionpolicy/AsyncLockBucketRetentionPolicy.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/lockbucketretentionpolicy/AsyncLockBucketRetentionPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/lockbucketretentionpolicy/SyncLockBucketRetentionPolicy.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/lockbucketretentionpolicy/SyncLockBucketRetentionPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/lockbucketretentionpolicy/SyncLockBucketRetentionPolicyBucketname.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/lockbucketretentionpolicy/SyncLockBucketRetentionPolicyBucketname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/lockbucketretentionpolicy/SyncLockBucketRetentionPolicyString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/lockbucketretentionpolicy/SyncLockBucketRetentionPolicyString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/querywritestatus/AsyncQueryWriteStatus.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/querywritestatus/AsyncQueryWriteStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/querywritestatus/SyncQueryWriteStatus.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/querywritestatus/SyncQueryWriteStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/querywritestatus/SyncQueryWriteStatusString.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/querywritestatus/SyncQueryWriteStatusString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/readobject/AsyncReadObject.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/readobject/AsyncReadObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/rewriteobject/AsyncRewriteObject.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/rewriteobject/AsyncRewriteObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/rewriteobject/SyncRewriteObject.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/rewriteobject/SyncRewriteObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/setiampolicy/AsyncSetIamPolicy.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/setiampolicy/AsyncSetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/setiampolicy/SyncSetIamPolicy.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/setiampolicy/SyncSetIamPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/setiampolicy/SyncSetIamPolicyResourcenamePolicy.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/setiampolicy/SyncSetIamPolicyResourcenamePolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/setiampolicy/SyncSetIamPolicyStringPolicy.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/setiampolicy/SyncSetIamPolicyStringPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/startresumablewrite/AsyncStartResumableWrite.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/startresumablewrite/AsyncStartResumableWrite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/startresumablewrite/SyncStartResumableWrite.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/startresumablewrite/SyncStartResumableWrite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/testiampermissions/AsyncTestIamPermissions.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/testiampermissions/AsyncTestIamPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/testiampermissions/SyncTestIamPermissions.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/testiampermissions/SyncTestIamPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/testiampermissions/SyncTestIamPermissionsResourcenameListstring.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/testiampermissions/SyncTestIamPermissionsResourcenameListstring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/testiampermissions/SyncTestIamPermissionsStringListstring.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/testiampermissions/SyncTestIamPermissionsStringListstring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/updatebucket/AsyncUpdateBucket.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/updatebucket/AsyncUpdateBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/updatebucket/SyncUpdateBucket.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/updatebucket/SyncUpdateBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/updatebucket/SyncUpdateBucketBucketFieldmask.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/updatebucket/SyncUpdateBucketBucketFieldmask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/updatehmackey/AsyncUpdateHmacKey.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/updatehmackey/AsyncUpdateHmacKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/updatehmackey/SyncUpdateHmacKey.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/updatehmackey/SyncUpdateHmacKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/updatehmackey/SyncUpdateHmacKeyHmackeymetadataFieldmask.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/updatehmackey/SyncUpdateHmacKeyHmackeymetadataFieldmask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/updateobject/AsyncUpdateObject.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/updateobject/AsyncUpdateObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/updateobject/SyncUpdateObject.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/updateobject/SyncUpdateObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/updateobject/SyncUpdateObjectObjectFieldmask.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/updateobject/SyncUpdateObjectObjectFieldmask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/writeobject/AsyncWriteObject.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storage/writeobject/AsyncWriteObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storagesettings/deletebucket/SyncDeleteBucket.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storagesettings/deletebucket/SyncDeleteBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/stub/storagestubsettings/deletebucket/SyncDeleteBucket.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/stub/storagestubsettings/deletebucket/SyncDeleteBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/src/com/google/storage/v2/BucketName.java
+++ b/test/integration/goldens/storage/src/com/google/storage/v2/BucketName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/src/com/google/storage/v2/CryptoKeyName.java
+++ b/test/integration/goldens/storage/src/com/google/storage/v2/CryptoKeyName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/src/com/google/storage/v2/MockStorage.java
+++ b/test/integration/goldens/storage/src/com/google/storage/v2/MockStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/src/com/google/storage/v2/MockStorageImpl.java
+++ b/test/integration/goldens/storage/src/com/google/storage/v2/MockStorageImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/src/com/google/storage/v2/NotificationName.java
+++ b/test/integration/goldens/storage/src/com/google/storage/v2/NotificationName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/src/com/google/storage/v2/ProjectName.java
+++ b/test/integration/goldens/storage/src/com/google/storage/v2/ProjectName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/src/com/google/storage/v2/StorageClient.java
+++ b/test/integration/goldens/storage/src/com/google/storage/v2/StorageClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/src/com/google/storage/v2/StorageClientTest.java
+++ b/test/integration/goldens/storage/src/com/google/storage/v2/StorageClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/src/com/google/storage/v2/StorageSettings.java
+++ b/test/integration/goldens/storage/src/com/google/storage/v2/StorageSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/src/com/google/storage/v2/package-info.java
+++ b/test/integration/goldens/storage/src/com/google/storage/v2/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/src/com/google/storage/v2/stub/GrpcStorageCallableFactory.java
+++ b/test/integration/goldens/storage/src/com/google/storage/v2/stub/GrpcStorageCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/src/com/google/storage/v2/stub/GrpcStorageStub.java
+++ b/test/integration/goldens/storage/src/com/google/storage/v2/stub/GrpcStorageStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/src/com/google/storage/v2/stub/StorageStub.java
+++ b/test/integration/goldens/storage/src/com/google/storage/v2/stub/StorageStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/goldens/storage/src/com/google/storage/v2/stub/StorageStubSettings.java
+++ b/test/integration/goldens/storage/src/com/google/storage/v2/stub/StorageStubSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fixes https://github.com/googleapis/sdk-platform-java/issues/3512.

The copyright year for GAPIC generated files are automatically [set to current year](https://github.com/googleapis/sdk-platform-java/blob/9a65386dfc3146de4f9b36962caae2df0662ac98/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/comment/CommentComposer.java#L38). This creates a problem that all the tests are going to automatically fail when new year comes. Updating all the golden files' copyright to 2025 in this PR for now. 

There are golden test files need to be updated in spring-cloud-gcp as well since it is dependent on the generator.

In the future, we need to come up with a better strategy that the tests do not fail automatically, created an issue https://github.com/googleapis/sdk-platform-java/issues/3547 to track the future enhancement.

