### PR TITLE
fix: Only send mtlsEndpoint if it is non-null

### DIFF
--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
@@ -223,7 +223,7 @@ public abstract class ClientContext {
       transportChannelProvider = transportChannelProvider.withEndpoint(endpoint);
     }
     transportChannelProvider = transportChannelProvider.withUseS2A(endpointContext.useS2A());
-    if (transportChannelProvider.needsMtlsEndpoint()) {
+    if (transportChannelProvider.needsMtlsEndpoint() && endpointContext.mtlsEndpoint() != null) {
       transportChannelProvider =
           transportChannelProvider.withMtlsEndpoint(endpointContext.mtlsEndpoint());
     }

--- a/gax-java/gax/src/test/java/com/google/api/gax/rpc/ClientContextTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/rpc/ClientContextTest.java
@@ -1264,8 +1264,7 @@ class ClientContextTest {
   @Test
   void test_nullMtlsEndpointIsNotPassedToTransportChannel() throws IOException {
     // Set the mtlsEndpoint in the TransportChannelProvider as null. This configures the
-    // ClientContext
-    // to attempt to pass the mtlsEndpoint over.
+    // ClientContext to attempt to pass the mtlsEndpoint over.
     TransportChannelProvider transportChannelProvider =
         new FakeTransportProvider(
             FakeTransportChannel.create(new FakeChannel()), null, true, null, null, null, null);
@@ -1276,6 +1275,7 @@ class ClientContextTest {
         new FakeStubSettings.Builder()
             .setEndpoint(DEFAULT_ENDPOINT)
             // Set this to be null so that the resolved mtls endpoint is null
+            // This resolved value should not be passed to the TransportChannelProvider
             .setMtlsEndpoint(null)
             .build();
     ClientSettings.Builder clientSettingsBuilder = new FakeClientSettings.Builder(settings);

--- a/gax-java/gax/src/test/java/com/google/api/gax/rpc/ClientContextTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/rpc/ClientContextTest.java
@@ -70,7 +70,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.commons.util.Preconditions;
 import org.mockito.Mockito;
 
 class ClientContextTest {
@@ -249,9 +248,11 @@ class ClientContextTest {
 
     @Override
     public TransportChannelProvider withMtlsEndpoint(String mtlsEndpoint) {
-      // Throws NPE if this is passed with a null value. This should never happen as
-      // GAPICs should always have a default mtlsEndpoint value
-      Preconditions.notNull(mtlsEndpoint, "mtlsEndpoint should never be null");
+      // Throws an exception if this is passed with a null value. This should never
+      // happen as GAPICs should always have a default mtlsEndpoint value
+      if (mtlsEndpoint == null) {
+        throw new IllegalArgumentException("mtlsEndpoint is null");
+      }
       return new FakeTransportProvider(
           this.transport,
           this.executor,

--- a/gax-java/gax/src/test/java/com/google/api/gax/rpc/ClientContextTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/rpc/ClientContextTest.java
@@ -1263,6 +1263,9 @@ class ClientContextTest {
   // the old behavior where BigTable doesn't set an mtlsEndpoint value.
   @Test
   void test_nullMtlsEndpointIsNotPassedToTransportChannel() throws IOException {
+    // Set the mtlsEndpoint in the TransportChannelProvider as null. This configures the
+    // ClientContext
+    // to attempt to pass the mtlsEndpoint over.
     TransportChannelProvider transportChannelProvider =
         new FakeTransportProvider(
             FakeTransportChannel.create(new FakeChannel()), null, true, null, null, null, null);


### PR DESCRIPTION
Temporary fix to only plumb the mtlsEndpoint to the gRPCChannelProviders if this has been set with a non-null value. Validation will still go through if it is set with bogus values.

Issue reported in https://github.com/googleapis/java-bigtable/pull/2565

This seems to due to how Bigtable wrappers the generated stubs. BigTable manually calls setEndpoint to for the StubSettings, but does not do the equivalent for setMtlsEndpoint. The EndpointContext is only aware of the TLS endpoint and passes a null value to the ChannelProviders. 

Potential longer term fix: BigTable's wrappers would need to set the mTLS Endpoint. This would be needed for BigTable to support S2A. This does not impact any of BigTable's existing functionality as the endpoint resolution for all non-S2A flows is done via `setEndpoint()`.