### PR TITLE
build: AR exit gate YAML to declare dependencies.gitSource

### DIFF
--- a/internal/librariangen/cloudbuild-exitgate.yaml
+++ b/internal/librariangen/cloudbuild-exitgate.yaml
@@ -43,3 +43,10 @@ options:
     logging: CLOUD_LOGGING_ONLY
 images:
   - us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/librarian-java:latest
+dependencies:
+- gitSource:
+    repository:
+      url: "${_LOUHI_REPOSITORY_URL}"
+    revision: "${_LOUHI_REF_SHA}"
+    destPath: "."
+


### PR DESCRIPTION
This should suppress the warning in b/450542318.