### PR TITLE
deps: Update opentelemetry-semconv to v1.29.0-alpha

### DIFF
--- a/java-shared-dependencies/third-party-dependencies/pom.xml
+++ b/java-shared-dependencies/third-party-dependencies/pom.xml
@@ -38,7 +38,7 @@
     <j2objc-annotations.version>3.0.0</j2objc-annotations.version>
     <google.cloud.opentelemetry.version>0.33.0</google.cloud.opentelemetry.version>
     <opentelemetry-grpc-instrumentation.version>2.1.0-alpha</opentelemetry-grpc-instrumentation.version>
-    <opentelemetry-semconv.version>1.26.0-alpha</opentelemetry-semconv.version>
+    <opentelemetry-semconv.version>1.29.0-alpha</opentelemetry-semconv.version>
     <flogger.version>0.8</flogger.version>
     <arrow.version>15.0.2</arrow.version>
     <dev.cel.version>0.6.0</dev.cel.version>
@@ -144,10 +144,12 @@
         <artifactId>opentelemetry-semconv</artifactId>
         <version>${opentelemetry-semconv.version}</version>
       </dependency>
+      <!-- io.opentelemetry:opentelemetry-semconv is to be removed: https://github.com/googleapis/sdk-platform-java/issues/3598 -->
+      <!-- Does not share the same version as the dep above. Hard-code the version for now -->
       <dependency>
         <groupId>io.opentelemetry</groupId>
         <artifactId>opentelemetry-semconv</artifactId>
-        <version>${opentelemetry-semconv.version}</version>
+        <version>1.26.0-alpha</version>
       </dependency>
       <dependency>
         <groupId>com.google.cloud.opentelemetry</groupId>


### PR DESCRIPTION
Discovered as part of CI error in https://github.com/googleapis/google-cloud-java/pull/11426

```
Error:  Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.5.0:enforce (enforce) on project google-cloud-notification: 
Error:  Rule 2: org.apache.maven.enforcer.rules.dependency.RequireUpperBoundDeps failed with message:
Error:  Failed while enforcing RequireUpperBoundDeps. The error(s) are [
Error:  Require upper bound dependencies error for io.opentelemetry.semconv:opentelemetry-semconv:1.26.0-alpha paths to dependency are:
Error:  +-com.google.cloud:google-cloud-notification:0.176.0-beta-SNAPSHOT
Error:    +-com.google.cloud:google-cloud-storage:2.48.1
Error:      +-io.opentelemetry.semconv:opentelemetry-semconv:1.26.0-alpha (managed) <-- io.opentelemetry.semconv:opentelemetry-semconv:1.27.0-alpha
Error:  ]
```