### PR TITLE
ci: remove unnecessary distributionManagement section

### DIFF
--- a/java-common-protos/pom.xml
+++ b/java-common-protos/pom.xml
@@ -31,16 +31,6 @@
   <organization>
     <name>Google LLC</name>
   </organization>
-  <distributionManagement>
-    <snapshotRepository>
-      <id>sonatype-nexus-snapshots</id>
-      <url>https://google.oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>sonatype-nexus-staging</id>
-      <url>https://google.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
   <licenses>
     <license>
       <name>Apache-2.0</name>

--- a/java-iam/pom.xml
+++ b/java-iam/pom.xml
@@ -31,16 +31,6 @@
   <organization>
     <name>Google LLC</name>
   </organization>
-  <distributionManagement>
-    <snapshotRepository>
-      <id>sonatype-nexus-snapshots</id>
-      <url>https://google.oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>sonatype-nexus-staging</id>
-      <url>https://google.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
   <licenses>
     <license>
       <name>Apache-2.0</name>


### PR DESCRIPTION
The distributionManagement declared in the pom.xml files interferes the upload to GCP ArtifactRegistry because it tries to
upload artifacts to google.oss.sonatype.org even when you try to upload artifacts to GCP Artifact Registry (b/377328233#comment9).

The distributionManagement is already configured in the parent POM at
https://github.com/googleapis/java-shared-config/blob/6d526a3129f585338b14dab8f041e56dbaae4cd5/native-image-shared-config/pom.xml#L42. No need redeclare in these pom.xml files.
