### PR TITLE
fix(hermetic-build): use public maven metadata for latest version inference

### DIFF
--- a/hermetic_build/library_generation/owlbot/templates/java_library/.github/scripts/update_generation_config.sh
+++ b/hermetic_build/library_generation/owlbot/templates/java_library/.github/scripts/update_generation_config.sh
@@ -15,8 +15,10 @@ set -e
 function get_latest_released_version() {
     local group_id=$1
     local artifact_id=$2
-    json_content=$(curl -s "https://search.maven.org/solrsearch/select?q=g:${group_id}+AND+a:${artifact_id}&core=gav&rows=500&wt=json")
-    latest=$(jq -r '.response.docs[] | select(.v | test("^[0-9]+(\\.[0-9]+)*$")) | .v' <<< "${json_content}" | sort -V | tail -n 1)
+    group_id_url_path="$(sed 's|\.|/|g' <<< "${group_id}")"
+    url="https://repo1.maven.org/maven2/${group_id_url_path}/${artifact_id}/maven-metadata.xml"
+    xml_content=$(curl -s --fail "${url}")
+    latest=$(xmllint --xpath 'metadata/versioning/latest/text()' - <<< "${xml_content}")
     if [[ -z "${latest}" ]]; then
         echo "The latest version of ${group_id}:${artifact_id} is empty."
         echo "The returned json from maven.org is invalid: ${json_content}"

--- a/hermetic_build/library_generation/owlbot/templates/java_library/.github/workflows/update_generation_config.yaml
+++ b/hermetic_build/library_generation/owlbot/templates/java_library/.github/workflows/update_generation_config.yaml
@@ -32,7 +32,7 @@ jobs:
         token: ${{ secrets.CLOUD_JAVA_BOT_TOKEN }}
     - name: Install Dependencies
       shell: bash
-      run: sudo apt install -y libxml2-utils
+      run: sudo apt-get update && sudo apt-get install -y libxml2-utils
     - name: Update params in generation config to latest
       shell: bash
       run: |

--- a/hermetic_build/library_generation/owlbot/templates/java_library/.github/workflows/update_generation_config.yaml
+++ b/hermetic_build/library_generation/owlbot/templates/java_library/.github/workflows/update_generation_config.yaml
@@ -30,6 +30,9 @@ jobs:
       with:
         fetch-depth: 0
         token: ${{ secrets.CLOUD_JAVA_BOT_TOKEN }}
+    - name: Install Dependencies
+      shell: bash
+      run: sudo apt install -y libxml2-utils
     - name: Update params in generation config to latest
       shell: bash
       run: |


### PR DESCRIPTION
Currently, the `get_latest_released_version()` function returns `2.59.0` for gapic-generator-java. This is not correct and is due to an ongoing issue with Maven.
This PR uses the alternative `maven-metadata.xml` files instead, which contains a `metadata/versioning/latest` entry always pointing to the latest version.

```bash
[hi on] diegomarquezp:~$ function get_latest_released_version() {
    local group_id=$1
    local artifact_id=$2
    group_id_url_path="$(sed 's|\.|/|g' <<< "${group_id}")"
    url="https://repo1.maven.org/maven2/${group_id_url_path}/${artifact_id}/maven-metadata.xml"
    xml_content=$(curl -s --fail "${url}")
    latest=$(xmllint --xpath 'metadata/versioning/latest/text()' - <<< "${xml_content}")
    if [[ -z "${latest}" ]]; then
        echo "The latest version of ${group_id}:${artifact_id} is empty."
        echo "The returned json from maven.org is invalid: ${json_content}"
        exit 1
    else
        echo "${latest}"
    fi
}
[hi on] diegomarquezp:~$ get_latest_released_version com.google.api gapic-generator-java
2.60.0
```