### PR TITLE
chore: Upper bound file deps change has chore type

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -221,6 +221,7 @@
       "matchManagers": [
         "regex"
       ],
+      "semanticCommitType": "chore",
       "matchFileNames": ["dependencies.txt"],
       "matchDatasources": ["maven"],
       "groupName": "Upper Bound Dependencies File",


### PR DESCRIPTION
Update to the `chore:` type so it doesn't show up in the release notes