### PR TITLE
chore: add vscode folder and python version file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,11 +13,12 @@ target/
 *.vim
 
 # Vscode Settings
-.vscode/settings.json
+.vscode
 
 # Python
 **/__pycache__/
 .venv
+.python-version
 
 # library generation
 **/googleapis


### PR DESCRIPTION
Add ignore to make local dev easier when working with vscode or python code (hermetic build).