### PR TITLE
fix: Avoid creating message string prematurely for streaming calls

### DIFF
--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/StateCheckingResponseObserver.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/StateCheckingResponseObserver.java
@@ -43,7 +43,7 @@ public abstract class StateCheckingResponseObserver<V> implements ResponseObserv
    * ensuring consistent state.
    */
   public final void onStart(StreamController controller) {
-    Preconditions.checkState(!isStarted, getClass() + " is already started.");
+    Preconditions.checkState(!isStarted, "%s is already started.", getClass());
     isStarted = true;
 
     onStartImpl(controller);
@@ -56,7 +56,7 @@ public abstract class StateCheckingResponseObserver<V> implements ResponseObserv
    * consistent state.
    */
   public final void onResponse(V response) {
-    Preconditions.checkState(!isClosed, getClass() + " received a response after being closed.");
+    Preconditions.checkState(!isClosed, "%s received a response after being closed.", getClass());
     onResponseImpl(response);
   }
 
@@ -67,7 +67,7 @@ public abstract class StateCheckingResponseObserver<V> implements ResponseObserv
    * state.
    */
   public final void onComplete() {
-    Preconditions.checkState(!isClosed, getClass() + " tried to double close.");
+    Preconditions.checkState(!isClosed, "%s tried to double close.", getClass());
     isClosed = true;
     onCompleteImpl();
   }
@@ -79,7 +79,7 @@ public abstract class StateCheckingResponseObserver<V> implements ResponseObserv
    * consistent state.
    */
   public final void onError(Throwable t) {
-    Preconditions.checkState(!isClosed, getClass() + " received error after being closed", t);
+    Preconditions.checkState(!isClosed, "%s received error after being closed", t, getClass());
     isClosed = true;
     onErrorImpl(t);
   }


### PR DESCRIPTION
- Creating the string message prematurely puts a lot of strain on the JVM and GC, switch to the format version of `Preconditions.checkState` which only constructs the string if we throw the exception
- Issue: https://github.com/googleapis/sdk-platform-java/issues/3621

Thank you for opening a Pull Request! Before submitting your PR, please read our [contributing guidelines](https://github.com/googleapis/gapic-generator-java/blob/main/CONTRIBUTING.md). 

There are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/gapic-generator-java/issues/new/choose) before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #3621 ☕️