### PR TITLE
deps: revert "deps: update arrow.version to v18.2.0"

### DIFF
--- a/java-shared-dependencies/third-party-dependencies/pom.xml
+++ b/java-shared-dependencies/third-party-dependencies/pom.xml
@@ -40,7 +40,7 @@
     <opentelemetry-grpc-instrumentation.version>2.1.0-alpha</opentelemetry-grpc-instrumentation.version>
     <opentelemetry-semconv.version>1.29.0-alpha</opentelemetry-semconv.version>
     <flogger.version>0.8</flogger.version>
-    <arrow.version>18.2.0</arrow.version>
+    <arrow.version>15.0.2</arrow.version>
     <dev.cel.version>0.6.0</dev.cel.version>
     <com.google.crypto.tink.version>1.16.0</com.google.crypto.tink.version>
   </properties>


### PR DESCRIPTION
Reverts googleapis/sdk-platform-java#3675

Due to JDK11+ requirement in arrow 18.
https://arrow.apache.org/docs/18.0/java/install.html#java-compatibility