### PR TITLE
fix: improve error messaging for LRO CancellationException

### DIFF
--- a/gax-java/gax/src/main/java/com/google/api/gax/longrunning/OperationTimedPollAlgorithm.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/longrunning/OperationTimedPollAlgorithm.java
@@ -91,7 +91,9 @@ public class OperationTimedPollAlgorithm extends ExponentialRetryAlgorithm {
     if (LOGGER.isLoggable(Level.WARNING)) {
       LOGGER.log(
           Level.WARNING,
-          "The task has been cancelled. Please refer to "
+          "The task has been cancelled. Possible reasons include a timeout or "
+              + "exceeding the maximum number of retry attempts."
+              + " Please refer to "
               + LRO_TROUBLESHOOTING_LINK
               + " for more information");
     }

--- a/gax-java/gax/src/main/java/com/google/api/gax/longrunning/OperationTimedPollAlgorithm.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/longrunning/OperationTimedPollAlgorithm.java
@@ -93,7 +93,7 @@ public class OperationTimedPollAlgorithm extends ExponentialRetryAlgorithm {
           Level.WARNING,
           "The long running operation request is no longer being tracked. "
               + "Possible reasons include a timeout or "
-              + "exceeding the maximum number of retry attempts."
+              + "exceeding the maximum number of poll attempts."
               + " Please refer to "
               + LRO_TROUBLESHOOTING_LINK
               + " for more information");

--- a/gax-java/gax/src/main/java/com/google/api/gax/longrunning/OperationTimedPollAlgorithm.java
+++ b/gax-java/gax/src/main/java/com/google/api/gax/longrunning/OperationTimedPollAlgorithm.java
@@ -91,7 +91,8 @@ public class OperationTimedPollAlgorithm extends ExponentialRetryAlgorithm {
     if (LOGGER.isLoggable(Level.WARNING)) {
       LOGGER.log(
           Level.WARNING,
-          "The task has been cancelled. Possible reasons include a timeout or "
+          "The long running operation request is no longer being tracked. "
+              + "Possible reasons include a timeout or "
               + "exceeding the maximum number of retry attempts."
               + " Please refer to "
               + LRO_TROUBLESHOOTING_LINK


### PR DESCRIPTION
Context: 433564823
Previously, we improved the error message by adding a link to our LRO documentation, but we need to include additional clarification into why the task was canceled (whether due to a timeout, reaching maximum attempts, or another reason). This PR lists these possible causes in the log statement. 