### PR TITLE
chore: update library-generation image to use latest alpine

### DIFF
--- a/.cloudbuild/library_generation/library_generation.Dockerfile
+++ b/.cloudbuild/library_generation/library_generation.Dockerfile
@@ -47,7 +47,7 @@ RUN git checkout "${GLIB_MUS_SHA}"
 RUN chmod a+x compile-x86_64-alpine-linux.sh
 RUN sh compile-x86_64-alpine-linux.sh
 
-FROM docker.io/library/python:3.13.2-alpine3.20@sha256:816feb29731cdee64b15b0ae91dd9f1cbc36765984ff8ea85a3d90f064417237 as final
+FROM docker.io/library/3.12-alpine3.21@sha256:8ec4eab7acc61b424ce9def281ad80365509ee71fd5373c6a05df34e45843afd as final
 
 ARG OWLBOT_CLI_COMMITTISH=3a68a9c0de318784b3aefadcc502a6521b3f1bc5
 ARG PROTOC_VERSION=25.5


### PR DESCRIPTION
This image has rsync 4.x, however other existing images may still have rsync 3.x

Next steps:
 - [ ] merge this PR
 - [ ] wait for next release of sdk-platform-java
 - [ ] ensure all downstream repos use the latest image
 - [ ] remove old versions of this image