### PR TITLE
build: prepare Cloud Build YAML file for librarian-java

### DIFF
--- a/internal/librariangen/cloudbuild-exitgate.yaml
+++ b/internal/librariangen/cloudbuild-exitgate.yaml
@@ -1,0 +1,45 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# note: /workspace is a special directory in the docker image where all the files in this folder
+# get placed on your behalf
+
+timeout: 7200s # 2 hours
+steps:
+  # Attempt to pull the latest image to use as a cache source.
+  - name: gcr.io/cloud-builders/docker
+    entrypoint: 'bash'
+    args:
+      - -c
+      - |
+        docker pull us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/librarian-java:latest || exit 0
+  - name: gcr.io/cloud-builders/docker
+    args:
+      [
+        "build",
+        "--cache-from",
+        "us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/librarian-java:latest",
+        "-t",
+        "us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/librarian-java:latest",
+        "-f",
+        "Dockerfile",
+        ".",
+      ]
+    dir: internal/librariangen
+options:
+    machineType: 'E2_HIGHCPU_8'
+    requestedVerifyOption: VERIFIED  # For provenance attestation generation
+    logging: CLOUD_LOGGING_ONLY
+images:
+  - us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/librarian-java:latest


### PR DESCRIPTION
This is the step in go/cloud-sdk-ar-exit-gate-onboarding#configure-cloudbuild.

This file is almost copy from
https://github.com/googleapis/google-cloud-go/blob/4e6e92b/internal/librariangen/cloudbuild-exitgate.yaml
except I renamed the container image to librarian-java from
librarian-go.

Part of https://github.com/googleapis/librarian/issues/2499