### PR TITLE
chore: update and fix logback versions used in test

### DIFF
--- a/java-showcase/gapic-showcase/pom.xml
+++ b/java-showcase/gapic-showcase/pom.xml
@@ -19,7 +19,7 @@
   <properties>
     <gapic-showcase.version>0.36.2</gapic-showcase.version>
     <!-- This is the last version supporting slf4j 1.x, do not upgrade -->
-    <slf4j1-logback.version>1.2.13</slf4j1-logback.version> 
+    <slf4j1-logback.version>1.2.13</slf4j1-logback.version>
     <slf4j2-logback.version>1.5.21</slf4j2-logback.version>
   </properties>
 


### PR DESCRIPTION
These are test only dependencies, dependabot [alerts](https://github.com/googleapis/sdk-platform-java/security/dependabot?q=package%3Ach.qos.logback%3Alogback-core+manifest%3Ajava-showcase%2Fgapic-showcase%2Fpom.xml+has%3Apatch) should not matter as code is not shipped and test is in controlled env. 
However, it is good practice to update versions when possible.