### PR TITLE
chore: include java-storage-nio changes in GraalVM config

### DIFF
--- a/gax-java/gax/pom.xml
+++ b/gax-java/gax/pom.xml
@@ -99,6 +99,7 @@
                 <include>com/google/api/gax/rpc/testing/**</include>
                 <include>com/google/api/gax/rpc/mtls/**</include>
                 <include>com/google/api/gax/util/**</include>
+                <include>**/native-image.properties</include>
               </includes>
             </configuration>
           </execution>

--- a/gax-java/gax/src/main/resources/META-INF/native-image/com.google.api/gax/native-image.properties
+++ b/gax-java/gax/src/main/resources/META-INF/native-image/com.google.api/gax/native-image.properties
@@ -4,6 +4,10 @@ Args = --enable-url-protocols=https,http \
   com.google.api.gax.core.GaxProperties,\
   com.google.common.base.Platform,\
   com.google.common.base.Platform$JdkPatternCompiler,\
+  com.google.common.collect.ImmutableMapEntry,\
+  com.google.common.collect.RegularImmutableList,\
+  com.google.common.collect.ImmutableMapEntry$NonTerminalImmutableMapEntry,\
+  com.google.common.collect.SingletonImmutableBiMap,\
   com.google.protobuf.RuntimeVersion,\
   com.google.protobuf.RuntimeVersion$RuntimeDomain \
   --features=com.google.api.gax.nativeimage.OpenCensusFeature,\

--- a/gax-java/gax/src/test/resources/META-INF/native-image/com.google.api/gax/native-image.properties
+++ b/gax-java/gax/src/test/resources/META-INF/native-image/com.google.api/gax/native-image.properties
@@ -5,4 +5,5 @@ Args=--initialize-at-build-time=java.lang.annotation.Annotation,\
   org.junit.runner.RunWith,\
   org.junit.runners.model.FrameworkField,\
   org.junit.validator.AnnotationValidator,\
-  org.junit.vintage.engine.discovery.FilterableIgnoringRunnerDecorator
+  org.junit.vintage.engine.discovery.FilterableIgnoringRunnerDecorator,\
+  org.junit.vintage.engine.discovery.IgnoringRunnerDecorator


### PR DESCRIPTION
Follow up from https://github.com/googleapis/sdk-platform-java/pull/3674
Context: Some local changes were not pushed to that PR before it was merged.
Main changes: 
 - include `src/test/.../native-image.properties` in testlib jar
 - include java-storage-nio related classes for initialization at build time