### PR TITLE
chore: prepare showcase for GraalVM for JDK 17

### DIFF
--- a/java-showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITHttpAnnotation.java
+++ b/java-showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITHttpAnnotation.java
@@ -31,6 +31,7 @@ import com.google.showcase.v1beta1.RepeatResponse;
 import com.google.showcase.v1beta1.it.util.TestClientInitializer;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.util.List;
 import java.util.Map;
@@ -73,7 +74,8 @@ class ITHttpAnnotation {
                 Objects.requireNonNull(
                     ITHttpAnnotation.class
                         .getClassLoader()
-                        .getResourceAsStream("compliance_suite.json"))),
+                        .getResourceAsStream("compliance_suite.json")),
+                StandardCharsets.UTF_8),
             builder);
     complianceSuite = builder.build();
 


### PR DESCRIPTION
Full context in [GraalVM 17 migration doc](https://docs.google.com/document/d/1bOeGtVFLsq5ts71If5pFXCvHIeNpbtBRvF6XQfavLZs/edit?tab=t.loipy7ydvwga)

Confirmation that this works: https://github.com/googleapis/java-shared-config/pull/1010/commits/95304940a769c3649875b8fa8a99f36e363580fb

### Problem
JDK 17 `InputStreamReader` produces different bytes from JDK 18+. This affects `ITHttpAnnotation#testComplianceGroup` because of the way `compliance_suite.json` is parsed.

### Cause
JDK 18 was released including commit [7fc854](https://github.com/openjdk/jdk/commit/7fc8540907e8e7483ad5729ea416167810aa8747) which enables usage of UTF-8 by default. Before this commit, each JVM will produce their own default Charset (_likely the reason we don't see this error in other CI setups using java 17_). As a confirmation, if we create an experiment test to print the default charset as in:

```java
 @Test
  void verifyByteSizeOfExtremePayload() throws IOException {
    System.out.println(System.getProperty("file.encoding"));
}
```

When using openjdk 17 we get the value `Cp1252`, and on openjdk 18 we get the value `UTF-8`.
Solution

### Solution
Finally, the solution is to explicitly use UTF-8 with the `InputStreamReader`