### PR TITLE
feat(librariangen): scaffold Java language container for Librarian

### DIFF
--- a/.github/workflows/librariangen-ci.yml
+++ b/.github/workflows/librariangen-ci.yml
@@ -1,0 +1,49 @@
+name: librariangen CI
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'internal/librariangen/**'
+  pull_request:
+    paths:
+      - 'internal/librariangen/**'
+permissions:
+  contents: read
+
+jobs:
+  test-docker-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+
+      - name: Display Go version
+        run: go version
+
+      - name: Run Go tests
+        run: go test ./...
+        working-directory: internal/librariangen
+
+      - name: Build Docker image
+        run: docker build -t librariangen-test ./internal/librariangen
+
+      - name: Run version command
+        id: version
+        run: |
+          output=$(docker run --rm -e GOOGLE_SDK_JAVA_LOGGING_LEVEL=quiet librariangen-test --version)
+          echo "version_output=$output" >> $GITHUB_OUTPUT
+
+      - name: Verify version
+        run: |
+          version_output="${{ steps.version.outputs.version_output }}"
+          if [[ ! "$version_output" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Version format is incorrect. Got: $version_output"
+            exit 1
+          fi
+          echo "Version check passed. Version is $version_output"

--- a/internal/librariangen/Dockerfile
+++ b/internal/librariangen/Dockerfile
@@ -1,0 +1,65 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This Dockerfile creates a MOSS-compliant image for the Go librariangen,
+# which is invoked by the Librarian tool. It uses a multi-stage build to
+# create a minimal final image.
+
+# --- Builder Stage ---
+# This stage builds the librariangen binary using the MOSS-compliant base image.
+FROM marketplace.gcr.io/google/debian12:latest AS builder
+
+# Set environment variables for tool versions for easy updates.
+ENV GO_VERSION=1.24.0
+
+# Install build dependencies.
+RUN apt-get update && \
+    apt-get install -y \
+    build-essential \
+    ca-certificates \
+    curl \
+    wget && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install the specific Go version required for compatibility.
+RUN wget https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz -O go.tar.gz && \
+    tar -C /usr/local -xzf go.tar.gz && \
+    rm go.tar.gz
+ENV PATH=/usr/local/go/bin:$PATH
+RUN go version
+
+WORKDIR /src
+
+# Copy go.mod and go.sum to download dependencies before copying all the source.
+# This allows Docker to cache the dependencies layer.
+# COPY go.mod go.sum ./
+# RUN go mod download
+
+# Copy all source code.
+COPY . .
+
+# Build the librariangen binary.
+RUN CGO_ENABLED=0 GOOS=linux go build -v -o /librariangen .
+
+# --- Final Stage ---
+# This stage creates the final, minimal image with the compiled binary and
+# all required runtime dependencies pinned to specific versions for compatibility.
+FROM marketplace.gcr.io/google/debian12:latest
+
+# Copy the compiled librariangen binary from the builder stage.
+COPY --from=builder /librariangen /usr/local/bin/librariangen
+
+# Set the entrypoint for the container to run the compiled librariangen.
+# The Librarian will provide commands like 'generate' as arguments.
+ENTRYPOINT [ "/usr/local/bin/librariangen" ]

--- a/internal/librariangen/README.md
+++ b/internal/librariangen/README.md
@@ -1,0 +1,3 @@
+# Java GAPIC Generator for Librarian (librariangen)
+
+This directory contains the source code for `librariangen`, a containerized Go application that serves as the Java-specific code generator within the Librarian pipeline. Its responsibility is to generate release-ready Java GAPIC client libraries from `googleapis` API definitions, replacing the legacy Java hermetic code generation toolchain.

--- a/internal/librariangen/go.mod
+++ b/internal/librariangen/go.mod
@@ -1,0 +1,3 @@
+module cloud.google.com/java/internal/librariangen
+
+go 1.24.4

--- a/internal/librariangen/main.go
+++ b/internal/librariangen/main.go
@@ -1,0 +1,85 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+const version = "0.1.0"
+
+// main is the entrypoint for the librariangen CLI.
+func main() {
+	logLevel := slog.LevelInfo
+	switch os.Getenv("GOOGLE_SDK_JAVA_LOGGING_LEVEL") {
+	case "debug":
+		logLevel = slog.LevelDebug
+	case "quiet":
+		logLevel = slog.LevelError + 1
+	}
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: logLevel,
+	})))
+	slog.Info("librariangen: invoked", "args", os.Args)
+	if err := run(context.Background(), os.Args[1:]); err != nil {
+		slog.Error("librariangen: failed", "error", err)
+		os.Exit(1)
+	}
+	slog.Info("librariangen: finished successfully")
+}
+
+// run executes the appropriate command based on the CLI's invocation arguments.
+// The idiomatic structure is `librariangen [command] [flags]`.
+func run(ctx context.Context, args []string) error {
+	if len(args) < 1 {
+		return errors.New("librariangen: expected a command")
+	}
+
+	// The --version flag is a special case and not a command.
+	if args[0] == "--version" {
+		fmt.Println(version)
+		return nil
+	}
+
+	cmd := args[0]
+	flags := args[1:]
+
+	if strings.HasPrefix(cmd, "-") {
+		return fmt.Errorf("librariangen: command cannot be a flag: %s", cmd)
+	}
+
+	switch cmd {
+	case "generate":
+		slog.Warn("librariangen: generate command is not yet implemented")
+		return nil
+	case "release-init":
+		slog.Warn("librariangen: release-init command is not yet implemented")
+		return nil
+	case "configure":
+		slog.Warn("librariangen: configure command is not yet implemented")
+		return nil
+	case "build":
+		slog.Warn("librariangen: build command is not yet implemented")
+		return nil
+	default:
+		return fmt.Errorf("librariangen: unknown command: %s (with flags %s)", cmd, flags)
+	}
+
+}

--- a/internal/librariangen/main_test.go
+++ b/internal/librariangen/main_test.go
@@ -1,0 +1,94 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"testing"
+)
+
+func TestRun(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{
+			name:    "no args",
+			args:    []string{},
+			wantErr: true,
+		},
+		{
+			name:    "version flag",
+			args:    []string{"--version"},
+			wantErr: false,
+		},
+		{
+			name:    "flag as command",
+			args:    []string{"--foo"},
+			wantErr: true,
+		},
+		{
+			name:    "unknown command",
+			args:    []string{"foo"},
+			wantErr: true,
+		},
+		{
+			name:    "build command no flags",
+			args:    []string{"build"},
+			wantErr: false,
+		},
+		{
+			name:    "build command with flags",
+			args:    []string{"build", "--repo=.", "--librarian=./.librarian"},
+			wantErr: false,
+		},
+		{
+			name:    "configure command",
+			args:    []string{"configure"},
+			wantErr: false,
+		},
+		{
+			name:    "generate command no flags",
+			args:    []string{"generate"},
+			wantErr: false,
+		},
+		{
+			name:    "generate command with flags",
+			args:    []string{"generate", "--source=.", "--output=./build_out"},
+			wantErr: false,
+		},
+		{
+			name:    "release-init command no flags",
+			args:    []string{"release-init"},
+			wantErr: false,
+		},
+		{
+			name:    "release-init command with flags",
+			args:    []string{"release-init", "--repo=.", "--output=./build_out"},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Since we are only testing the command dispatching, we can pass a nil
+			// context. The generate function is not actually called.
+			if err := run(ctx, tt.args); (err != nil) != tt.wantErr {
+				t.Errorf("run() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change introduces the initial scaffolding for `librariangen`, a containerized Go application that will serve as the Java-specific code generator  within the Librarian pipeline.

The primary goal of this change is to establish the foundational components for the Java language container, including:
* A new `librariangen` CLI application: Written in Go, this will be the entry point for Java code generation tasks invoked by Librarian. It currently includes basic command dispatching and support for `--version`.
* A multi-stage `Dockerfile`: This creates a minimal container image for librariangen.
* Unit tests and CI: A new GitHub Actions workflow has been added to build and test the container, ensuring that the librariangen executable is correctly built and responds to commands.

This scaffolding is the first step in implementing the full code generation logic within the Librarian system, eventually replacing the Java hermetic code generation system.

The code is largely adapted from the Go language container at https://github.com/googleapis/google-cloud-go/tree/main/internal/librariangen.

Fixes: https://github.com/googleapis/librarian/issues/2500
