### PR TITLE
deps: bump opentelemetry.version to 1.52.0

### DIFF
--- a/gapic-generator-java-pom-parent/pom.xml
+++ b/gapic-generator-java-pom-parent/pom.xml
@@ -33,7 +33,7 @@
     <gson.version>2.12.1</gson.version>
     <guava.version>33.5.0-jre</guava.version>
     <protobuf.version>3.25.8</protobuf.version>
-    <opentelemetry.version>1.47.0</opentelemetry.version>
+    <opentelemetry.version>1.52.0</opentelemetry.version>
     <errorprone.version>2.42.0</errorprone.version>
     <j2objc-annotations.version>3.1</j2objc-annotations.version>
     <threetenbp.version>1.7.0</threetenbp.version>


### PR DESCRIPTION
With the [recent upgrade of grpc](https://github.com/googleapis/sdk-platform-java/pull/3942), the transitive dependency on `opentelemetry-api` was bumped to 1.52.0 as per https://github.com/grpc/grpc-java/commit/f30964ab82efab6c92354bea1b9b8f6a9c6dddbe.

In order to prevent upper bound dependency warnings (as in https://github.com/googleapis/java-storage/pull/3381), we update opentelemetry.version to 1.52.0