### PR TITLE
feat: add cloudbuild config to publish image via AR Exit Gate

### DIFF
--- a/.cloudbuild/library_generation/cloudbuild-library-generation-push-exitgate.yaml
+++ b/.cloudbuild/library_generation/cloudbuild-library-generation-push-exitgate.yaml
@@ -1,0 +1,42 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+timeout: 7200s # 2 hours
+substitutions:
+  _GAPIC_GENERATOR_JAVA_VERSION: '2.57.1-SNAPSHOT' # {x-version-update:gapic-generator-java:current}
+  _IMAGE_NAME: "us-central1-docker.pkg.dev/cloud-sdk-production-pipeline/images-dev/java-library-generation"
+  _SHA_IMAGE_ID: "${_IMAGE_NAME}:${COMMIT_SHA}"
+  _VERSIONED_IMAGE_ID: "${_IMAGE_NAME}:${_GAPIC_GENERATOR_JAVA_VERSION}"
+steps:
+  # Library generation build
+  - name: gcr.io/cloud-builders/docker
+    args: [
+      "build",
+      "-t", "${_SHA_IMAGE_ID}",
+      "-t", "${_VERSIONED_IMAGE_ID}",
+      "-f", ".cloudbuild/library_generation/library_generation_airlock.Dockerfile",
+      "."
+    ]
+    id: library-generation-build
+    waitFor: ["-"]
+    env: 
+      - 'DOCKER_BUILDKIT=1'
+
+options:
+  machineType: 'E2_HIGHCPU_8'
+  requestedVerifyOption: VERIFIED  # For provenance attestation generation
+
+images:
+  - ${_SHA_IMAGE_ID}
+  - ${_VERSIONED_IMAGE_ID}


### PR DESCRIPTION
The new file .cloudbuild/library_generation/cloudbuild-library-generation-push-exitgate.yaml is based on .cloudbuild/library_generation/cloudbuild-library-generation-push.yaml. The main difference is that the image is output to us-central1-docker.pkg.dev/cloud-sdk-production-pipeline/images-dev, which is the entry point of the AR Exit Gate.