### PR TITLE
chore: fix logback-classic version for testing

### DIFF
--- a/java-showcase/gapic-showcase/pom.xml
+++ b/java-showcase/gapic-showcase/pom.xml
@@ -281,7 +281,7 @@
         <dependency>
           <groupId>ch.qos.logback</groupId>
           <artifactId>logback-classic</artifactId>
-          <version>1.2.13</version>
+          <version>1.3.15</version>
           <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This should be consistent with logback-core version. 1.3.x used because we test java 11+ in showcase

(typo in commit message, logback-classic is the one fixed)