### PR TITLE
deps: update google auth library dependencies to v1.37.1

### DIFF
--- a/gapic-generator-java-pom-parent/pom.xml
+++ b/gapic-generator-java-pom-parent/pom.xml
@@ -27,7 +27,7 @@
         consistent across modules in this repository -->
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
     <grpc.version>1.71.0</grpc.version>
-    <google.auth.version>1.37.0</google.auth.version>
+    <google.auth.version>1.37.1</google.auth.version>
     <google.http-client.version>1.47.0</google.http-client.version>
     <gson.version>2.12.1</gson.version>
     <guava.version>33.4.0-jre</guava.version>


### PR DESCRIPTION
Manually create the update since renovate bot dashboard is being slow and not creating the PR even after trying to force it multiple times.