### PR TITLE
fix(hermetic-build): use correct image name in templated graalvm jobs

### DIFF
--- a/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/presubmit/graalvm-a.cfg
+++ b/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/presubmit/graalvm-a.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:3.45.1"
+  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:3.45.1"
 }
 
 env_vars: {

--- a/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/presubmit/graalvm-c.cfg
+++ b/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/presubmit/graalvm-c.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:3.45.1"
+  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_c:3.45.1"
 }
 
 env_vars: {


### PR DESCRIPTION
Fixes a typo in two image references on templates.