### PR TITLE
chore: Update README and CI with the new name of showcase module.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -304,7 +304,7 @@ jobs:
         run: |
           mvn install -B -ntp -T 1C -DskipTests
           # change to `cd java-showcase` once https://github.com/googleapis/sdk-platform-java/pull/3568/ is merged
-          cd showcase
+          cd java-showcase
           mvn install -B -ntp -T 1C -DskipTests
           SHOWCASE_CLIENT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           echo "SHOWCASE_CLIENT_VERSION=$SHOWCASE_CLIENT_VERSION" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -303,7 +303,6 @@ jobs:
       - name: Install sdk-platform-java and showcase to local maven repository
         run: |
           mvn install -B -ntp -T 1C -DskipTests
-          # change to `cd java-showcase` once https://github.com/googleapis/sdk-platform-java/pull/3568/ is merged
           cd java-showcase
           mvn install -B -ntp -T 1C -DskipTests
           SHOWCASE_CLIENT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)

--- a/java-showcase/README.md
+++ b/java-showcase/README.md
@@ -17,7 +17,7 @@ update to a compatible client version in `./WORKSPACE`.
 
 ```shell
 # Install the showcase server version defined in gapic-showcase/pom.xml
-cd showcase
+cd java-showcase
 go install github.com/googleapis/gapic-showcase/cmd/gapic-showcase@v"$(cd gapic-showcase;mvn help:evaluate -Dexpression=gapic-showcase.version -q -DforceStdout |sed 's/\x1b\[[0-9;]*m//g')"
 PATH=$PATH:`go env GOPATH`/bin
 gapic-showcase --help
@@ -67,7 +67,7 @@ Open a new terminal window in the root project directory.
 This step does not require Docker.
 
 ```shell
-cd showcase
+cd java-showcase
 mvn verify -P enable-integration-tests
 ```
 


### PR DESCRIPTION
https://github.com/googleapis/sdk-platform-java/pull/3568 updated the name `showcase` module to `java-showcase`. This PR updates a few places that still reference the old name to the new name.