### PR TITLE
chore: update logging mod

### DIFF
--- a/.github/workflows/java_sdk_logging.yaml
+++ b/.github/workflows/java_sdk_logging.yaml
@@ -53,3 +53,33 @@ jobs:
       run: |
         mvn -B -ntp fmt:check
       working-directory: java-sdk-logging
+  module-clirr:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
+      with:
+        java-version: 11
+        distribution: temurin
+    - name: Install parent module
+      run: |
+        mvn install -B -ntp -pl gapic-generator-java-pom-parent
+    - name: Clirr check
+      run: |
+        mvn -B -ntp -Denforcer.skip=true clirr:check
+      working-directory: java-sdk-logging
+  module-enforcer:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
+      with:
+        java-version: 11
+        distribution: temurin
+    - name: Install parent module
+      run: |
+        mvn install -B -ntp -pl gapic-generator-java-pom-parent
+    - name: Enforcer check
+      run: |
+        mvn -B -ntp enforcer:enforce@enforce -T 1C
+      working-directory: java-sdk-logging

--- a/java-sdk-logging/license-checks.xml
+++ b/java-sdk-logging/license-checks.xml
@@ -5,6 +5,6 @@
 <module name="Checker">
   <module name="RegexpHeader">
     <property name="fileExtensions" value="java"/>
-    <property name="headerFile" value="./java-sdk-logging/java.header"/>
+    <property name="headerFile" value="./java.header"/>
   </module>
 </module>

--- a/java-sdk-logging/log4j2-extension/pom.xml
+++ b/java-sdk-logging/log4j2-extension/pom.xml
@@ -4,7 +4,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.google.api</groupId>
+    <groupId>com.google.cloud</groupId>
     <artifactId>java-sdk-logging-parent</artifactId>
     <version>0.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>

--- a/java-sdk-logging/logback-extension/pom.xml
+++ b/java-sdk-logging/logback-extension/pom.xml
@@ -4,7 +4,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.google.api</groupId>
+    <groupId>com.google.cloud</groupId>
     <artifactId>java-sdk-logging-parent</artifactId>
     <version>0.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>

--- a/java-sdk-logging/pom.xml
+++ b/java-sdk-logging/pom.xml
@@ -3,6 +3,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <groupId>com.google.cloud</groupId>
   <artifactId>java-sdk-logging-parent</artifactId>
   <version>0.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>


### PR DESCRIPTION
A follow up of #3706:
- Change the group id to `com.google.cloud` as it is a customer-facing library.
- Add clirr and enforcer check in CI.