### PR TITLE
chore: allow generation-input as folder that supplies config and vers…

### DIFF
--- a/hermetic_build/library_generation/cli/entry_point.py
+++ b/hermetic_build/library_generation/cli/entry_point.py
@@ -37,6 +37,9 @@ def main(ctx):
     help="""
     Absolute or relative path to a generation_config.yaml that contains the
     metadata about library generation.
+    When not set, will use generation_config.yaml from --generation-input.
+    When neither this or --generation-input is set default to 
+    generation_config.yaml in the current working directory 
     """,
 )
 @click.option(
@@ -47,7 +50,9 @@ def main(ctx):
     help="""
     Absolute or relative path to a input folder that contains 
     generation_config.yaml and versions.txt.
-    This is only used when generation-config-path is not set.
+    This is only used when --generation-config-path is not set.
+    When neither this or --generation-config-path is set default to 
+    generation_config.yaml in the current working directory 
     """,
 )
 @click.option(
@@ -142,6 +147,7 @@ def __generate_repo_impl(
         # override if present.
         _copy_versions_file(generation_input, repository_path)
     if generation_config_path is None and generation_input is None:
+        print("Using default generation config path")
         generation_config_path = default_generation_config_path
     generation_config_path = os.path.abspath(generation_config_path)
     if not os.path.isfile(generation_config_path):

--- a/hermetic_build/library_generation/cli/entry_point.py
+++ b/hermetic_build/library_generation/cli/entry_point.py
@@ -137,15 +137,6 @@ def __generate_repo_impl(
         print(
             "generation_config_path is not provided, using generation-input folder provided"
         )
-        source_file = Path(generation_input) / "versions.txt"
-        destination_file = Path(repository_path) / "versions.txt"
-
-        # perhaps allow not present and create an empty one?
-        if not source_file.exists():
-            raise FileNotFoundError(
-                f"Source file not found from {generation_input}: {source_file}"
-            )
-
         generation_config_path = f"{generation_input}/generation_config.yaml"
         # copy versions.txt from generation_input to repository_path
         # override if present.
@@ -183,17 +174,18 @@ def _copy_versions_file(generation_input_path, repository_path):
     source_file = Path(generation_input_path) / "versions.txt"
     destination_file = Path(repository_path) / "versions.txt"
 
-    # perhaps allow not present and create an empty one?
     if not source_file.exists():
-        raise FileNotFoundError(
-            f"Source file not found from {generation_input_path}: {source_file}"
+        destination_file.touch()
+        print(
+            f"generation-input does not contain versions.txt. "
+            f"Created empty versions file: {source_file}"
         )
+        return
     try:
-        # Use shutil.copyfile to copy the file, overwriting if it exists.
         shutil.copy2(source_file, destination_file)
         print(f"Copied '{source_file}' to '{destination_file}'")
     except Exception as e:
-        print(f"An error occurred while copying the file: {e}")
+        print(f"An error occurred while copying the versions.txt: {e}")
 
 
 def _needs_full_repo_generation(generation_config: GenerationConfig) -> bool:

--- a/hermetic_build/library_generation/cli/entry_point.py
+++ b/hermetic_build/library_generation/cli/entry_point.py
@@ -126,7 +126,7 @@ def __generate_repo_impl(
     library_names: Optional[str],
     repository_path: str,
     api_definitions_path: str,
-    generation_input: Optional[str] = None,
+    generation_input: Optional[str],
 ):
     """
     Implementation method for generate().

--- a/hermetic_build/library_generation/generate_repo.py
+++ b/hermetic_build/library_generation/generate_repo.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import shutil
+from pathlib import Path
 from typing import Optional
 import library_generation.utils.utilities as util
 from common.model.generation_config import GenerationConfig
@@ -64,6 +65,14 @@ def generate_from_yaml(
     monorepo_postprocessing(
         repository_path=repository_path, versions_file=repo_config.versions_file
     )
+
+    # cleanup temp output folder
+    try:
+        shutil.rmtree(Path(repo_config.output_folder))
+        print(f"Directory {repo_config.output_folder} and its contents removed.")
+    except OSError as e:
+        print(f"Error: {e} - Failed to remove directory {repo_config.output_folder}.")
+        raise
 
 
 def get_target_libraries(

--- a/hermetic_build/library_generation/tests/cli/entry_point_unit_tests.py
+++ b/hermetic_build/library_generation/tests/cli/entry_point_unit_tests.py
@@ -51,6 +51,20 @@ class EntryPointTest(unittest.TestCase):
         self.assertEqual(FileNotFoundError, result.exc_info[0])
         self.assertRegex(result.exception.args[0], "/non-existent/file does not exist.")
 
+    def test_entry_point_with_invalid_generation_input_raise_file_exception(
+        self,
+    ):
+        os.chdir(script_dir)
+        runner = CliRunner()
+        # noinspection PyTypeChecker
+        result = runner.invoke(generate, ["--generation-input=/non-existent/folder"])
+        self.assertEqual(1, result.exit_code)
+        self.assertEqual(FileNotFoundError, result.exc_info[0])
+        self.assertRegex(
+            result.exception.args[0],
+            "/non-existent/folder/generation_config.yaml does not exist.",
+        )
+
     def test_validate_generation_config_succeeds(
         self,
     ):
@@ -96,6 +110,7 @@ class EntryPointTest(unittest.TestCase):
         # does special handling when a method is annotated with @main.command()
         generate_impl(
             generation_config_path=config_path,
+            generation_input=None,
             library_names=None,
             repository_path=".",
             api_definitions_path=".",
@@ -124,6 +139,7 @@ class EntryPointTest(unittest.TestCase):
         # does special handling when a method is annotated with @main.command()
         generate_impl(
             generation_config_path=config_path,
+            generation_input=None,
             library_names="non-existent-library",
             repository_path=".",
             api_definitions_path=".",
@@ -152,6 +168,7 @@ class EntryPointTest(unittest.TestCase):
         # does special handling when a method is annotated with @main.command()
         generate_impl(
             generation_config_path=config_path,
+            generation_input=None,
             library_names=None,
             repository_path=".",
             api_definitions_path=".",
@@ -179,6 +196,7 @@ class EntryPointTest(unittest.TestCase):
         # does special handling when a method is annotated with @main.command()
         generate_impl(
             generation_config_path=config_path,
+            generation_input=None,
             library_names="iam,non-existent-library",
             repository_path=".",
             api_definitions_path=".",
@@ -208,6 +226,7 @@ class EntryPointTest(unittest.TestCase):
         # does special handling when a method is annotated with @main.command()
         generate_impl(
             generation_config_path=config_path,
+            generation_input=None,
             library_names=None,
             repository_path=".",
             api_definitions_path=".",
@@ -237,6 +256,7 @@ class EntryPointTest(unittest.TestCase):
         # does special handling when a method is annotated with @main.command()
         generate_impl(
             generation_config_path=config_path,
+            generation_input=None,
             library_names="asset",
             repository_path=".",
             api_definitions_path=".",
@@ -264,10 +284,10 @@ class EntryPointTest(unittest.TestCase):
         # does special handling when a method is annotated with @main.command()
         generate_impl(
             generation_config_path=None,
+            generation_input=test_resource_dir,
             library_names="asset",
             repository_path="./test-output",
             api_definitions_path=".",
-            generation_input=test_resource_dir,
         )
         from_yaml.assert_called_with(os.path.abspath(config_path))
         self.assertTrue(os.path.exists(f"test-output/versions.txt"))

--- a/hermetic_build/library_generation/tests/cli/entry_point_unit_tests.py
+++ b/hermetic_build/library_generation/tests/cli/entry_point_unit_tests.py
@@ -269,10 +269,7 @@ class EntryPointTest(unittest.TestCase):
             api_definitions_path=".",
             generation_input=test_resource_dir,
         )
-        from_yaml.assert_called_with(
-            os.path.abspath(config_path)
-            # config_path
-        )
+        from_yaml.assert_called_with(os.path.abspath(config_path))
         self.assertTrue(os.path.exists(f"test-output/versions.txt"))
 
     def tearDown(self):
@@ -281,10 +278,6 @@ class EntryPointTest(unittest.TestCase):
             shutil.rmtree(Path("./output"))
         if os.path.exists("./test-output"):
             shutil.rmtree(Path("./test-output"))
-        # # if os.path.exists(f"{test_resource_dir}/versions.txt"):
-        # #     os.remove(f"{test_resource_dir}/versions.txt")
-        # if os.path.exists(f"test-output/versions.txt"):
-        #     os.remove(f"test-output/versions.txt")
 
     def _create_folder_in_current_dir(self, folder_name):
         """Creates a folder in the current directory."""

--- a/hermetic_build/library_generation/utils/utilities.py
+++ b/hermetic_build/library_generation/utils/utilities.py
@@ -159,14 +159,14 @@ def prepare_repo(
         json_name = ".repo-metadata.json"
         if os.path.exists(f"{absolute_library_path}/{json_name}"):
             os.remove(f"{absolute_library_path}/{json_name}")
-    versions_file = f"{repo_path}/versions.txt"
-    if not Path(versions_file).exists():
-        raise FileNotFoundError(f"{versions_file} is not found.")
-
+    versions_file = Path(repo_path) / "versions.txt"
+    if not versions_file.exists():
+        versions_file.touch()
+        print(f"Created empty versions file: {versions_file}")
     return RepoConfig(
         output_folder=output_folder,
         libraries=libraries,
-        versions_file=str(Path(versions_file).resolve()),
+        versions_file=str(versions_file),
     )
 
 


### PR DESCRIPTION
…ions file.

This change adds `--generation-input` option to generation command, only intend to be used when `--generation-config-path` is not provided. If none of these 2 provided, then default behavior does not change.

Also added a clean up to delete the temp output folder created in generation process. This should only be an improvement to local dev workflow.

cc. @ldetmer 