### PR TITLE
build(deps): update dependency com.google.cloud:google-cloud-shared-config to v1.15.0

### DIFF
--- a/.cloudbuild/graalvm/cloudbuild-test-a-downstream-kms.yaml
+++ b/.cloudbuild/graalvm/cloudbuild-test-a-downstream-kms.yaml
@@ -15,7 +15,7 @@
 timeout: 7200s # 2 hours
 substitutions:
   _SHARED_DEPENDENCIES_VERSION: '3.30.1-SNAPSHOT' # {x-version-update:google-cloud-shared-dependencies:current}
-  _JAVA_SHARED_CONFIG_VERSION: '1.14.4'
+  _JAVA_SHARED_CONFIG_VERSION: '1.15.0'
 options:
   machineType: 'E2_HIGHCPU_8'
   logging: CLOUD_LOGGING_ONLY

--- a/.cloudbuild/graalvm/cloudbuild-test-a-downstream-kmsinventory.yaml
+++ b/.cloudbuild/graalvm/cloudbuild-test-a-downstream-kmsinventory.yaml
@@ -15,7 +15,7 @@
 timeout: 7200s # 2 hours
 substitutions:
   _SHARED_DEPENDENCIES_VERSION: '3.30.1-SNAPSHOT' # {x-version-update:google-cloud-shared-dependencies:current}
-  _JAVA_SHARED_CONFIG_VERSION: '1.14.4'
+  _JAVA_SHARED_CONFIG_VERSION: '1.15.0'
 options:
   machineType: 'E2_HIGHCPU_8'
   logging: CLOUD_LOGGING_ONLY

--- a/.cloudbuild/graalvm/cloudbuild-test-a.yaml
+++ b/.cloudbuild/graalvm/cloudbuild-test-a.yaml
@@ -15,7 +15,7 @@
 timeout: 7200s # 2 hours
 substitutions:
   _SHARED_DEPENDENCIES_VERSION: '3.44.1-SNAPSHOT' # {x-version-update:google-cloud-shared-dependencies:current}
-  _JAVA_SHARED_CONFIG_VERSION: '1.14.4'
+  _JAVA_SHARED_CONFIG_VERSION: '1.15.0'
 options:
   machineType: 'E2_HIGHCPU_8'
   logging: CLOUD_LOGGING_ONLY

--- a/.cloudbuild/graalvm/cloudbuild-test-b-downstream-kms.yaml
+++ b/.cloudbuild/graalvm/cloudbuild-test-b-downstream-kms.yaml
@@ -15,7 +15,7 @@
 timeout: 7200s # 2 hours
 substitutions:
   _SHARED_DEPENDENCIES_VERSION: '3.30.1-SNAPSHOT' # {x-version-update:google-cloud-shared-dependencies:current}
-  _JAVA_SHARED_CONFIG_VERSION: '1.14.4'
+  _JAVA_SHARED_CONFIG_VERSION: '1.15.0'
 options:
   machineType: 'E2_HIGHCPU_8'
   logging: CLOUD_LOGGING_ONLY

--- a/.cloudbuild/graalvm/cloudbuild-test-b-downstream-kmsinventory.yaml
+++ b/.cloudbuild/graalvm/cloudbuild-test-b-downstream-kmsinventory.yaml
@@ -15,7 +15,7 @@
 timeout: 7200s # 2 hours
 substitutions:
   _SHARED_DEPENDENCIES_VERSION: '3.30.1-SNAPSHOT' # {x-version-update:google-cloud-shared-dependencies:current}
-  _JAVA_SHARED_CONFIG_VERSION: '1.14.4'
+  _JAVA_SHARED_CONFIG_VERSION: '1.15.0'
 options:
   machineType: 'E2_HIGHCPU_8'
   logging: CLOUD_LOGGING_ONLY

--- a/.cloudbuild/graalvm/cloudbuild-test-b.yaml
+++ b/.cloudbuild/graalvm/cloudbuild-test-b.yaml
@@ -15,7 +15,7 @@
 timeout: 7200s # 2 hours
 substitutions:
   _SHARED_DEPENDENCIES_VERSION: '3.44.1-SNAPSHOT' # {x-version-update:google-cloud-shared-dependencies:current}
-  _JAVA_SHARED_CONFIG_VERSION: '1.14.4'
+  _JAVA_SHARED_CONFIG_VERSION: '1.15.0'
 options:
   machineType: 'E2_HIGHCPU_8'
   logging: CLOUD_LOGGING_ONLY

--- a/.cloudbuild/graalvm/cloudbuild.yaml
+++ b/.cloudbuild/graalvm/cloudbuild.yaml
@@ -15,7 +15,7 @@
 timeout: 7200s # 2 hours
 substitutions:
   _SHARED_DEPENDENCIES_VERSION: '3.44.1-SNAPSHOT' # {x-version-update:google-cloud-shared-dependencies:current}
-  _JAVA_SHARED_CONFIG_VERSION: '1.14.4'
+  _JAVA_SHARED_CONFIG_VERSION: '1.15.0'
 steps:
   # GraalVM A build
   - name: gcr.io/cloud-builders/docker

--- a/gapic-generator-java-pom-parent/pom.xml
+++ b/gapic-generator-java-pom-parent/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-shared-config</artifactId>
-    <version>1.14.4</version>
+    <version>1.15.0</version>
     <relativePath/>
   </parent>
 

--- a/gax-java/gax-bom/pom.xml
+++ b/gax-java/gax-bom/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-shared-config</artifactId>
-    <version>1.14.4</version>
+    <version>1.15.0</version>
     <relativePath/>
   </parent>
 

--- a/java-shared-dependencies/first-party-dependencies/pom.xml
+++ b/java-shared-dependencies/first-party-dependencies/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-shared-config</artifactId>
-    <version>1.14.4</version>
+    <version>1.15.0</version>
     <relativePath />
   </parent>
 

--- a/java-shared-dependencies/upper-bound-check/pom.xml
+++ b/java-shared-dependencies/upper-bound-check/pom.xml
@@ -16,7 +16,7 @@
     <groupId>com.google.cloud</groupId>
     <!-- The shared config has RequireUpperBoundDeps enforcer rule -->
     <artifactId>google-cloud-shared-config</artifactId>
-    <version>1.14.4</version>
+    <version>1.15.0</version>
     <relativePath/>
   </parent>
 

--- a/java-showcase/pom.xml
+++ b/java-showcase/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-shared-config</artifactId>
-    <version>1.14.4</version>
+    <version>1.15.0</version>
     <relativePath/>
   </parent>
 

--- a/sdk-platform-java-config/pom.xml
+++ b/sdk-platform-java-config/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-shared-config</artifactId>
-        <version>1.14.4</version>
+        <version>1.15.0</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
RenovateBot is not creating a pull request for the version. I created this manually based on the previous pull request
https://github.com/googleapis/sdk-platform-java/pull/3655/files.
