### PR TITLE
chore: Add IAM v3beta to gapic-generator-bom

### DIFF
--- a/gapic-generator-java-bom/pom.xml
+++ b/gapic-generator-java-bom/pom.xml
@@ -119,6 +119,11 @@
         <artifactId>proto-google-iam-v3</artifactId>
         <version>1.51.1-SNAPSHOT</version><!-- {x-version-update:proto-google-iam-v3:current} -->
       </dependency>
+      <dependency>
+        <groupId>com.google.api.grpc</groupId>
+        <artifactId>proto-google-iam-v3beta</artifactId>
+        <version>1.51.1-SNAPSHOT</version><!-- {x-version-update:proto-google-iam-v3beta:current} -->
+      </dependency>
 
       <!-- Following test deps are kept to keep them consistent with versions above -->
       <dependency>
@@ -140,6 +145,11 @@
         <groupId>com.google.api.grpc</groupId>
         <artifactId>grpc-google-iam-v3</artifactId>
         <version>1.51.1-SNAPSHOT</version><!-- {x-version-update:grpc-google-iam-v3:current} -->
+      </dependency>
+      <dependency>
+        <groupId>com.google.api.grpc</groupId>
+        <artifactId>grpc-google-iam-v3beta</artifactId>
+        <version>1.51.1-SNAPSHOT</version><!-- {x-version-update:grpc-google-iam-v3beta:current} -->
       </dependency>
     </dependencies>
 


### PR DESCRIPTION
Looks like this was removed in an earlier release-please PR. Adding this back in in this PR.

Once we cut a new version of sdk-platform-java, we can remove the hard-coded version set in google-cloud-java.