### PR TITLE
chore: checking the Java formatter test

### DIFF
--- a/java-core/google-cloud-core/src/main/java/com/google/cloud/Service.java
+++ b/java-core/google-cloud-core/src/main/java/com/google/cloud/Service.java
@@ -22,6 +22,4 @@ package com.google.cloud;
  * @param <OptionsT> the {@code ServiceOptions} subclass corresponding to the service
  */
 public interface Service<OptionsT extends ServiceOptions<?, OptionsT>> {
-
-  OptionsT getOptions();
-}
+OptionsT getOptions();}


### PR DESCRIPTION
Does the Java formatter really run?
Looking at https://github.com/googleapis/java-shared-config/blob/f4daddb30447165f73e2b5d8bcb8436c684cf5fb/java-shared-config/pom.xml#L172,
it only be configured as pluginManagement and it doesn't seem to
be configured run in CI builds.
