### PR TITLE
fix: subscribe Airlock Docker image definition to GRPC updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -70,7 +70,7 @@
     {
       "customType": "regex",
       "fileMatch": [
-        "^.cloudbuild/library_generation/library_generation.Dockerfile$"
+        "^.cloudbuild/library_generation/library_generation.*\\.Dockerfile$"
       ],
       "matchStrings": [
         "OWLBOT_CLI_COMMITTISH=(?<currentDigest>.*?)\\n"

--- a/renovate.json
+++ b/renovate.json
@@ -35,7 +35,7 @@
       "customType": "regex",
       "fileMatch": [
         "^gax-java/dependencies\\.properties$",
-        "^\\.cloudbuild/library_generation/library_generation\\.Dockerfile$"
+        "^\\.cloudbuild/library_generation/library_generation.*\\.Dockerfile$"
       ],
       "matchStrings": [
         "version\\.io_grpc=(?<currentValue>.+?)\\n",


### PR DESCRIPTION
Temporary solution while https://github.com/googleapis/sdk-platform-java/issues/3766 is not fixed