### PR TITLE
deps: Downgrade opentelemetry to 1.51.0

### DIFF
--- a/gapic-generator-java-pom-parent/pom.xml
+++ b/gapic-generator-java-pom-parent/pom.xml
@@ -33,7 +33,7 @@
     <gson.version>2.12.1</gson.version>
     <guava.version>33.5.0-jre</guava.version>
     <protobuf.version>3.25.8</protobuf.version>
-    <opentelemetry.version>1.52.0</opentelemetry.version>
+    <opentelemetry.version>1.51.0</opentelemetry.version>
     <errorprone.version>2.42.0</errorprone.version>
     <j2objc-annotations.version>3.1</j2objc-annotations.version>
     <threetenbp.version>1.7.0</threetenbp.version>


### PR DESCRIPTION
v1.52.0 of [opentelemetry-exporter-sender-okhttp](https://central.sonatype.com/artifact/io.opentelemetry/opentelemetry-exporter-sender-okhttp/1.52.0) and [opentelemetry-sdk-extension-jaeger-remote-sampler](https://central.sonatype.com/artifact/io.opentelemetry/opentelemetry-sdk-extension-jaeger-remote-sampler/1.52.0) now requires OkHttp 5.x which is incompatible with customers still rely on 4.x. Even though we don't use these two artifacts in client libraries, they are included in the opentelemetry-bom. If a customer uses v1.51.0 version of opentelemetry-bom and latest client libraries, they would get enforcer errors. 

Downgrade the opentelemetry version to 1.51.0 to give customers more time to migrate their codebase to be compatible with Okhttp 5.x and opentelemetry 1.52+.