### PR TITLE
fix: use java 17 in samples.yaml

### DIFF
--- a/hermetic_build/library_generation/owlbot/templates/java_library/.github/workflows/samples.yaml
+++ b/hermetic_build/library_generation/owlbot/templates/java_library/.github/workflows/samples.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 17
       - name: Run checkstyle
         run: mvn -P lint --quiet --batch-mode checkstyle:check
         working-directory: samples/snippets


### PR DESCRIPTION
This follows from the linter upgrade done in https://github.com/googleapis/java-shared-config/pull/1003
