### PR TITLE
chore: introduce .kokoro templates for GraalVM jobs

### DIFF
--- a/.github/workflows/verify_library_generation.yaml
+++ b/.github/workflows/verify_library_generation.yaml
@@ -79,7 +79,7 @@ jobs:
         format: tty
         severity: error
         ignore_paths: 
-          hermetic_build/library_generation/owlbot/templates
+          ./library_generation/owlbot/templates
   library-generation-lint-python:
     runs-on: ubuntu-22.04
     needs: should-run-library-generation-tests

--- a/.github/workflows/verify_library_generation.yaml
+++ b/.github/workflows/verify_library_generation.yaml
@@ -78,6 +78,8 @@ jobs:
         scandir: 'hermetic_build'
         format: tty
         severity: error
+        ignore_paths: 
+          hermetic_build/library_generation/owlbot/templates
   library-generation-lint-python:
     runs-on: ubuntu-22.04
     needs: should-run-library-generation-tests

--- a/.github/workflows/verify_library_generation.yaml
+++ b/.github/workflows/verify_library_generation.yaml
@@ -79,7 +79,7 @@ jobs:
         format: tty
         severity: error
         ignore_paths: 
-          ./library_generation/owlbot/templates
+          .kokoro
   library-generation-lint-python:
     runs-on: ubuntu-22.04
     needs: should-run-library-generation-tests

--- a/hermetic_build/library_generation/owlbot/templates/java_library/.github/sync-repo-settings.yaml
+++ b/hermetic_build/library_generation/owlbot/templates/java_library/.github/sync-repo-settings.yaml
@@ -49,8 +49,9 @@ branchProtectionRules:
   - "Kokoro - Test: Integration"
   - "cla/google"
   - "OwlBot Post Processor"
-  - "Kokoro - Test: Java GraalVM Native Image"
-  - "Kokoro - Test: Java 17 GraalVM Native Image"
+  - "Kokoro - Test: Java GraalVM Native Image A"
+  - "Kokoro - Test: Java GraalVM Native Image B"
+  - "Kokoro - Test: Java GraalVM Native Image C"
 # List of explicit permissions to add (additive only)
 permissionRules:
 - team: yoshi-admins

--- a/hermetic_build/library_generation/owlbot/templates/java_library/.github/workflows/renovate_config_check.yaml
+++ b/hermetic_build/library_generation/owlbot/templates/java_library/.github/workflows/renovate_config_check.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   renovate_bot_config_validation:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout code
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '22'
 
     - name: Install Renovate and Config Validator
       run: |

--- a/hermetic_build/library_generation/owlbot/templates/java_library/.github/workflows/update_generation_config.yaml
+++ b/hermetic_build/library_generation/owlbot/templates/java_library/.github/workflows/update_generation_config.yaml
@@ -21,7 +21,7 @@ on:
 {% raw %}
 jobs:
   update-generation-config:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       # the branch into which the pull request is merged
       base_branch: main

--- a/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/build.sh
+++ b/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/build.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
-
-# Copyright 2018 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,13 +15,133 @@
 
 set -eo pipefail
 
-cd github/synthtool
+## Get the directory of the build script
+scriptDir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
+## cd to the parent directory, i.e. the root of the git repo
+cd ${scriptDir}/..
 
-# Disable buffering, so that the logs stream through.
-export PYTHONUNBUFFERED=1
+# include common functions
+source ${scriptDir}/common.sh
 
-# Run tests
-nox -s lint test
+# Print out Maven & Java version
+mvn -version
+echo ${JOB_TYPE}
 
-# remove all files, preventing kokoro from trying to sync them.
-rm -rf *
+# attempt to install 3 times with exponential backoff (starting with 10 seconds)
+retry_with_backoff 3 10 \
+  mvn install -B -V -ntp \
+    -DskipTests=true \
+    -Dclirr.skip=true \
+    -Denforcer.skip=true \
+    -Dmaven.javadoc.skip=true \
+    -Dgcloud.download.skip=true \
+    -T 1C
+
+# if GOOGLE_APPLICATION_CREDENTIALS is specified as a relative path, prepend Kokoro root directory onto it
+if [[ ! -z "${GOOGLE_APPLICATION_CREDENTIALS}" && "${GOOGLE_APPLICATION_CREDENTIALS}" != /* ]]; then
+    export GOOGLE_APPLICATION_CREDENTIALS=$(realpath ${KOKORO_GFILE_DIR}/${GOOGLE_APPLICATION_CREDENTIALS})
+fi
+{% if metadata['repo']['api_shortname'] == 'storage' %}
+
+export TEST_UNIVERSE_DOMAIN_CREDENTIAL=$(realpath ${KOKORO_GFILE_DIR}/secret_manager/client-library-test-universe-domain-credential)
+export TEST_UNIVERSE_DOMAIN=$(gcloud secrets versions access latest --project cloud-devrel-kokoro-resources --secret=client-library-test-universe-domain)
+export TEST_UNIVERSE_PROJECT_ID=$(gcloud secrets versions access latest --project cloud-devrel-kokoro-resources --secret=client-library-test-universe-project-id)
+export TEST_UNIVERSE_LOCATION=$(gcloud secrets versions access latest --project cloud-devrel-kokoro-resources --secret=client-library-test-universe-storage-location)
+{% endif %}
+
+RETURN_CODE=0
+set +e
+
+case ${JOB_TYPE} in
+test)
+    echo "SUREFIRE_JVM_OPT: ${SUREFIRE_JVM_OPT}"
+    mvn test -B -ntp -Dclirr.skip=true -Denforcer.skip=true ${SUREFIRE_JVM_OPT}
+    RETURN_CODE=$?
+    ;;
+lint)
+    mvn com.coveo:fmt-maven-plugin:check -B -ntp
+    RETURN_CODE=$?
+    ;;
+javadoc)
+    mvn javadoc:javadoc javadoc:test-javadoc -B -ntp
+    RETURN_CODE=$?
+    ;;
+integration)
+    mvn -B ${INTEGRATION_TEST_ARGS} \
+      -ntp \
+      -Penable-integration-tests \
+      -DtrimStackTrace=false \
+      -Dclirr.skip=true \
+      -Denforcer.skip=true \
+      -fae \
+      verify
+    RETURN_CODE=$?
+    ;;
+graalvmA)
+    # Run Unit and Integration Tests with Native Image
+    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative test
+    RETURN_CODE=$?
+    ;;
+graalvmB)
+    # Run Unit and Integration Tests with Native Image
+    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative test
+    RETURN_CODE=$?
+    ;;
+graalvmC)
+    # Run Unit and Integration Tests with Native Image
+    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative test
+    RETURN_CODE=$?
+    ;;
+samples)
+    SAMPLES_DIR=samples
+    # only run ITs in snapshot/ on presubmit PRs. run ITs in all 3 samples/ subdirectories otherwise.
+    if [[ ! -z ${KOKORO_GITHUB_PULL_REQUEST_NUMBER} ]]
+    then
+      SAMPLES_DIR=samples/snapshot
+    fi
+
+    if [[ -f ${SAMPLES_DIR}/pom.xml ]]
+    then
+        for FILE in ${KOKORO_GFILE_DIR}/secret_manager/*-samples-secrets; do
+          [[ -f "$FILE" ]] || continue
+          source "$FILE"
+        done
+
+        pushd ${SAMPLES_DIR}
+        mvn -B \
+          -ntp \
+          -DtrimStackTrace=false \
+          -Dclirr.skip=true \
+          -Denforcer.skip=true \
+          -fae \
+          verify
+        RETURN_CODE=$?
+        popd
+    else
+        echo "no sample pom.xml found - skipping sample tests"
+    fi
+    ;;
+clirr)
+    mvn -B -ntp -Denforcer.skip=true clirr:check
+    RETURN_CODE=$?
+    ;;
+*)
+    ;;
+esac
+
+if [ "${REPORT_COVERAGE}" == "true" ]
+then
+  bash ${KOKORO_GFILE_DIR}/codecov.sh
+fi
+
+# fix output location of logs
+bash .kokoro/coerce_logs.sh
+
+if [[ "${ENABLE_FLAKYBOT}" == "true" ]]
+then
+    chmod +x ${KOKORO_GFILE_DIR}/linux_amd64/flakybot
+    ${KOKORO_GFILE_DIR}/linux_amd64/flakybot -repo=googleapis/java-storage
+fi
+
+echo "exiting with ${RETURN_CODE}"
+exit ${RETURN_CODE}

--- a/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/build.sh
+++ b/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/build.sh
@@ -77,17 +77,7 @@ integration)
       verify
     RETURN_CODE=$?
     ;;
-graalvmA)
-    # Run Unit and Integration Tests with Native Image
-    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative test
-    RETURN_CODE=$?
-    ;;
-graalvmB)
-    # Run Unit and Integration Tests with Native Image
-    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative test
-    RETURN_CODE=$?
-    ;;
-graalvmC)
+graalvm)
     # Run Unit and Integration Tests with Native Image
     mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative test
     RETURN_CODE=$?

--- a/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/build.sh
+++ b/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/build.sh
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      https://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/build.sh
+++ b/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/build.sh
@@ -73,6 +73,8 @@ integration)
       -DtrimStackTrace=false \
       -Dclirr.skip=true \
       -Denforcer.skip=true \
+      -Dcheckstyle.skip=true \
+      -DskipUnitTests=true \
       -fae \
       verify
     RETURN_CODE=$?
@@ -130,7 +132,7 @@ bash .kokoro/coerce_logs.sh
 if [[ "${ENABLE_FLAKYBOT}" == "true" ]]
 then
     chmod +x ${KOKORO_GFILE_DIR}/linux_amd64/flakybot
-    ${KOKORO_GFILE_DIR}/linux_amd64/flakybot -repo=googleapis/java-storage
+    ${KOKORO_GFILE_DIR}/linux_amd64/flakybot -repo=googleapis/java-{{ metadata['repo']['api_shortname'] }}
 fi
 
 echo "exiting with ${RETURN_CODE}"

--- a/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/build.sh
+++ b/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/build.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-# Copyright 2019 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/presubmit/graalvm-a.cfg
+++ b/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/presubmit/graalvm-a.cfg
@@ -8,7 +8,7 @@ env_vars: {
 
 env_vars: {
   key: "JOB_TYPE"
-  value: "graalvmA"
+  value: "graalvm"
 }
 
 # TODO: remove this after we've migrated all tests and scripts

--- a/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/presubmit/graalvm-a.cfg
+++ b/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/presubmit/graalvm-a.cfg
@@ -1,0 +1,38 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+  key: "TRAMPOLINE_IMAGE"
+  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:3.45.1"
+}
+
+env_vars: {
+  key: "JOB_TYPE"
+  value: "graalvmA"
+}
+
+# TODO: remove this after we've migrated all tests and scripts
+env_vars: {
+  key: "GCLOUD_PROJECT"
+  value: "gcloud-devel"
+}
+
+env_vars: {
+  key: "GOOGLE_CLOUD_PROJECT"
+  value: "gcloud-devel"
+}
+
+env_vars: {
+  key: "GOOGLE_APPLICATION_CREDENTIALS"
+  value: "secret_manager/java-it-service-account"
+}
+
+env_vars: {
+  key: "SECRET_MANAGER_KEYS"
+  value: "java-it-service-account"
+}
+
+env_vars: {
+  key: "IT_SERVICE_ACCOUNT_EMAIL"
+  value: "it-service-account@gcloud-devel.iam.gserviceaccount.com"
+}

--- a/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/presubmit/graalvm-b.cfg
+++ b/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/presubmit/graalvm-b.cfg
@@ -1,0 +1,38 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+  key: "TRAMPOLINE_IMAGE"
+  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:3.45.1"
+}
+
+env_vars: {
+  key: "JOB_TYPE"
+  value: "graalvmB"
+}
+
+# TODO: remove this after we've migrated all tests and scripts
+env_vars: {
+  key: "GCLOUD_PROJECT"
+  value: "gcloud-devel"
+}
+
+env_vars: {
+  key: "GOOGLE_CLOUD_PROJECT"
+  value: "gcloud-devel"
+}
+
+env_vars: {
+  key: "GOOGLE_APPLICATION_CREDENTIALS"
+  value: "secret_manager/java-it-service-account"
+}
+
+env_vars: {
+  key: "SECRET_MANAGER_KEYS"
+  value: "java-it-service-account"
+}
+
+env_vars: {
+  key: "IT_SERVICE_ACCOUNT_EMAIL"
+  value: "it-service-account@gcloud-devel.iam.gserviceaccount.com"
+}

--- a/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/presubmit/graalvm-b.cfg
+++ b/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/presubmit/graalvm-b.cfg
@@ -8,7 +8,7 @@ env_vars: {
 
 env_vars: {
   key: "JOB_TYPE"
-  value: "graalvmB"
+  value: "graalvm"
 }
 
 # TODO: remove this after we've migrated all tests and scripts

--- a/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/presubmit/graalvm-c.cfg
+++ b/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/presubmit/graalvm-c.cfg
@@ -1,0 +1,38 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+  key: "TRAMPOLINE_IMAGE"
+  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:3.45.1"
+}
+
+env_vars: {
+  key: "JOB_TYPE"
+  value: "graalvmC"
+}
+
+# TODO: remove this after we've migrated all tests and scripts
+env_vars: {
+  key: "GCLOUD_PROJECT"
+  value: "gcloud-devel"
+}
+
+env_vars: {
+  key: "GOOGLE_CLOUD_PROJECT"
+  value: "gcloud-devel"
+}
+
+env_vars: {
+  key: "GOOGLE_APPLICATION_CREDENTIALS"
+  value: "secret_manager/java-it-service-account"
+}
+
+env_vars: {
+  key: "SECRET_MANAGER_KEYS"
+  value: "java-it-service-account"
+}
+
+env_vars: {
+  key: "IT_SERVICE_ACCOUNT_EMAIL"
+  value: "it-service-account@gcloud-devel.iam.gserviceaccount.com"
+}

--- a/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/presubmit/graalvm-c.cfg
+++ b/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/presubmit/graalvm-c.cfg
@@ -8,7 +8,7 @@ env_vars: {
 
 env_vars: {
   key: "JOB_TYPE"
-  value: "graalvmC"
+  value: "graalvm"
 }
 
 # TODO: remove this after we've migrated all tests and scripts

--- a/hermetic_build/library_generation/setup.py
+++ b/hermetic_build/library_generation/setup.py
@@ -27,7 +27,6 @@ setup(
             "owlbot/templates/java_library/.github/**/*",
             "owlbot/templates/java_library/**/*",
             "owlbot/templates/java_library/.kokoro/build.sh",
-            "owlbot/templates/java_library/.kokoro/common.cfg",
             "owlbot/templates/java_library/.kokoro/presubmit/graalvm-*.cfg",
         ],
         "synthtool": ["owlbot/synthtool/**/*"],

--- a/hermetic_build/library_generation/setup.py
+++ b/hermetic_build/library_generation/setup.py
@@ -25,10 +25,10 @@ setup(
             "owlbot/templates/clirr/*.j2",
             "owlbot/templates/poms/*.j2",
             "owlbot/templates/java_library/.github/**/*",
-            # TODO: uncomment this line after https://github.com/googleapis/sdk-platform-java/pull/3723
-            # has been merged.
-            # "owlbot/templates/java_library/.kokoro/**/*",
             "owlbot/templates/java_library/**/*",
+            "owlbot/templates/java_library/.kokoro/build.sh",
+            "owlbot/templates/java_library/.kokoro/common.cfg",
+            "owlbot/templates/java_library/.kokoro/presubmit/graalvm-*.cfg",
         ],
         "synthtool": ["owlbot/synthtool/**/*"],
     },


### PR DESCRIPTION
Context: [we will introduce a new GraalVM job](https://docs.google.com/document/d/1bOeGtVFLsq5ts71If5pFXCvHIeNpbtBRvF6XQfavLZs/edit?tab=t.dcjxhf429j6t#bookmark=id.3s7d4dj247hr) and will leverage the hermetic build templates to propagate this change to some of the repositories. Each PR will be followed with ad-hoc changes such as sync-repo-settings (the cannot be templated).

Demo PRs
 * https://github.com/googleapis/java-bigtable/pull/2558
 * https://github.com/googleapis/java-bigquerystorage/pull/2937
 * https://github.com/googleapis/java-storage/pull/3029
 * https://github.com/googleapis/java-datastore/pull/1816
   * There are manual changes in `build.sh`. We will add this file to the [ignored files in owlbot.py](https://github.com/googleapis/java-datastore/blob/8ceb62b5182e30b4f771d6c1b586a22fb084c9ac/owlbot.py#L48-L57) and will raise an issue to move this logic elsewhere (if feasible).
 * https://github.com/googleapis/java-firestore/pull/2074
 * https://github.com/googleapis/java-logging/pull/1789
 * https://github.com/googleapis/java-pubsub/pull/2389
 * https://github.com/googleapis/java-pubsublite/pull/1839
 * https://github.com/googleapis/java-spanner/pull/3821