### PR TITLE
fix: copy project metadata

### DIFF
--- a/api-common-java/pom.xml
+++ b/api-common-java/pom.xml
@@ -10,7 +10,7 @@
     <description>Common utilities for Google APIs in Java</description>
 
     <parent>
-        <groupId>com.google.api</groupId>
+        <groupId>com.google.cloud</groupId>
         <artifactId>gapic-generator-java-pom-parent</artifactId>
         <version>2.59.1</version><!-- {x-version-update:gapic-generator-java:current} -->
         <relativePath>../gapic-generator-java-pom-parent</relativePath>

--- a/gapic-generator-java-bom/pom.xml
+++ b/gapic-generator-java-bom/pom.xml
@@ -13,7 +13,7 @@
   </description>
 
   <parent>
-    <groupId>com.google.api</groupId>
+    <groupId>com.google.cloud</groupId>
     <artifactId>gapic-generator-java-pom-parent</artifactId>
     <version>2.59.1</version><!-- {x-version-update:gapic-generator-java:current} -->
     <relativePath>../gapic-generator-java-pom-parent</relativePath>

--- a/gapic-generator-java-bom/pom.xml
+++ b/gapic-generator-java-bom/pom.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>com.google.api</groupId>
+  <groupId>com.google.cloud</groupId>
   <artifactId>gapic-generator-java-bom</artifactId>
   <packaging>pom</packaging>
   <version>2.59.1</version><!-- {x-version-update:gapic-generator-java:current} -->

--- a/gapic-generator-java-bom/pom.xml
+++ b/gapic-generator-java-bom/pom.xml
@@ -77,13 +77,64 @@
         <artifactId>api-common</artifactId>
         <version>2.50.1</version><!-- {x-version-update:api-common:current} -->
       </dependency>
+
+      <!-- Copying the content of gax-bom to untagle the circular dependencies of com.google.cloud and com.google.api -->
       <dependency>
         <groupId>com.google.api</groupId>
-        <artifactId>gax-bom</artifactId>
+        <artifactId>gax</artifactId>
         <version>2.67.1</version><!-- {x-version-update:gax:current} -->
-        <type>pom</type>
-        <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>com.google.api</groupId>
+        <artifactId>gax</artifactId>
+        <version>2.67.1</version><!-- {x-version-update:gax:current} -->
+        <type>test-jar</type>
+        <classifier>testlib</classifier>
+      </dependency>
+      <dependency>
+        <groupId>com.google.api</groupId>
+        <artifactId>gax</artifactId>
+        <version>2.67.1</version><!-- {x-version-update:gax:current} -->
+        <classifier>testlib</classifier>
+      </dependency>
+      <dependency>
+        <groupId>com.google.api</groupId>
+        <artifactId>gax-grpc</artifactId>
+        <version>2.67.1</version><!-- {x-version-update:gax-grpc:current} -->
+      </dependency>
+      <dependency>
+        <groupId>com.google.api</groupId>
+        <artifactId>gax-grpc</artifactId>
+        <version>2.67.1</version><!-- {x-version-update:gax-grpc:current} -->
+        <type>test-jar</type>
+        <classifier>testlib</classifier>
+      </dependency>
+      <dependency>
+        <groupId>com.google.api</groupId>
+        <artifactId>gax-grpc</artifactId>
+        <version>2.67.1</version><!-- {x-version-update:gax-grpc:current} -->
+        <classifier>testlib</classifier>
+      </dependency>
+      <dependency>
+        <groupId>com.google.api</groupId>
+        <artifactId>gax-httpjson</artifactId>
+        <version>2.67.1</version><!-- {x-version-update:gax:current} -->
+      </dependency>
+      <dependency>
+        <groupId>com.google.api</groupId>
+        <artifactId>gax-httpjson</artifactId>
+        <version>2.67.1</version><!-- {x-version-update:gax:current} -->
+        <type>test-jar</type>
+        <classifier>testlib</classifier>
+      </dependency>
+      <dependency>
+        <groupId>com.google.api</groupId>
+        <artifactId>gax-httpjson</artifactId>
+        <version>2.67.1</version><!-- {x-version-update:gax:current} -->
+        <classifier>testlib</classifier>
+      </dependency>
+      <!-- End of the content of gax-bom -->
+
       <dependency>
         <groupId>com.google.api</groupId>
         <artifactId>gapic-generator-java</artifactId>

--- a/gapic-generator-java-pom-parent/pom.xml
+++ b/gapic-generator-java-pom-parent/pom.xml
@@ -3,7 +3,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" child.project.url.inherit.append.path="false">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>com.google.api</groupId>
+  <groupId>com.google.cloud</groupId>
   <artifactId>gapic-generator-java-pom-parent</artifactId>
   <version>2.59.1</version><!-- {x-version-update:gapic-generator-java:current} -->
   <packaging>pom</packaging>

--- a/gapic-generator-java/pom.xml
+++ b/gapic-generator-java/pom.xml
@@ -29,7 +29,7 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.google.api</groupId>
+        <groupId>com.google.cloud</groupId>
         <artifactId>gapic-generator-java-bom</artifactId>
         <version>2.59.1</version><!-- {x-version-update:gapic-generator-java:current} -->
         <type>pom</type>

--- a/gapic-generator-java/pom.xml
+++ b/gapic-generator-java/pom.xml
@@ -20,7 +20,7 @@
   </properties>
 
   <parent>
-    <groupId>com.google.api</groupId>
+    <groupId>com.google.cloud</groupId>
     <artifactId>gapic-generator-java-pom-parent</artifactId>
     <version>2.59.1</version><!-- {x-version-update:gapic-generator-java:current} -->
     <relativePath>../gapic-generator-java-pom-parent</relativePath>

--- a/gax-java/pom.xml
+++ b/gax-java/pom.xml
@@ -9,7 +9,7 @@
   <description>Google Api eXtensions for Java (Parent)</description>
 
   <parent>
-    <groupId>com.google.api</groupId>
+    <groupId>com.google.cloud</groupId>
     <artifactId>gapic-generator-java-pom-parent</artifactId>
     <version>2.59.1</version><!-- {x-version-update:gapic-generator-java:current} -->
     <relativePath>../gapic-generator-java-pom-parent</relativePath>

--- a/java-common-protos/pom.xml
+++ b/java-common-protos/pom.xml
@@ -11,7 +11,7 @@
   </description>
 
   <parent>
-    <groupId>com.google.api</groupId>
+    <groupId>com.google.cloud</groupId>
     <artifactId>gapic-generator-java-pom-parent</artifactId>
     <version>2.59.1</version><!-- {x-version-update:gapic-generator-java:current} -->
     <relativePath>../gapic-generator-java-pom-parent</relativePath>

--- a/java-core/google-cloud-core-bom/pom.xml
+++ b/java-core/google-cloud-core-bom/pom.xml
@@ -7,7 +7,7 @@
   <packaging>pom</packaging>
 
   <parent>
-    <groupId>com.google.api</groupId>
+    <groupId>com.google.cloud</groupId>
     <artifactId>gapic-generator-java-pom-parent</artifactId>
     <version>2.59.1</version><!-- {x-version-update:gapic-generator-java:current} -->
     <relativePath>../../gapic-generator-java-pom-parent</relativePath>

--- a/java-core/pom.xml
+++ b/java-core/pom.xml
@@ -11,7 +11,7 @@
   </description>
 
   <parent>
-    <groupId>com.google.api</groupId>
+    <groupId>com.google.cloud</groupId>
     <artifactId>gapic-generator-java-pom-parent</artifactId>
     <version>2.59.1</version><!-- {x-version-update:gapic-generator-java:current} -->
     <relativePath>../gapic-generator-java-pom-parent</relativePath>

--- a/java-core/pom.xml
+++ b/java-core/pom.xml
@@ -17,6 +17,44 @@
     <relativePath>../gapic-generator-java-pom-parent</relativePath>
   </parent>
 
+  <!-- Because the parent POM is in the com.google.api namespace and this artifact is in
+    the com.google.cloud namespace in Central Portal (we cannot mix multiple namespaces
+    in one deployment bundle) and we want to release them in one release job, we copy the
+    following metadata (developers, scm, and licenses). This enables us to release this
+    artifact independently from the parent artifact. -->
+  <url>https://github.com/googleapis/sdk-platform-java</url>
+  <developers>
+    <developer>
+      <id>suztomo</id>
+      <name>Tomo Suzuki</name>
+      <email>suztomo@google.com</email>
+      <organization>Google</organization>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+  </developers>
+  <organization>
+    <name>Google LLC</name>
+  </organization>
+  <scm child.scm.connection.inherit.append.path="false"  child.scm.developerConnection.inherit.append.path="false"
+       child.scm.url.inherit.append.path="false">
+    <connection>scm:git:git@github.com:googleapis/sdk-platform-java.git</connection>
+    <developerConnection>scm:git:git@github.com:googleapis/sdk-platform-java.git</developerConnection>
+    <url>https://github.com/googleapis/sdk-platform-java</url>
+    <tag>HEAD</tag>
+  </scm>
+  <issueManagement>
+    <url>https://github.com/googleapis/sdk-platform-java/issues</url>
+    <system>GitHub Issues</system>
+  </issueManagement>
+
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/java-iam/pom.xml
+++ b/java-iam/pom.xml
@@ -11,7 +11,7 @@
   </description>
 
   <parent>
-    <groupId>com.google.api</groupId>
+    <groupId>com.google.cloud</groupId>
     <artifactId>gapic-generator-java-pom-parent</artifactId>
     <version>2.59.1</version><!-- {x-version-update:gapic-generator-java:current} -->
     <relativePath>../gapic-generator-java-pom-parent</relativePath>

--- a/java-iam/pom.xml
+++ b/java-iam/pom.xml
@@ -17,6 +17,19 @@
     <relativePath>../gapic-generator-java-pom-parent</relativePath>
   </parent>
 
+  <!-- Because the parent POM is in the com.google.api namespace and this artifact is in
+    the com.google.cloud namespace in Central Portal (we cannot mix multiple namespaces
+    in one deployment bundle) and we want to release them in one release job, we copy the
+    following metadata (developers, scm, and licenses). This enables us to release this
+    artifact independently from the parent artifact. -->
+  <url>https://github.com/googleapis/sdk-platform-java</url>
+  <scm child.scm.connection.inherit.append.path="false"  child.scm.developerConnection.inherit.append.path="false"
+       child.scm.url.inherit.append.path="false">
+    <connection>scm:git:git@github.com:googleapis/sdk-platform-java.git</connection>
+    <developerConnection>scm:git:git@github.com:googleapis/sdk-platform-java.git</developerConnection>
+    <url>https://github.com/googleapis/sdk-platform-java</url>
+    <tag>HEAD</tag>
+  </scm>
   <developers>
     <developer>
       <id>chingor</id>

--- a/java-iam/pom.xml
+++ b/java-iam/pom.xml
@@ -23,8 +23,7 @@
     following metadata (developers, scm, and licenses). This enables us to release this
     artifact independently from the parent artifact. -->
   <url>https://github.com/googleapis/sdk-platform-java</url>
-  <scm child.scm.connection.inherit.append.path="false"  child.scm.developerConnection.inherit.append.path="false"
-       child.scm.url.inherit.append.path="false">
+  <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
     <connection>scm:git:git@github.com:googleapis/sdk-platform-java.git</connection>
     <developerConnection>scm:git:git@github.com:googleapis/sdk-platform-java.git</developerConnection>
     <url>https://github.com/googleapis/sdk-platform-java</url>

--- a/java-shared-dependencies/first-party-dependencies/pom.xml
+++ b/java-shared-dependencies/first-party-dependencies/pom.xml
@@ -64,7 +64,7 @@
     <dependencies>
       <dependency>
         <!-- This BOM declares the versions gRPC, Protobuf, Guava, etc. -->
-        <groupId>com.google.api</groupId>
+        <groupId>com.google.cloud</groupId>
         <artifactId>gapic-generator-java-bom</artifactId>
         <version>2.59.1</version><!-- {x-version-update:gapic-generator-java:current} -->
         <type>pom</type>

--- a/java-shared-dependencies/first-party-dependencies/pom.xml
+++ b/java-shared-dependencies/first-party-dependencies/pom.xml
@@ -18,6 +18,39 @@
     <version>1.16.0</version>
     <relativePath />
   </parent>
+  <url>https://github.com/googleapis/sdk-platform-java</url>
+  <developers>
+    <developer>
+      <id>suztomo</id>
+      <name>Tomo Suzuki</name>
+      <email>suztomo@google.com</email>
+      <organization>Google</organization>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+  </developers>
+  <organization>
+    <name>Google LLC</name>
+  </organization>
+  <scm child.scm.connection.inherit.append.path="false"  child.scm.developerConnection.inherit.append.path="false"
+       child.scm.url.inherit.append.path="false">
+    <connection>scm:git:git@github.com:googleapis/sdk-platform-java.git</connection>
+    <developerConnection>scm:git:git@github.com:googleapis/sdk-platform-java.git</developerConnection>
+    <url>https://github.com/googleapis/sdk-platform-java</url>
+    <tag>HEAD</tag>
+  </scm>
+  <issueManagement>
+    <url>https://github.com/googleapis/sdk-platform-java/issues</url>
+    <system>GitHub Issues</system>
+  </issueManagement>
+
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/java-shared-dependencies/pom.xml
+++ b/java-shared-dependencies/pom.xml
@@ -15,7 +15,7 @@
   </description>
 
   <parent>
-    <groupId>com.google.api</groupId>
+    <groupId>com.google.cloud</groupId>
     <artifactId>gapic-generator-java-pom-parent</artifactId>
     <version>2.59.1</version><!-- {x-version-update:gapic-generator-java:current} -->
     <relativePath>../gapic-generator-java-pom-parent</relativePath>

--- a/java-shared-dependencies/pom.xml
+++ b/java-shared-dependencies/pom.xml
@@ -21,6 +21,45 @@
     <relativePath>../gapic-generator-java-pom-parent</relativePath>
   </parent>
 
+  <!-- Because the parent POM is in the com.google.api namespace and this artifact is in
+  the com.google.cloud namespace in Central Portal (we cannot mix multiple namespaces
+  in one deployment bundle) and we want to release them in one release job, we copy the
+  following metadata (developers, scm, and licenses). This enables us to release this
+  artifact independently from the parent artifact. -->
+  <url>https://github.com/googleapis/sdk-platform-java</url>
+  <developers>
+    <developer>
+      <id>suztomo</id>
+      <name>Tomo Suzuki</name>
+      <email>suztomo@google.com</email>
+      <organization>Google</organization>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+  </developers>
+  <organization>
+    <name>Google LLC</name>
+  </organization>
+  <scm child.scm.connection.inherit.append.path="false"  child.scm.developerConnection.inherit.append.path="false"
+       child.scm.url.inherit.append.path="false">
+    <connection>scm:git:git@github.com:googleapis/sdk-platform-java.git</connection>
+    <developerConnection>scm:git:git@github.com:googleapis/sdk-platform-java.git</developerConnection>
+    <url>https://github.com/googleapis/sdk-platform-java</url>
+    <tag>HEAD</tag>
+  </scm>
+  <issueManagement>
+    <url>https://github.com/googleapis/sdk-platform-java/issues</url>
+    <system>GitHub Issues</system>
+  </issueManagement>
+
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <site.installationModule>${project.artifactId}</site.installationModule>

--- a/java-shared-dependencies/third-party-dependencies/pom.xml
+++ b/java-shared-dependencies/third-party-dependencies/pom.xml
@@ -13,7 +13,7 @@
   </description>
 
   <parent>
-    <groupId>com.google.api</groupId>
+    <groupId>com.google.cloud</groupId>
     <artifactId>gapic-generator-java-pom-parent</artifactId>
     <version>2.59.1</version><!-- {x-version-update:gapic-generator-java:current} -->
     <relativePath>../../gapic-generator-java-pom-parent</relativePath>

--- a/java-shared-dependencies/third-party-dependencies/pom.xml
+++ b/java-shared-dependencies/third-party-dependencies/pom.xml
@@ -18,6 +18,44 @@
     <version>2.59.1</version><!-- {x-version-update:gapic-generator-java:current} -->
     <relativePath>../../gapic-generator-java-pom-parent</relativePath>
   </parent>
+  <!-- Because the parent POM is in the com.google.api namespace and this artifact is in
+    the com.google.cloud namespace in Central Portal (we cannot mix multiple namespaces
+    in one deployment bundle) and we want to release them in one release job, we copy the
+    following metadata (developers, scm, and licenses). This enables us to release this
+    artifact independently from the parent artifact. -->
+  <url>https://github.com/googleapis/sdk-platform-java</url>
+  <developers>
+    <developer>
+      <id>suztomo</id>
+      <name>Tomo Suzuki</name>
+      <email>suztomo@google.com</email>
+      <organization>Google</organization>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+  </developers>
+  <organization>
+    <name>Google LLC</name>
+  </organization>
+  <scm child.scm.connection.inherit.append.path="false"  child.scm.developerConnection.inherit.append.path="false"
+       child.scm.url.inherit.append.path="false">
+    <connection>scm:git:git@github.com:googleapis/sdk-platform-java.git</connection>
+    <developerConnection>scm:git:git@github.com:googleapis/sdk-platform-java.git</developerConnection>
+    <url>https://github.com/googleapis/sdk-platform-java</url>
+    <tag>HEAD</tag>
+  </scm>
+  <issueManagement>
+    <url>https://github.com/googleapis/sdk-platform-java/issues</url>
+    <system>GitHub Issues</system>
+  </issueManagement>
+
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Due to the boundary of com.google.api and com.google.cloud
namespaces, we copy the project metadata rather than relying on
the project inheritance across the boundary.
