### PR TITLE
chore: Stop running downstream checks on pushing to main

### DIFF
--- a/.github/workflows/downstream.yaml
+++ b/.github/workflows/downstream.yaml
@@ -1,7 +1,4 @@
 on:
-  push:
-    branches:
-      - main
   pull_request:
     # Changes to these directories do not directly affect the downstream libraries
     paths-ignore:


### PR DESCRIPTION
Stop running downstream checks on pushing to main as it does not reflect the repo health. Downstream checks are an optional indicator on presubmit checks.