### PR TITLE
chore: Update protobuf-java to 4.32.0 in downstream compatibility check

### DIFF
--- a/.github/workflows/downstream_protobuf_compatibility_check_nightly.yaml
+++ b/.github/workflows/downstream_protobuf_compatibility_check_nightly.yaml
@@ -41,7 +41,7 @@ jobs:
           - java-storage-nio
         # Default Protobuf-Java versions to use are specified here. Without this, the nightly workflow won't know
         # which values to use and would resolve to ''.
-        protobuf-version: ${{ fromJSON(format('[{0}]', inputs.protobuf_runtime_versions || '"3.25.5","4.32.0"')) }}
+        protobuf-version: ${{ fromJSON(format('[{0}]', inputs.protobuf_runtime_versions || '"3.25.8","4.32.0"')) }}
     steps:
       - name: Checkout sdk-platform-java repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Update downstream_protobuf_compatibility_check_nightly.yaml to test against the latest protobuf-java runtime v4.32.0
