### PR TITLE
chore: Update the upper bound dependencies file

### DIFF
--- a/dependencies.txt
+++ b/dependencies.txt
@@ -3,7 +3,8 @@
 # "1P" refers to First-Party dependencies (owned by Google).
 # "3P" refers to Third-Party dependencies.
 
-# Pom-Parent Dependencies (https://github.com/googleapis/sdk-platform-java/blob/main/gapic-generator-java-pom-parent/pom.xml)
+# Pom-Parent Dependencies
+# These dependencies are declared: https://github.com/googleapis/sdk-platform-java/blob/main/gapic-generator-java-pom-parent/pom.xml
 javax.annotation-api=1.3.2
 grpc=1.74.0
 google.auth=1.37.1
@@ -11,18 +12,21 @@ google.http-client=1.47.1
 gson=2.13.1
 guava=33.4.8-jre
 protobuf=4.31.1
+# Note: This opentelemetry version refers to the opentelemetry-bom
 opentelemetry=1.52.0
 errorprone=2.41.0
-j2objc-annotations=3.0.0
-threetenbp=1.7.1
+j2objc-annotations=3.1
+threetenbp=1.7.2
 slf4j=2.0.17
 
-# 1P Shared-Deps (https://github.com/googleapis/sdk-platform-java/blob/main/java-shared-dependencies/first-party-dependencies/pom.xml)
+# 1P Shared-Deps
+# These dependencies are declared: https://github.com/googleapis/sdk-platform-java/blob/main/java-shared-dependencies/first-party-dependencies/pom.xml
 grpc-gcp=1.6.1
 google.oauth-client=1.39.0
-google.api-client=2.8.0
+google.api-client=2.8.1
 
-# 3P Shared-Deps (https://github.com/googleapis/sdk-platform-java/blob/main/java-shared-dependencies/third-party-dependencies/pom.xml)
+# 3P Shared-Deps
+# These dependencies are declared: https://github.com/googleapis/sdk-platform-java/blob/main/java-shared-dependencies/third-party-dependencies/pom.xml
 threeten-extra=1.8.0
 opencensus=0.31.0
 findbugs=3.0.2
@@ -33,10 +37,12 @@ httpcomponents.httpclient=4.5.14
 apache-httpclient-5=5.5
 apache-httpcore-5=5.3.4
 perfmark-api=0.27.0
+# Note: This is the google opentelemetry exporter and not the general opentelemetry project
 google.cloud.opentelemetry=0.36.0
-opentelemetry-semconv=1.34.0
 flogger=0.9
 arrow=18.3.0
 dev.cel=0.10.1
 com.google.crypto.tink=1.18.0
+# The follow opentelemetry dependencies have a different version from the opentelemetry-bom
+opentelemetry-semconv=1.34.0
 io.opentelemetry.contrib.opentelemetry-gcp-resources=1.48.0-alpha


### PR DESCRIPTION
Updates to the following upper bound dependency versions:
```
j2objc-annotations=3.1
threetenbp=1.7.2
google.api-client=2.8.1
opentelemetry-semconv=1.34.0
```