### PR TITLE
ci: Use Java 8 for downstream tests

### DIFF
--- a/.github/workflows/downstream.yaml
+++ b/.github/workflows/downstream.yaml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
-          java-version: 17
+          java-version: 8
           distribution: temurin
       - run: mvn -version
       - name: Install xmllint


### PR DESCRIPTION
Testing based on https://github.com/googleapis/sdk-platform-java/pull/3716#issuecomment-2737615278