### PR TITLE
chore: Remove hardcoded clirr.skip=false in showcase-clirr check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -402,7 +402,7 @@ jobs:
         working-directory: java-showcase
         run: |
           mvn versions:set -B -ntp -DnewVersion=local
-          mvn clirr:check -B -ntp -Dclirr.skip=false -DcomparisonVersion=$SHOWCASE_CLIENT_VERSION
+          mvn clirr:check -B -ntp -DcomparisonVersion=$SHOWCASE_CLIENT_VERSION
 
   gapic-generator-java-bom:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Remove hardcoded clirr.skip=false in showcase-clirr check. This enables us to configure the clirr check in poms.
