### PR TITLE
fix: manage graalvm image versions via Hermetic Build templates _only_

### DIFF
--- a/hermetic_build/library_generation/owlbot/templates/java_library/renovate.json
+++ b/hermetic_build/library_generation/owlbot/templates/java_library/renovate.json
@@ -26,17 +26,6 @@
     {
       "customType": "regex",
       "fileMatch": [
-        "^.kokoro/presubmit/graalvm-native.*.cfg$"
-      ],
-      "matchStrings": [
-        "value: \"gcr.io/cloud-devrel-public-resources/graalvm.*:(?<currentValue>.*?)\""
-      ],
-      "depNameTemplate": "com.google.cloud:sdk-platform-java-config",
-      "datasourceTemplate": "maven"
-    },
-    {
-      "customType": "regex",
-      "fileMatch": [
         "^.github/workflows/unmanaged_dependency_check.yaml$"
       ],
       "matchStrings": [


### PR DESCRIPTION
So far these versions are managed both by renovate-bot and Hermetic Build. Since each release of Hermetic Build keeps these template versions up to date, it's better suited to manage these versions via Hermetic Build.

The updates should be reflected by updating `.github/workflows/hermetic_library_generation.yaml` referenced version to the current released one.