### PR TITLE
chore: update lint workflow template to use Java 17

### DIFF
--- a/hermetic_build/library_generation/owlbot/templates/java_library/.github/workflows/ci.yaml
+++ b/hermetic_build/library_generation/owlbot/templates/java_library/.github/workflows/ci.yaml
@@ -104,7 +104,7 @@ jobs:
     - uses: actions/setup-java@v4
       with:
         distribution: temurin
-        java-version: 11
+        java-version: 17
     - run: java -version
     - run: .kokoro/build.sh
       env:


### PR DESCRIPTION
This PR follows from https://github.com/googleapis/java-shared-config/pull/1003, which updated google-java-format to the latest and is now [requiring](https://github.com/google/google-java-format/releases/tag/v1.25.0) Java 17.

Note that this template will not be spread until https://github.com/googleapis/sdk-platform-java/issues/3701, but the changes will be done to prevent regressions when it's fixed.
