### PR TITLE
chore: add aliases to generate command options.

### DIFF
--- a/hermetic_build/library_generation/cli/entry_point.py
+++ b/hermetic_build/library_generation/cli/entry_point.py
@@ -50,6 +50,7 @@ def main(ctx):
 )
 @click.option(
     "--repository-path",
+    "--output",
     type=str,
     default=".",
     show_default=True,
@@ -62,6 +63,7 @@ def main(ctx):
 )
 @click.option(
     "--api-definitions-path",
+    "--api-root",
     type=str,
     default=".",
     show_default=True,


### PR DESCRIPTION
Adding alias to repository-path and api-definitions-path to be compatible with Librarian [options](https://github.com/googleapis/librarian/blob/d3f78d51103c523da60251e790c05a681331192a/internal/command/flags.go#L40) 

[click options](https://click.palletsprojects.com/en/stable/options/) allows alias directly, so this change is trivial and does not affect any existing usage cases.