### PR TITLE
chore: Update dependencies.txt to latest

### DIFF
--- a/dependencies.txt
+++ b/dependencies.txt
@@ -9,7 +9,7 @@
 # Pom-Parent Dependencies
 # These dependencies are declared: https://github.com/googleapis/sdk-platform-java/blob/main/gapic-generator-java-pom-parent/pom.xml
 javax.annotation:javax.annotation-api,javax.annotation-api=1.3.2
-io.grpc:grpc-bom,grpc=1.77.0
+io.grpc:grpc-bom,grpc=1.76.2
 com.google.auth:google-auth-library-bom,google.auth=1.41.0
 com.google.http-client:google-http-client,google.http-client=2.0.2
 com.google.code.gson:gson,gson=2.13.2


### PR DESCRIPTION
Renovate bot has not been responsive due to [rate limit](https://github.com/googleapis/google-cloud-java/issues/12536). Manually updating the dependency versions to latest in upper bound test file dependencies.txt.

grpc-java 1.77.0 is not compatible. Created https://github.com/googleapis/sdk-platform-java/issues/4012 to track it.