### PR TITLE
test: Reduce the LRO timeout value in Showcase tests

### DIFF
--- a/java-showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITLongRunningOperation.java
+++ b/java-showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITLongRunningOperation.java
@@ -161,17 +161,17 @@ class ITLongRunningOperation {
       throws Exception {
     RetrySettings initialUnaryRetrySettings =
         RetrySettings.newBuilder()
-            .setInitialRpcTimeout(Duration.ofMillis(5000L))
+            .setInitialRpcTimeout(Duration.ofMillis(500L))
             .setRpcTimeoutMultiplier(1.0)
-            .setMaxRpcTimeout(Duration.ofMillis(5000L))
-            .setTotalTimeout(Duration.ofMillis(5000L))
+            .setMaxRpcTimeout(Duration.ofMillis(500L))
+            .setTotalTimeout(Duration.ofMillis(500L))
             .build();
     RetrySettings pollingRetrySettings =
         RetrySettings.newBuilder()
-            .setInitialRetryDelay(Duration.ofMillis(1000L))
+            .setInitialRetryDelay(Duration.ofMillis(100L))
             .setRetryDelayMultiplier(2.0)
-            .setMaxRetryDelay(Duration.ofMillis(3000L))
-            .setTotalTimeout(Duration.ofMillis(5000L))
+            .setMaxRetryDelay(Duration.ofMillis(500L))
+            .setTotalTimeout(Duration.ofMillis(1000L))
             .build();
     EchoClient httpjsonClient =
         TestClientInitializer.createHttpJsonEchoClientCustomWaitSettings(


### PR DESCRIPTION
fixes: https://github.com/googleapis/sdk-platform-java/issues/3277

I run the flaky test locally 1000 times but couldn't reproduce the issue. Despite that, reduce the LRO timeout values in the Showcase test `ITLongRunningOperation.testHttpJson_LROUnsuccessfulResponse_exceedsTotalTimeout_throwsDeadlineExceededException` could make the test scenario fail fast and less flaky.



