### PR TITLE
chore: Group upper bound dependencies file deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["/^dependencies\\.txt$/"],
+      "fileMatch": ["dependencies.txt"],
       "matchStrings": ["(?<depName>.*),(.*)=(?<currentValue>.*)"],
       "datasourceTemplate": "maven"
     },


### PR DESCRIPTION
Tested in https://github.com/lqiu96/sdk-platform-java/pull/22

These rules need to be added to the end as renovate `packageRules` configurations are `mergeable`. This means that it scans the rules top-down and each subsequent matching rules gets its configurations overwritten. This tries to make it so that only the `dependencies.txt` are in its own file. 