### PR TITLE
chore: adjust native-image config for spring-cloud-gcp

### DIFF
--- a/gax-java/gax/src/main/resources/META-INF/native-image/com.google.api/gax/native-image.properties
+++ b/gax-java/gax/src/main/resources/META-INF/native-image/com.google.api/gax/native-image.properties
@@ -4,7 +4,8 @@ Args = --enable-url-protocols=https,http \
   com.google.api.gax.core.GaxProperties,\
   com.google.common.base.Platform,\
   com.google.common.base.Platform$JdkPatternCompiler,\
-  com.google.protobuf.RuntimeVersion \
+  com.google.protobuf.RuntimeVersion,\
+  com.google.protobuf.RuntimeVersion$RuntimeDomain \
   --features=com.google.api.gax.nativeimage.OpenCensusFeature,\
   com.google.api.gax.nativeimage.GoogleJsonClientFeature \
   --add-modules=jdk.httpserver


### PR DESCRIPTION
Context: upgrading to GraalVM for JDK 23

Updating the image support in spring (https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/3536) caused errors at analysis time solved by https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/3536/commits/d3f6185f6f1cbca811ca22d8abe3b4149ea7877a

Gax seems to be a better place for this kind of configs.
