### PR TITLE
fix: S2A gRPC flow creates ComputeEngineCredentials via newBuilder.

### DIFF
--- a/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
+++ b/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
@@ -1208,8 +1208,8 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
               ComputeEngineCredentials.newBuilder()
                   .setScopes(credsBuilder.getScopes())
                   .setHttpTransportFactory(credsBuilder.getHttpTransportFactory())
-                  .setGoogleAuthTransport(ComputeEngineCredentials.GoogleAuthTransport.MTLS)
-                  .setBindingEnforcement(ComputeEngineCredentials.BindingEnforcement.ON)
+                  .setGoogleAuthTransport(googleAuthTransport)
+                  .setBindingEnforcement(bindingEnforcement)
                   .build());
     }
 

--- a/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
+++ b/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
@@ -1199,14 +1199,18 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
     CallCredentials createHardBoundTokensCallCredentials(
         ComputeEngineCredentials.GoogleAuthTransport googleAuthTransport,
         ComputeEngineCredentials.BindingEnforcement bindingEnforcement) {
+      ComputeEngineCredentials.Builder credsBuilder =
+          ((ComputeEngineCredentials) credentials).toBuilder();
       // We only set scopes and HTTP transport factory from the original credentials because
       // only those are used in gRPC CallCredentials to fetch request metadata.
-      return MoreCallCredentials.from(
-          ((ComputeEngineCredentials) this.credentials)
-              .toBuilder()
-              .setGoogleAuthTransport(googleAuthTransport)
-              .setBindingEnforcement(bindingEnforcement)
-              .build());
+      CallCredentials callCreds =
+          MoreCallCredentials.from(
+              ComputeEngineCredentials.newBuilder()
+                  .setScopes(credsBuilder.getScopes())
+                  .setHttpTransportFactory(credsBuilder.getHttpTransportFactory())
+                  .setGoogleAuthTransport(ComputeEngineCredentials.GoogleAuthTransport.MTLS)
+                  .setBindingEnforcement(ComputeEngineCredentials.BindingEnforcement.ON)
+                  .build());
     }
 
     public InstantiatingGrpcChannelProvider build() {

--- a/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
+++ b/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
@@ -1203,14 +1203,13 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
           ((ComputeEngineCredentials) credentials).toBuilder();
       // We only set scopes and HTTP transport factory from the original credentials because
       // only those are used in gRPC CallCredentials to fetch request metadata.
-      CallCredentials callCreds =
-          MoreCallCredentials.from(
-              ComputeEngineCredentials.newBuilder()
-                  .setScopes(credsBuilder.getScopes())
-                  .setHttpTransportFactory(credsBuilder.getHttpTransportFactory())
-                  .setGoogleAuthTransport(googleAuthTransport)
-                  .setBindingEnforcement(bindingEnforcement)
-                  .build());
+      return MoreCallCredentials.from(
+          ComputeEngineCredentials.newBuilder()
+              .setScopes(credsBuilder.getScopes())
+              .setHttpTransportFactory(credsBuilder.getHttpTransportFactory())
+              .setGoogleAuthTransport(googleAuthTransport)
+              .setBindingEnforcement(bindingEnforcement)
+              .build());
     }
 
     public InstantiatingGrpcChannelProvider build() {

--- a/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
+++ b/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
@@ -1202,7 +1202,13 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
       ComputeEngineCredentials.Builder credsBuilder =
           ((ComputeEngineCredentials) credentials).toBuilder();
       // We only set scopes and HTTP transport factory from the original credentials because
-      // only those are used in gRPC CallCredentials to fetch request metadata.
+      // only those are used in gRPC CallCredentials to fetch request metadata. We create a new
+      // credential
+      // via {@code newBuilder} as opposed to {@code toBuilder} because we don't want a reference to
+      // the
+      // access token held by {@code credentials}; we want this new credential to fetch a new access
+      // token
+      // from MDS using the {@param googleAuthTransport} and {@param bindingEnforcement}.
       return MoreCallCredentials.from(
           ComputeEngineCredentials.newBuilder()
               .setScopes(credsBuilder.getScopes())


### PR DESCRIPTION
@rockspore pointed out that the credential should be created from scratch because when using [toBuilder](https://github.com/googleapis/google-auth-library-java/blob/main/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java#L648) the underlying [access token is copied](https://github.com/googleapis/google-auth-library-java/blob/37d228410e99799e4a7be8650fe472ea712c9b4d/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java#L657). 

This was confirmed to be a bug with local testing which:
- deployed a GAE app, the app performs the below two actions sequentially
- create Google API client ( `allowedHardBoundAccessTokens` empty in GrpcProvider) and then ping the API, logs show the bearer token is used, obtained from making call to MDS
- create a Google API client  ( `allowedHardBoundAccessTokens` contains `MTLS_S2A` in GrpcProvider) and then ping the API, logs show the bearer token is used. A call to MDS is **not** made. 

This is likely because the credential and channel have different lifetimes.