### PR TITLE
chore(hermetic-build): infer formatter version from java-shared-config property

### DIFF
--- a/.cloudbuild/library_generation/library_generation.Dockerfile
+++ b/.cloudbuild/library_generation/library_generation.Dockerfile
@@ -26,7 +26,7 @@ ENV DOCKER_GAPIC_GENERATOR_VERSION="2.55.2-SNAPSHOT"
 # Download the java formatter
 RUN mvn -pl gapic-generator-java-pom-parent help:evaluate -Dexpression='google-java-format.version' -q -DforceStdout > /java-formatter-version
 RUN cat /java-formatter-version
-RUN curl -o "/google-java-format.jar" "https://maven-central.storage-download.googleapis.com/maven2/com/google/googlejavaformat/google-java-format/$(cat /java-formatter-version)/google-java-format-$(cat /java-formatter-version)-all-deps.jar"
+RUN V=$(cat /java-formatter-version) curl -o "/google-java-format.jar" "https://maven-central.storage-download.googleapis.com/maven2/com/google/googlejavaformat/google-java-format/${V}/google-java-format-${V}-all-deps.jar"
 
 # Compile and install packages
 RUN mvn install -B -ntp -DskipTests -Dclirr.skip -Dcheckstyle.skip

--- a/.cloudbuild/library_generation/library_generation.Dockerfile
+++ b/.cloudbuild/library_generation/library_generation.Dockerfile
@@ -26,7 +26,7 @@ ENV DOCKER_GAPIC_GENERATOR_VERSION="2.55.2-SNAPSHOT"
 # Download the java formatter
 RUN mvn -pl gapic-generator-java-pom-parent help:evaluate -Dexpression='google-java-format.version' -q -DforceStdout > /java-formatter-version
 RUN cat /java-formatter-version
-RUN V=$(cat /java-formatter-version) curl -o "/google-java-format.jar" "https://maven-central.storage-download.googleapis.com/maven2/com/google/googlejavaformat/google-java-format/${V}/google-java-format-${V}-all-deps.jar"
+RUN V=$(cat /java-formatter-version) && curl -o "/google-java-format.jar" "https://maven-central.storage-download.googleapis.com/maven2/com/google/googlejavaformat/google-java-format/${V}/google-java-format-${V}-all-deps.jar"
 
 # Compile and install packages
 RUN mvn install -B -ntp -DskipTests -Dclirr.skip -Dcheckstyle.skip

--- a/.cloudbuild/library_generation/library_generation.Dockerfile
+++ b/.cloudbuild/library_generation/library_generation.Dockerfile
@@ -23,6 +23,12 @@ COPY . .
 ENV DOCKER_GAPIC_GENERATOR_VERSION="2.55.2-SNAPSHOT"
 # {x-version-update-end}
 
+# Download the java formatter
+RUN mvn -pl gapic-generator-java-pom-parent help:evaluate -Dexpression='google-java-format.version' -q -DforceStdout > /java-formatter-version
+RUN cat /java-formatter-version
+RUN curl -o "/google-java-format.jar" "https://maven-central.storage-download.googleapis.com/maven2/com/google/googlejavaformat/google-java-format/$(cat /java-formatter-version)/google-java-format-$(cat /java-formatter-version)-all-deps.jar"
+
+# Compile and install packages
 RUN mvn install -B -ntp -DskipTests -Dclirr.skip -Dcheckstyle.skip
 RUN cp "/root/.m2/repository/com/google/api/gapic-generator-java/${DOCKER_GAPIC_GENERATOR_VERSION}/gapic-generator-java-${DOCKER_GAPIC_GENERATOR_VERSION}.jar" \
   "./gapic-generator-java.jar"
@@ -52,7 +58,6 @@ FROM docker.io/library/python:3.13.2-alpine3.20@sha256:816feb29731cdee64b15b0ae9
 ARG OWLBOT_CLI_COMMITTISH=3a68a9c0de318784b3aefadcc502a6521b3f1bc5
 ARG PROTOC_VERSION=25.5
 ARG GRPC_VERSION=1.70.0
-ARG JAVA_FORMAT_VERSION=1.7
 ENV HOME=/home
 ENV OS_ARCHITECTURE="linux-x86_64"
 
@@ -117,6 +122,11 @@ RUN owl-bot copy-code --version
 RUN chmod o+rx $(which owl-bot)
 RUN apk del -r npm && apk cache clean
 
+# copy the Java formatter
+COPY --from=ggj-build "/google-java-format.jar" "${HOME}"/.library_generation/google-java-format.jar
+RUN chmod 755 "${HOME}"/.library_generation/google-java-format.jar
+ENV JAVA_FORMATTER_LOCATION="${HOME}/.library_generation/google-java-format.jar"
+
 # Here we transfer gapic-generator-java from the previous stage.
 # Note that the destination is a well-known location that will be assumed at runtime
 # We hard-code the location string to avoid making it configurable (via ARG) as
@@ -124,12 +134,6 @@ RUN apk del -r npm && apk cache clean
 COPY --from=ggj-build "/sdk-platform-java/gapic-generator-java.jar" "${HOME}/.library_generation/gapic-generator-java.jar"
 RUN chmod 755 "${HOME}/.library_generation/gapic-generator-java.jar"
 ENV GAPIC_GENERATOR_LOCATION="${HOME}/.library_generation/gapic-generator-java.jar"
-
-# download the Java formatter
-ADD https://maven-central.storage-download.googleapis.com/maven2/com/google/googlejavaformat/google-java-format/${JAVA_FORMAT_VERSION}/google-java-format-${JAVA_FORMAT_VERSION}-all-deps.jar \
-  "${HOME}"/.library_generation/google-java-format.jar
-RUN chmod 755 "${HOME}"/.library_generation/google-java-format.jar
-ENV JAVA_FORMATTER_LOCATION="${HOME}/.library_generation/google-java-format.jar"
 
 # allow users to access the script folders
 RUN chmod -R o+rx /src


### PR DESCRIPTION
This ties the google-java-format.jar version to the one [declared in java-shared-config](https://github.com/googleapis/java-shared-config/blob/a315cf154ffb2dfd77ff7ce9892f8bb8a40ec7cc/java-shared-config/pom.xml#L31)

The purpose is to later upgrade this version to avoid the old Guava dependency.

I moved the download step to ggj-build so the final image only copies artifacts from "build related" stages.