### PR TITLE
tests: Add protobuf 3.x compatibility tests with a third party library tensorflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -372,6 +372,12 @@ jobs:
           mvn clean verify -P '!showcase,enable-integration-tests,loggingTestBase,disabledLogging'  \
             --batch-mode \
             --no-transfer-progress
+      - name: Showcase integration tests - Protobuf 3 compatibility with third party library Tensorflow
+        working-directory: java-showcase
+        run: |
+          mvn clean verify -P 'enable-integration-tests,protobuf3,showcase'  \
+            --batch-mode \
+            --no-transfer-progress
 
   showcase-clirr:
     if: ${{ github.base_ref != '' }} # Only execute on pull_request trigger event

--- a/java-showcase/gapic-showcase/pom.xml
+++ b/java-showcase/gapic-showcase/pom.xml
@@ -201,6 +201,14 @@
       <scope>test</scope>
     </dependency>
 
+    <!--  Protobuf 3.x compatibility tests, tensorflow depends on protobuf 3.x gen code and runtime  -->
+    <dependency>
+      <groupId>org.tensorflow</groupId>
+      <artifactId>tensorflow-core-platform</artifactId>
+      <version>1.1.0</version>
+      <scope>test</scope>
+    </dependency>
+
     <!-- Otel testing libraries -->
     <dependency>
       <groupId>io.opentelemetry</groupId>
@@ -356,6 +364,25 @@
                 <testExclude>**/com/google/showcase/v1beta1/it/logging/ITLogging1x.java</testExclude>
                 <testExclude>**/com/google/showcase/v1beta1/it/logging/ITLogging.java</testExclude>
               </testExcludes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>protobuf3</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <testExcludes>
+                <testExclude>**/com/google/showcase/v1beta1/it/logging/*.java</testExclude>
+              </testExcludes>
+              <testIncludes>
+                <testInclude>**/com/google/showcase/v1beta1/it/ITProtobuf3Compatibility.java</testInclude>
+              </testIncludes>
             </configuration>
           </plugin>
         </plugins>

--- a/java-showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITProtobuf3Compatibility.java
+++ b/java-showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITProtobuf3Compatibility.java
@@ -1,0 +1,67 @@
+package com.google.showcase.v1beta1.it;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.tensorflow.Graph;
+import org.tensorflow.Session;
+import org.tensorflow.op.Ops;
+import org.tensorflow.op.core.Constant;
+import org.tensorflow.op.math.Add;
+import org.tensorflow.proto.GraphDef;
+import org.tensorflow.types.TInt32;
+
+/**
+ * Tensorflow depends on protobuf 3.x gen code and runtime, we test it in showcase module to prove
+ * that it works with protobuf 4.33+ gen code and runtime that comes with client libraries.
+ */
+class ITProtobuf3Compatibility {
+
+  @Test
+  void testTensorflow_helloWorldExample() {
+    try (Graph graph = new Graph()) {
+      // Hello world example for "10 + 32" operation.
+      Ops tf = Ops.create(graph);
+
+      int expectedValue1 = 10;
+      int expectedValue2 = 32;
+      int expectedSum = 42;
+
+      String name1 = "constant1";
+      String name2 = "constant2";
+
+      Constant<TInt32> constant1 = tf.withName(name1).constant(expectedValue1);
+      Constant<TInt32> constant2 = tf.withName(name2).constant(expectedValue2);
+
+      Add<TInt32> sum = tf.math.add(constant1, constant2);
+
+      try (Session s = new Session(graph)) {
+        try (TInt32 result = (TInt32) s.runner().fetch(sum).run().get(0)) {
+          int actualResult = result.getInt();
+          assertThat(actualResult).isEqualTo(expectedSum);
+        }
+      }
+
+      // GraphDef is a protobuf gen code.
+      GraphDef graphDef = graph.toGraphDef();
+
+      // Inspect the protobuf gen code
+      Integer actual1 = getValueFromGraphDefByName(graphDef, name1);
+      Integer actual2 = getValueFromGraphDefByName(graphDef, name2);
+
+      assertThat(actual1).isEqualTo(expectedValue1);
+      assertThat(actual2).isEqualTo(expectedValue2);
+    }
+  }
+
+  private static Integer getValueFromGraphDefByName(GraphDef graphDef, String name1) {
+    return graphDef.getNodeList().stream()
+        .filter(nodeDef -> nodeDef.getName().equals(name1))
+        .findFirst()
+        .get()
+        .getAttrOrThrow("value")
+        .getTensor()
+        .getIntValList()
+        .get(0);
+  }
+}

--- a/java-showcase/pom.xml
+++ b/java-showcase/pom.xml
@@ -79,6 +79,7 @@
               <!--   Do not compile by default (without logging deps)  -->
               <testExcludes>
                 <testExclude>**/com/google/showcase/v1beta1/it/logging/*.java</testExclude>
+                <testExclude>**/com/google/showcase/v1beta1/it/ITProtobuf3Compatibility.java</testExclude>
               </testExcludes>
             </configuration>
           </plugin>
@@ -120,6 +121,7 @@
               <!--   Do not compile by default (without logging deps)  -->
               <testExcludes>
                 <testExclude>**/com/google/showcase/v1beta1/it/logging/*.java</testExclude>
+                <testExclude>**/com/google/showcase/v1beta1/it/ITProtobuf3Compatibility.java</testExclude>
               </testExcludes>
             </configuration>
           </plugin>


### PR DESCRIPTION
Add protobuf 3.x compatibility tests with a third party library tensorflow in showcase module.

Tensorflow depends on [protobuf-java
v3.21.9](https://github.com/tensorflow/java/blob/cbf942051d55291ba9bdb019b2f207f013889bba/tensorflow-core/pom.xml#L45) gen code and runtime. This proves that client libraries with 4.33 runtime and gen code are compatible with a third party library that contains 3.x gen code and runtime.