### PR TITLE
chore: add jdk 23 job for showcase tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -263,7 +263,7 @@ jobs:
       - uses: graalvm/setup-graalvm@v1
         with:
           version: '23.0.1'
-          java-version: '21'
+          java-version: '23'
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - run: mvn -version

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -262,7 +262,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
-          version: '23.0.1'
           java-version: '23'
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -263,7 +263,6 @@ jobs:
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: '23'
-          components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - run: mvn -version
       - run: native-image --version

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        java: [ 11, 17 ]
+        java: [ 11, 17]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        java: [ 11, 17, 23]
+        java: [ 11, 17 ]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -214,7 +214,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        java: [ 11, 17, 21 ]
+        java: [ 11, 17, 21, 23 ]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -262,8 +262,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
-          version: '22.3.2'
-          java-version: '17'
+          version: '23.0.1'
+          java-version: '21'
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - run: mvn -version

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        java: [ 11, 17]
+        java: [ 11, 17, 23]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -255,34 +255,6 @@ jobs:
             -P enable-integration-tests \
             --batch-mode \
             --no-transfer-progress
-
-  showcase-native:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: graalvm/setup-graalvm@v1
-        with:
-          java-version: '23'
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: mvn -version
-      - run: native-image --version
-      - name: Install sdk-platform-java
-        run: mvn install -B -ntp -DskipTests -Dclirr.skip -Dcheckstyle.skip
-      - name: Parse showcase version
-        working-directory: showcase/gapic-showcase
-        run: echo "SHOWCASE_VERSION=$(mvn help:evaluate -Dexpression=gapic-showcase.version -q -DforceStdout)" >> "$GITHUB_ENV"
-      - name: Install showcase server
-        run: |
-          sudo mkdir -p /usr/src/showcase
-          sudo chown -R ${USER} /usr/src/
-          curl --location https://github.com/googleapis/gapic-showcase/releases/download/v${{env.SHOWCASE_VERSION}}/gapic-showcase-${{env.SHOWCASE_VERSION}}-linux-amd64.tar.gz --output /usr/src/showcase/showcase-${{env.SHOWCASE_VERSION}}-linux-amd64.tar.gz
-          cd /usr/src/showcase/
-          tar -xf showcase-*
-          ./gapic-showcase run &
-          cd -
-      - name: Build native image
-        working-directory: showcase
-        run: mvn test -Pnative,-showcase -ntp -B
 
   showcase-clirr:
     if: ${{ github.base_ref != '' }} # Only execute on pull_request trigger event


### PR DESCRIPTION
We also remove showcase-native because it's already being [tested in Cloud Build](https://www.google.com/url?q=https://github.com/googleapis/sdk-platform-java/blob/09d9708dec7ef82f7d269c6285a9588dec48ac5d/.cloudbuild/graalvm/cloudbuild-test-a.yaml%23L45&sa=D&source=docs&ust=1737144190134588&usg=AOvVaw0VT7f-vqeGpoSEAKvWhwg9)