### PR TITLE
chore(build): fix typo

### DIFF
--- a/java-core/pom.xml
+++ b/java-core/pom.xml
@@ -64,7 +64,7 @@
       </dependency>
       <dependency>
         <groupId>com.google.errorprone</groupId>
-        <artifactId>error_prone_annotationsa</artifactId>
+        <artifactId>error_prone_annotations</artifactId>
         <version>${errorprone.version}</version>
       </dependency>
     </dependencies>


### PR DESCRIPTION
fix a typo.

Did the typo cause any failures for us? Is this dependency necessary?