### PR TITLE
fix: keep native image templates up to date

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -10,6 +10,9 @@ extraFiles:
   - .cloudbuild/graalvm/cloudbuild-test-b.yaml
   - .cloudbuild/graalvm/cloudbuild-test-c.yaml
   - .cloudbuild/library_generation/cloudbuild-library-generation-release.yaml
+  - hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/presubmit/graalvm-native-a.cfg
+  - hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/presubmit/graalvm-native-b.cfg
+  - hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/presubmit/graalvm-native-c.cfg
   - generation_config.yaml
 branches:
   - branch: 2.23.x

--- a/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/presubmit/graalvm-native-a.cfg
+++ b/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/presubmit/graalvm-native-a.cfg
@@ -3,6 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
+  # {x-version-update:google-cloud-shared-dependencies:current}
   value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:3.45.1"
 }
 

--- a/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/presubmit/graalvm-native-b.cfg
+++ b/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/presubmit/graalvm-native-b.cfg
@@ -3,6 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
+  # {x-version-update:google-cloud-shared-dependencies:current}
   value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:3.45.1"
 }
 

--- a/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/presubmit/graalvm-native-c.cfg
+++ b/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/presubmit/graalvm-native-c.cfg
@@ -3,6 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
+  # {x-version-update:google-cloud-shared-dependencies:current}
   value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_c:3.45.1"
 }
 


### PR DESCRIPTION
This ensures the templates are up to date with the latest released version of sdk-platform-java-config