### PR TITLE
chore: cleanup release-please config

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -23,7 +23,7 @@ branches:
       releaseType: java-backport
     - branch: 2.40.x
       releaseType: java-backport
-    - releaseType: java-backport
-      branch: 2.54.x
-    - releaseType: java-backport
-      branch: 2.59.x
+    - branch: 2.54.x
+      releaseType: java-backport
+    - branch: 2.59.x
+      releaseType: java-backport


### PR DESCRIPTION
This PR cleans up the .github/release-please.yml file by removing redundant options and the bump-minor-pre-major setting for major releases.