### PR TITLE
chore: add renovate rule so logback do not bump major versions.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -211,6 +211,11 @@
       "matchPackageNames": [
         "/^com.google.errorprone/"
       ]
+    },
+    {
+      "matchPackageNames": ["ch.qos.logback:logback-classic", "ch.qos.logback:logback-core"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "enabled": true
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -214,7 +214,7 @@
     },
     {
       "matchPackageNames": ["ch.qos.logback:logback-classic", "ch.qos.logback:logback-core"],
-      "matchUpdateTypes": ["minor", "patch"],
+      "matchUpdateTypes": ["patch"],
       "enabled": true
     }
   ]


### PR DESCRIPTION
setting up this so logback versions 1.3.x used to test slf4j 1.x won't be updated.
side effect is 1.5.x won't get updates either when 1.6.x comes out.