### PR TITLE
chore: Manage errorprone and j2objc versions in pom-parent

### DIFF
--- a/java-shared-dependencies/third-party-dependencies/pom.xml
+++ b/java-shared-dependencies/third-party-dependencies/pom.xml
@@ -28,7 +28,6 @@
     <opencensus.version>0.31.1</opencensus.version>
     <findbugs.version>3.0.2</findbugs.version>
     <jackson.version>2.18.2</jackson.version>
-    <errorprone.version>2.38.0</errorprone.version>
     <codec.version>1.18.0</codec.version>
     <httpcomponents.httpcore.version>4.4.16</httpcomponents.httpcore.version>
     <httpcomponents.httpclient.version>4.5.14</httpcomponents.httpclient.version>
@@ -37,7 +36,6 @@
     <!-- ensure checker-qual version matches what Guava uses -->
     <checker-qual.version>3.49.0</checker-qual.version>
     <perfmark-api.version>0.27.0</perfmark-api.version>
-    <j2objc-annotations.version>3.0.0</j2objc-annotations.version>
     <google.cloud.opentelemetry.version>0.33.0</google.cloud.opentelemetry.version>
     <opentelemetry-grpc-instrumentation.version>2.1.0-alpha</opentelemetry-grpc-instrumentation.version>
     <opentelemetry-semconv.version>1.29.0-alpha</opentelemetry-semconv.version>


### PR DESCRIPTION
Versions are managed here: https://github.com/googleapis/sdk-platform-java/blob/1962491d13a03621e023a437370a25c446327b72/gapic-generator-java-pom-parent/pom.xml#L37-L38

third-party-deps pom already inherits from pom-parent, so there should not be any difference: https://github.com/googleapis/sdk-platform-java/blob/1962491d13a03621e023a437370a25c446327b72/java-shared-dependencies/third-party-dependencies/pom.xml#L15-L20