### PR TITLE
build: Update macOS version in nightly workflow

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macOS-15, ubuntu-22.04, windows-2022 ]
+        os: [ macos-15-intel, ubuntu-22.04, windows-2022 ]
         java: [ 11, 17 ]
     runs-on: ${{ matrix.os }}
     steps:
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macOS-15, ubuntu-22.04, windows-2022 ]
+        os: [ macos-15-intel, ubuntu-22.04, windows-2022 ]
     runs-on: ${{ matrix.os }}
     steps:
       - run: git config --global core.longpaths true


### PR DESCRIPTION
Fixes nightly tests not running since December due to missing macOS-13 runner image.