### PR TITLE
chore: fix showcase clirr test after java-showcase renaming

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -304,7 +304,7 @@ jobs:
         run: |
           mvn install -B -ntp -T 1C -DskipTests
           # change to `cd java-showcase` once https://github.com/googleapis/sdk-platform-java/pull/3568/ is merged
-          cd showcase
+          cd java-showcase
           mvn install -B -ntp -T 1C -DskipTests
           SHOWCASE_CLIENT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           echo "SHOWCASE_CLIENT_VERSION=$SHOWCASE_CLIENT_VERSION" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -303,7 +303,6 @@ jobs:
       - name: Install sdk-platform-java and showcase to local maven repository
         run: |
           mvn install -B -ntp -T 1C -DskipTests
-          # change to `cd java-showcase` once https://github.com/googleapis/sdk-platform-java/pull/3568/ is merged
           cd java-showcase
           mvn install -B -ntp -T 1C -DskipTests
           SHOWCASE_CLIENT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)


### PR DESCRIPTION
observed in https://github.com/googleapis/sdk-platform-java/actions/runs/13730578942/job/38406676526?pr=3684

#3568 is merged.