### PR TITLE
chore: revert "ci: exclude internal/librariangen/** on unrelated checks"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,8 +3,6 @@ on:
     branches:
       - main
   pull_request:
-    paths-ignore:
-      - 'internal/librariangen/**'
 name: ci
 jobs:
   build:

--- a/.github/workflows/dependency_compatibility_test.yaml
+++ b/.github/workflows/dependency_compatibility_test.yaml
@@ -4,8 +4,6 @@ on:
   pull_request:
     branches:
       - 'main'
-    paths-ignore:
-      - 'internal/librariangen/**'      
   workflow_dispatch:
     inputs:
       dependencies-list:

--- a/.github/workflows/hermetic_library_generation.yaml
+++ b/.github/workflows/hermetic_library_generation.yaml
@@ -16,8 +16,6 @@
 name: Hermetic library generation upon generation config change through pull requests
 on:
   pull_request:
-    paths-ignore:
-      - 'internal/librariangen/**'
 
 env:
   REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/java_compatibility_check.yaml
+++ b/.github/workflows/java_compatibility_check.yaml
@@ -15,8 +15,6 @@
 # downstream client libraries before they are released.
 on:
   pull_request:
-    paths-ignore:
-      - 'internal/librariangen/**'  
 name: Java 8 compatibility check
 jobs:
   java8-compatibility-check:

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -5,8 +5,6 @@ on:
       - main
   pull_request:
     types: [opened, synchronize, reopened]
-    paths-ignore:
-      - 'internal/librariangen/**'
 jobs:
   build:
     name: Build

--- a/.github/workflows/verify_library_generation.yaml
+++ b/.github/workflows/verify_library_generation.yaml
@@ -1,7 +1,5 @@
 on:
   pull_request:
-    paths-ignore:
-      - 'internal/librariangen/**'
 
 name: verify_library_generation
 jobs:


### PR DESCRIPTION
Reverts googleapis/sdk-platform-java#3953. Due to the change, GitHub Actions stopped running the checks while the checks are still marked as required. Tried this in https://github.com/googleapis/sdk-platform-java/pull/3959#issuecomment-3424217797.

<img width="1742" height="1336" alt="image" src="https://github.com/user-attachments/assets/513fb435-65a9-4841-b3ca-d79a00fe1687" />

The documentation about this GitHub Actions behavior is https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks :

> If a workflow is skipped due to [path filtering](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore), [branch filtering](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpull_requestpull_request_targetbranchesbranches-ignore) or a [commit message](https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs), then checks associated with that workflow will remain in a "Pending" state. A pull request that requires those checks to be successful will be blocked from merging.
> 
> If, however, a job within a workflow is skipped due to a conditional, it will report its status as "Success". For more information, see [Using conditions to control job execution](https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution).

I didn't find usages of a file path filter in the condition of a job within a workflow.

https://github.com/googleapis/sdk-platform-java/blob/main/.github/workflows/verify_library_generation.yaml#L8 is is a good example how to skip the main job library-generation-unit-tests, by introducing the should-run-library-generation-tests job.