### PR TITLE
Skip S2A on platforms where netty-tcnative is not available

### DIFF
--- a/gax-java/gax/src/main/java/com/google/api/gax/rpc/EndpointContext.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/rpc/EndpointContext.java
@@ -309,6 +309,17 @@ public abstract class EndpointContext {
     /** Determine if S2A can be used */
     @VisibleForTesting
     boolean shouldUseS2A() {
+      // If running on windows or macos intel, skip S2A. S2A has runtime 
+      // dependency on netty-tcnative which is dropping support on these platforms.
+      // https://github.com/netty/netty-tcnative/issues/898
+      // https://github.com/netty/netty-tcnative/issues/897
+      if (System.getProperty("os.name").contains("Windows") || 
+        (System.getProperty("os.name").contains("OS X") 
+        && System.getProperty("os.arch").contains("x86_64"))) {
+          return false;
+      }
+
+
       // If mTLS endpoint is not available, skip S2A
       if (Strings.isNullOrEmpty(mtlsEndpoint())) {
         return false;


### PR DESCRIPTION
S2A has a [runtime dependency on netty-tcnative](https://github.com/grpc/grpc-java/blob/master/s2a/build.gradle#L38).

netty-tcnative is looking to drop support for [windows](https://github.com/netty/netty-tcnative/issues/897) and [macos intel](https://github.com/netty/netty-tcnative/issues/898) based builds. To avoid runtime errors for users of the Cloud SDK, disable S2A if they are running on these platforms.